### PR TITLE
Fix parent container always invalidate children and each other every frame

### DIFF
--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -94,7 +94,7 @@ public class Container : Drawable
         {
             foreach (var child in children)
             {
-                child.Invalidate(InvalidationFlags.DrawInfo);
+                child.Invalidate(InvalidationFlags.DrawInfo, false);
             }
         }
 

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -313,14 +313,15 @@ public class Drawable
     /// Marks all or part of this drawable as requiring re-computation.
     /// </summary>
     /// <param name="flags">An <see cref="InvalidationFlags"/> flag representing which aspects of the drawable need to be recomputed.</param>
-    public virtual void Invalidate(InvalidationFlags flags = InvalidationFlags.All)
+    /// <param name="propagateToParent">Whether this invalidation should also invalidate this drawable's parent.</param>
+    public virtual void Invalidate(InvalidationFlags flags = InvalidationFlags.All, bool propagateToParent = true)
     {
         if ((Invalidation & flags) == flags)
             return; // Already invalidated for these flags.
 
         Invalidation |= flags;
 
-        if ((flags & InvalidationFlags.DrawInfo) != 0)
+        if (propagateToParent && (flags & InvalidationFlags.DrawInfo) != 0)
             Parent?.Invalidate(InvalidationFlags.DrawInfo);
     }
 


### PR DESCRIPTION
Found during implement vertex batching

In `Update` method in `Container`, there are a flow that parent `Container` will invalidate all children within the `Container` here 

https://github.com/HelloYeew/sakura/blob/71f0bf3f9ac90b6f0b68739a9ecf9608074059ca/Sakura.Framework/Graphics/Drawables/Container.cs#L85-L105

But from this, the child will also invalidate the parent too (in `Drawable` class) and create a feedback loop between parent and child drawable.

https://github.com/HelloYeew/sakura/blob/71f0bf3f9ac90b6f0b68739a9ecf9608074059ca/Sakura.Framework/Graphics/Drawables/Drawable.cs#L323-L325

So I add a parameter into the `Invalidate` method in drawable to stop these loop. Can be tested via add log here

```csharp
        if (propagateToParent && (flags & InvalidationFlags.DrawInfo) != 0)
        {
            Logger.LogPrint($"Drawable {this} invalidated with flags {flags}, propagating to parent {Parent}");
            Parent?.Invalidate(InvalidationFlags.DrawInfo);
        }
```