### PR TITLE
Add texture fill mode setting to the drawable texture

### DIFF
--- a/Sakura.Framework/Graphics/Textures/GLTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/GLTexture.cs
@@ -41,6 +41,17 @@ public class GLTexture : IDisposable
         this.gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
     }
 
+    /// <summary>
+    /// Change the texture wrap mode (for tiling/repeating).
+    /// </summary>
+    /// <param name="mode">The wrap mode to set.</param>
+    public void SetWrapMode(TextureWrapMode mode)
+    {
+        Bind();
+        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)mode);
+        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)mode);
+    }
+
     public static void CreateWhitePixel(GL gl)
     {
         if (WhitePixel == null)

--- a/Sakura.Framework/Graphics/Textures/TextureFillMode.cs
+++ b/Sakura.Framework/Graphics/Textures/TextureFillMode.cs
@@ -1,0 +1,30 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Graphics.Textures;
+
+public enum TextureFillMode
+{
+    /// <summary>
+    /// The texture is stretched to fill the drawable's size (default).
+    /// Aspect ratio is ignored.
+    /// </summary>
+    Stretch,
+
+    /// <summary>
+    /// The texture is scaled to fit within the drawable's bounds while maintaining aspect ratio.
+    /// This may result in empty space (letterboxing) if aspect ratios differ.
+    /// </summary>
+    Fit,
+
+    /// <summary>
+    /// The texture is scaled to fill the entire drawable's bounds while maintaining aspect ratio.
+    /// Parts of the texture may be cropped if aspect ratios differ.
+    /// </summary>
+    Fill,
+
+    /// <summary>
+    /// Repeats the texture to fill the DrawSize.
+    /// </summary>
+    Tile
+}


### PR DESCRIPTION
Add ability to set how the texture should be represent in the drawable. Now have 4 setting (stretch, it, fill and tile). Already add the XML doc into the setting enum.