### PR TITLE
Make the resize event work event window is resizing

### DIFF
--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -252,6 +252,17 @@ public abstract class AppHost : IDisposable
                 Window.Minimized += updateTargetUpdateHz;
                 Window.Restored += updateTargetUpdateHz;
                 Window.DisplayChanged += _ => updateTargetUpdateHz();
+                Window.RenderRequested += () =>
+                {
+                    if (executionState == ExecutionState.Running)
+                    {
+                        // Force an update and draw when requested
+                        // during the resize operation since the loop is blocked.
+                        app?.Update();
+                        if (!IsHeadless)
+                            PerformDraw();
+                    }
+                };
 
                 Window.Initialize();
                 Window.Create();

--- a/Sakura.Framework/Platform/IWindow.cs
+++ b/Sakura.Framework/Platform/IWindow.cs
@@ -106,6 +106,13 @@ public interface IWindow : IDisposable
     event Action<ScrollEvent> OnScroll;
 
     /// <summary>
+    /// Invoked when a render is requested.
+    /// This will use when there is a need to render a new frame outside the normal update loop.
+    /// Like SDL resize event that block the update loop until the resize is finished.
+    /// </summary>
+    event Action RenderRequested;
+
+    /// <summary>
     /// Close the window peacefully.
     /// </summary>
     void Close();


### PR DESCRIPTION
From the SDL behavior, when window is resizing all update and event polling will be stop until the resize is complete. This make all render loop stop and the `Resized` event trigger only when window has finish resized. This make some "weird" size on the drawable. This PR fix this problem. Now when resize the resized event will be trigger all the time on resizing and make the app (main container) forced update and got correct new size and make the drawable size in the window always true all the time.