### PR TITLE
Add FPS text and limiter to the FPS graph

### DIFF
--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -8,10 +8,10 @@ using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Timing;
 using Sakura.Framework.Utilities;
-using Vector2 = Sakura.Framework.Maths.Vector2;
 
 namespace Sakura.Framework.Graphics.Performance;
 


### PR DESCRIPTION
Since Sakura can render the text now so why not!

<img width="968" height="707" alt="Screenshot 2025-12-15 at 3 46 03" src="https://github.com/user-attachments/assets/e26f48a4-bc89-496a-9a7a-6ba3cc0490fc" />
