### PR TITLE
Make base Drawable class abstract

### DIFF
--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -25,7 +25,7 @@ namespace Sakura.Framework.Graphics.Drawables;
 /// <summary>
 /// A lowest level of the component hierarchy. All drawable components should be inherited from this class.
 /// </summary>
-public class Drawable
+public abstract class Drawable
 {
     public Container? Parent { get; internal set; }
 


### PR DESCRIPTION
From dogfooding my framework, the base `Drawable` class don't need to be "initialize" by an application framework. We already have another alternative class that based on `Drawable` like `Component` that do the same thing as `Drawable`. This make how `Drawable` more look like this is the base class of anything, so don't just directly initialize it. Also this make the draw heirachy debugger more usable and more approachable by see the class type of the drawable.