### PR TITLE
Migrate draw vertices to draw node

### DIFF
--- a/Sakura.Framework/Graphics/Containers/FlowContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/FlowContainer.cs
@@ -5,6 +5,7 @@ using System;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Maths;
+using Sakura.Framework.Utilities;
 
 namespace Sakura.Framework.Graphics.Containers;
 
@@ -106,15 +107,20 @@ public class FlowContainer : Container
 
                 // set child's position.
                 // must control these properties for layout to work.
-                child.RelativePositionAxes = Axes.None; // reset to absolute positioning
-                child.Anchor = Anchor.TopLeft; // Reset anchor to top-left
-                child.Origin = Anchor.TopLeft; // Reset origin to top-left
+                if (child.RelativePositionAxes != Axes.None)
+                    child.RelativePositionAxes = Axes.None; // reset to absolute positioning
+                if (child.Anchor != Anchor.TopLeft)
+                    child.Anchor = Anchor.TopLeft; // Reset anchor to top-left
+                if (child.Origin != Anchor.TopLeft)
+                    child.Origin = Anchor.TopLeft; // Reset origin to top-left
 
                 // calculate final pixel position for the child (including its margin)
                 var childPosPixels = new Vector2(currentPosPixels.X + child.Margin.Left, currentPosPixels.Y + child.Margin.Top);
+                var finalPos = new Vector2(childPosPixels.X + Padding.Left, childPosPixels.Y + Padding.Top);
 
-                // Apply position (offset by Padding)
-                child.Position = new Vector2(childPosPixels.X + Padding.Left, childPosPixels.Y + Padding.Top);
+                if (!Precision.AlmostEquals(child.Position, finalPos))
+                    // Apply position (offset by Padding)
+                    child.Position = finalPos;
 
                 // Track content size
                 float childRight = childPosPixels.X + childDrawSizePixels.X + child.Margin.Right;
@@ -138,15 +144,20 @@ public class FlowContainer : Container
                 }
 
                 // set child's position
-                child.RelativePositionAxes = Axes.None;
-                child.Anchor = Anchor.TopLeft;
-                child.Origin = Anchor.TopLeft;
+                if (child.RelativePositionAxes != Axes.None)
+                    child.RelativePositionAxes = Axes.None;
+                if (child.Anchor != Anchor.TopLeft)
+                    child.Anchor = Anchor.TopLeft;
+                if (child.Origin != Anchor.TopLeft)
+                    child.Origin = Anchor.TopLeft;
 
                 // calculate final pixel position for the child (including its margin)
                 var childPosPixels = new Vector2(currentPosPixels.X + child.Margin.Left, currentPosPixels.Y + child.Margin.Top);
+                var finalPos = new Vector2(childPosPixels.X + Padding.Left, childPosPixels.Y + Padding.Top);
 
-                // Apply position
-                child.Position = new Vector2(childPosPixels.X + Padding.Left, childPosPixels.Y + Padding.Top);
+                if (!Precision.AlmostEquals(child.Position, finalPos))
+                    // Apply position (offset by Padding)
+                    child.Position = finalPos;
 
                 // Track content size
                 float childRight = childPosPixels.X + childDrawSizePixels.X + child.Margin.Right;
@@ -168,10 +179,10 @@ public class FlowContainer : Container
             if ((AutoSizeAxes & Axes.Y) != 0)
                 newSize.Y = maxBottom + Padding.Bottom;
 
-            if (Size != newSize)
+            if (!Precision.AlmostEquals(Size, newSize))
             {
                 Size = newSize;
-                Parent?.Invalidate(InvalidationFlags.DrawInfo);
+                // Parent?.Invalidate(InvalidationFlags.DrawInfo);
             }
         }
     }

--- a/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
@@ -9,6 +9,7 @@ using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Input;
 using Sakura.Framework.Maths;
+using Sakura.Framework.Utilities;
 
 namespace Sakura.Framework.Graphics.Containers;
 
@@ -282,8 +283,8 @@ public class ScrollableContainer : Container
     public override void Update()
     {
         updateScrollPosition();
-        base.Update();
         updateScrollbars();
+        base.Update();
     }
 
     private void updateScrollPosition()
@@ -344,8 +345,11 @@ public class ScrollableContainer : Container
             }
             else
             {
-                verticalScrollbar.Height = barHeight;
-                verticalScrollbar.Position = new Vector2(0, availableTrack * currentRatio);
+                if (!Precision.AlmostEquals(verticalScrollbar.Height, barHeight))
+                    verticalScrollbar.Height = barHeight;
+                float newY = availableTrack * currentRatio;
+                if (!Precision.AlmostEquals(verticalScrollbar.Position.Y, newY))
+                    verticalScrollbar.Position = new Vector2(0, newY);
             }
         }
 

--- a/Sakura.Framework/Graphics/Drawables/BezierCurve.cs
+++ b/Sakura.Framework/Graphics/Drawables/BezierCurve.cs
@@ -172,7 +172,7 @@ public class BezierCurve : Drawable
     }
 
     /// <summary>
-    /// Calculates a point on a cubic bezier curve defined by four control points and a parameter t (0 <= t <= 1).
+    /// Calculates a point on a cubic bezier curve defined by four control points and a parameter t (0 &lt;= t &lt;= 1).
     /// </summary>
     /// <param name="point0">First control point (start of the curve)</param>
     /// <param name="point1">Second control point</param>

--- a/Sakura.Framework/Graphics/Drawables/BezierCurve.cs
+++ b/Sakura.Framework/Graphics/Drawables/BezierCurve.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Sakura.Framework.Extensions.ColorExtensions;
-using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Rendering.Vertex;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Utilities;
@@ -19,8 +18,6 @@ public class BezierCurve : Drawable
 
     private float thickness = 3f;
     private const int segments = 25;
-
-    protected new Vertex[] Vertices = Array.Empty<Vertex>();
 
     public Vector2 P0
     {
@@ -195,12 +192,5 @@ public class BezierCurve : Drawable
         float y = uuu * point0.Y + 3 * uu * t * point1.Y + 3 * u * tt * point2.Y + ttt * point3.Y;
 
         return new Vector2(x, y);
-    }
-
-    public override void Draw(IRenderer renderer)
-    {
-        if (DrawAlpha <= 0 || Vertices.Length == 0)
-            return;
-        renderer.DrawVertices(Vertices, Texture ?? renderer.WhitePixel);
     }
 }

--- a/Sakura.Framework/Graphics/Drawables/Circle.cs
+++ b/Sakura.Framework/Graphics/Drawables/Circle.cs
@@ -2,8 +2,8 @@
 // See the LICENSE file for full license text.
 
 using System;
-using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Maths;
 
 namespace Sakura.Framework.Graphics.Drawables;
 
@@ -12,13 +12,27 @@ namespace Sakura.Framework.Graphics.Drawables;
 /// </summary>
 public class Circle : Drawable
 {
-    public override void Draw(IRenderer renderer)
+    protected override DrawNode CreateDrawNode() => new CircleDrawNode();
+
+    public class CircleDrawNode : DrawNode
     {
-        if (DrawAlpha <= 0)
-            return;
-        float radius = Math.Min(DrawRectangle.Width, DrawRectangle.Height) / 2f;
-        renderer.PushMask(this, radius);
-        base.Draw(renderer);
-        renderer.PopMask(this, radius, 0f, Color.Transparent);
+        public RectangleF DrawRectangle { get; private set; }
+        public float Radius { get; private set; }
+
+        public override void ApplyState(Drawable source)
+        {
+            base.ApplyState(source);
+            DrawRectangle = source.DrawRectangle;
+            Radius = Math.Min(DrawRectangle.Width, DrawRectangle.Height) / 2f;
+        }
+
+        public override void Draw(IRenderer renderer)
+        {
+            if (DrawAlpha <= 0) return;
+
+            renderer.PushMask(DrawRectangle, Radius);
+            base.Draw(renderer);
+            renderer.PopMask(DrawRectangle, Radius, 0f, Colors.Color.Transparent);
+        }
     }
 }

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -9,7 +9,6 @@ using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Input;
 using Sakura.Framework.Maths;
-using Sakura.Framework.Statistic;
 using Sakura.Framework.Timing;
 using Sakura.Framework.Utilities;
 
@@ -17,6 +16,12 @@ namespace Sakura.Framework.Graphics.Drawables;
 
 public class Container : Drawable
 {
+    /// <summary>
+    /// A version number that is incremented whenever the topology of the container changes
+    /// (i.e., when children are added or removed).
+    /// </summary>
+    internal long TopologyVersion { get; private set; } = 1;
+
     private readonly List<Drawable> children = new();
     private Drawable? draggedChild;
 
@@ -97,6 +102,7 @@ public class Container : Drawable
 
         drawable.Parent = this;
         children.Add(drawable);
+        InvalidateTopology();
         if (drawable.Clock is FramedClock framedClock)
         {
             framedClock.Source = Clock;
@@ -122,6 +128,7 @@ public class Container : Drawable
         {
             drawable.Parent = null;
             Invalidate(InvalidationFlags.DrawInfo);
+            InvalidateTopology();
         }
     }
 
@@ -133,7 +140,10 @@ public class Container : Drawable
         }
         children.Clear();
         Invalidate(InvalidationFlags.DrawInfo);
+        InvalidateTopology();
     }
+
+    internal void InvalidateTopology() => TopologyVersion++;
 
     public override void Update()
     {
@@ -252,52 +262,30 @@ public class Container : Drawable
         }
     }
 
-    public override void Draw(IRenderer renderer)
+    protected override DrawNode CreateDrawNode() => new ContainerDrawNode();
+
+    public override DrawNode GenerateDrawNodeSubtree()
     {
-        if (DrawAlpha <= 0)
-            return;
+        var node = (ContainerDrawNode)base.GenerateDrawNodeSubtree();
 
-        GlobalStatistics.Get<int>("Drawables", "Drawn Last Frame").Value++;
-
-        if (Masking)
-            renderer.PushMask(this, CornerRadius);
-
-        RectangleF? clipRect = null;
-        for (Container p = this; p != null; p = p.Parent)
+        if (node.TopologyInvalidationID != TopologyVersion)
         {
-            if (p.Masking)
+            node.Children.Clear();
+            foreach (var child in Children.OrderBy(c => c.Depth))
             {
-                clipRect = p.DrawRectangle;
-                break;
+                node.Children.Add(child.GenerateDrawNodeSubtree());
+            }
+            node.TopologyInvalidationID = TopologyVersion;
+        }
+        else
+        {
+            foreach (var child in Children)
+            {
+                child.GenerateDrawNodeSubtree();
             }
         }
 
-        foreach (var child in children.OrderBy(c => c.Depth))
-        {
-            if (clipRect.HasValue)
-            {
-                var cr = clipRect.Value;
-                var dr = child.DrawRectangle;
-
-                // Simple AABB intersection test
-                bool isVisible = dr.X <= cr.X + cr.Width &&
-                                 dr.X + dr.Width >= cr.X &&
-                                 dr.Y <= cr.Y + cr.Height &&
-                                 dr.Y + dr.Height >= cr.Y;
-
-                // If the child is completely outside the masking bounds, skip drawing it entirely
-                if (!isVisible)
-                {
-                    GlobalStatistics.Get<int>("Drawables", "Culled").Value++;
-                    continue;
-                }
-            }
-
-            child.Draw(renderer);
-        }
-
-        if (Masking)
-            renderer.PopMask(this, CornerRadius, BorderThickness, BorderColor);
+        return node;
     }
 
     public override void Load()

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -74,7 +74,7 @@ public abstract class Drawable
     /// <summary>
     /// The scheduler for this drawable, used for delaying and scheduling tasks.
     /// </summary>
-    public Scheduler Scheduler { get; }
+    public Scheduler? Scheduler { get; }
 
     private readonly List<ITransform> transforms = new();
 
@@ -486,16 +486,16 @@ public abstract class Drawable
                     if (textureAspect > drawAspect)
                     {
                         // Texture is wider: Fit width, center height
-                        float scale = drawAspect / textureAspect;
-                        float offset = (1.0f - scale) / 2.0f;
+                        float localScale = drawAspect / textureAspect;
+                        float offset = (1.0f - localScale) / 2.0f;
                         drawTopLeft.Y = offset;
                         drawBottomRight.Y = 1.0f - offset;
                     }
                     else
                     {
                         // Texture is taller: Fit height, center width
-                        float scale = textureAspect / drawAspect;
-                        float offset = (1.0f - scale) / 2.0f;
+                        float localScale = textureAspect / drawAspect;
+                        float offset = (1.0f - localScale) / 2.0f;
                         drawTopLeft.X = offset;
                         drawBottomRight.X = 1.0f - offset;
                     }
@@ -616,7 +616,7 @@ public abstract class Drawable
         OnLoadComplete(this);
     }
 
-    protected internal long DrawNodeInvalidationID { get; private set; } = 1;
+    protected internal long DrawNodeInvalidationId { get; private set; } = 1;
     private DrawNode? drawNode;
 
     protected virtual DrawNode CreateDrawNode() => new DrawNode();
@@ -633,10 +633,10 @@ public abstract class Drawable
         drawNode ??= CreateDrawNode();
 
         // Only apply state if the drawable has been invalidated since last generation
-        if (drawNode.InvalidationID != DrawNodeInvalidationID)
+        if (drawNode.InvalidationID != DrawNodeInvalidationId)
         {
             drawNode.ApplyState(this);
-            drawNode.InvalidationID = DrawNodeInvalidationID;
+            drawNode.InvalidationID = DrawNodeInvalidationId;
         }
 
         return drawNode;
@@ -660,7 +660,7 @@ public abstract class Drawable
 
         if ((flags & (InvalidationFlags.DrawInfo | InvalidationFlags.Colour)) != 0)
         {
-            DrawNodeInvalidationID++;
+            DrawNodeInvalidationId++;
         }
 
         if (propagateToParent && (flags & InvalidationFlags.DrawInfo) != 0)
@@ -764,7 +764,7 @@ public abstract class Drawable
         GlobalStatistics.Get<int>("Drawables", "Updated Last Frame").Value++;
 
         (Clock as FramedClock)?.Update();
-        Scheduler.Update();
+        Scheduler?.Update();
         applyTransforms();
 
         if (Invalidation == InvalidationFlags.None)
@@ -858,7 +858,7 @@ public abstract class Drawable
 
         foreach (var t in transforms)
         {
-            if (t.EndTime == latestEndTime)
+            if (Precision.AlmostEquals(t.EndTime, latestEndTime))
                 t.IsLooping = true;
         }
     }

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -91,7 +91,7 @@ public abstract class Drawable
     /// </summary>
     protected InvalidationFlags Invalidation = InvalidationFlags.All;
 
-    protected internal readonly Vertex[] Vertices = new Vertex[6];
+    protected internal Vertex[] Vertices = new Vertex[6];
 
     public Anchor Anchor
     {
@@ -227,6 +227,7 @@ public abstract class Drawable
             if (Math.Abs(depth - value) < 0.0001f) return;
             depth = value;
             // Re-sort children in parent required
+            Parent?.InvalidateTopology();
             Parent?.Invalidate(InvalidationFlags.DrawInfo);
         }
     }
@@ -615,16 +616,30 @@ public abstract class Drawable
         OnLoadComplete(this);
     }
 
-    public virtual void Draw(IRenderer renderer)
+    protected internal long DrawNodeInvalidationID { get; private set; } = 1;
+    private DrawNode? drawNode;
+
+    protected virtual DrawNode CreateDrawNode() => new DrawNode();
+
+    public DrawNode GenerateDrawNode()
     {
-        if (DrawAlpha <= 0)
-            return;
+        drawNode ??= CreateDrawNode();
+        drawNode.ApplyState(this);
+        return drawNode;
+    }
 
-        GlobalStatistics.Get<int>("Drawables", "Drawn Last Frame").Value++;
+    public virtual DrawNode GenerateDrawNodeSubtree()
+    {
+        drawNode ??= CreateDrawNode();
 
-        renderer.SetBlendMode(Blending);
+        // Only apply state if the drawable has been invalidated since last generation
+        if (drawNode.InvalidationID != DrawNodeInvalidationID)
+        {
+            drawNode.ApplyState(this);
+            drawNode.InvalidationID = DrawNodeInvalidationID;
+        }
 
-        renderer.DrawVertices(Vertices, Texture ?? renderer.WhitePixel);
+        return drawNode;
     }
 
     /// <summary>
@@ -639,7 +654,14 @@ public abstract class Drawable
 
         GlobalStatistics.Get<int>("Drawables", "Invalidations").Value++;
 
+        // Logger.Debug($"Invalidating {GetType().Name} (Parent: {Parent?.GetType().Name ?? "null"}, Flags: {flags})");
+
         Invalidation |= flags;
+
+        if ((flags & (InvalidationFlags.DrawInfo | InvalidationFlags.Colour)) != 0)
+        {
+            DrawNodeInvalidationID++;
+        }
 
         if (propagateToParent && (flags & InvalidationFlags.DrawInfo) != 0)
             Parent?.Invalidate(InvalidationFlags.DrawInfo);

--- a/Sakura.Framework/Graphics/Drawables/Line.cs
+++ b/Sakura.Framework/Graphics/Drawables/Line.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Sakura.Framework.Extensions.ColorExtensions;
-using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Rendering.Vertex;
 using Sakura.Framework.Maths;
 
@@ -103,10 +102,5 @@ public class Line : Drawable
         Vertices[3] = bottomRight;
         Vertices[4] = bottomLeft;
         Vertices[5] = topLeft;
-    }
-
-    public override void Draw(IRenderer renderer)
-    {
-        renderer.DrawVertices(Vertices, Texture ?? renderer.WhitePixel);
     }
 }

--- a/Sakura.Framework/Graphics/Drawables/Path.cs
+++ b/Sakura.Framework/Graphics/Drawables/Path.cs
@@ -2,7 +2,6 @@
 // See the LICENSE file for full license text.
 
 using Sakura.Framework.Extensions.ColorExtensions;
-using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Rendering.Vertex;
 using Sakura.Framework.Maths;
 using System;
@@ -15,8 +14,6 @@ public class Path : Drawable
 {
     private readonly List<Vector2> vertices = new();
     public IReadOnlyList<Vector2> PathVertices => vertices;
-
-    protected new Vertex[] Vertices = Array.Empty<Vertex>();
 
     private float thickness = 3f;
     public float Thickness
@@ -211,12 +208,6 @@ public class Path : Drawable
             Vertices[offset + 4] = bottomLeft;
             Vertices[offset + 5] = topLeft;
         }
-    }
-
-    public override void Draw(IRenderer renderer)
-    {
-        if (DrawAlpha <= 0 || Vertices.Length == 0) return;
-        renderer.DrawVertices(Vertices, Texture ?? renderer.WhitePixel);
     }
 }
 

--- a/Sakura.Framework/Graphics/Drawables/SpriteText.cs
+++ b/Sakura.Framework/Graphics/Drawables/SpriteText.cs
@@ -211,43 +211,6 @@ public class SpriteText : Drawable
         DrawRectangle = new RectangleF(minX, minY, maxX - minX, maxY - minY);
     }
 
-    public override void Draw(IRenderer renderer)
-    {
-        if (DrawAlpha <= 0 || currentVertexCount == 0 || shapedText == null || shapedText.Glyphs.Count == 0)
-            return;
-
-        Texture? currentTextureRegion = null;
-        int batchStart = 0;
-        int batchCount = 0;
-
-        // Glyphs aligns 1:1 with the Quads in textVertices
-        // (Each glyph = 6 vertices)
-        for (int i = 0; i < shapedText.Glyphs.Count; i++)
-        {
-            var glyph = shapedText.Glyphs[i];
-
-            // If texture changes (and it's not the start), flush the draw
-            bool isNewAtlasPage = currentTextureRegion != null &&
-                                  glyph.Texture.GlTexture.Handle != currentTextureRegion.GlTexture.Handle;
-
-            if (isNewAtlasPage)
-            {
-                flushBatch(renderer, currentTextureRegion, batchStart, batchCount);
-                batchStart += batchCount;
-                batchCount = 0;
-            }
-
-            currentTextureRegion = glyph.Texture;
-            batchCount++;
-        }
-
-        // Flush final batch
-        if (currentTextureRegion != null && batchCount > 0)
-        {
-            flushBatch(renderer, currentTextureRegion, batchStart, batchCount);
-        }
-    }
-
     private void flushBatch(IRenderer renderer, Texture texture, int glyphStart, int glyphCount)
     {
         // 6 vertices per glyph (2 triangles)
@@ -256,5 +219,93 @@ public class SpriteText : Drawable
 
         var slice = textVertices.AsSpan(vertexStart, vertexCount);
         renderer.DrawVertices(slice, texture);
+    }
+
+    protected override DrawNode CreateDrawNode() => new SpriteTextDrawNode();
+
+    public class SpriteTextDrawNode : DrawNode
+    {
+        private struct GlyphBatch
+        {
+            public Texture Texture;
+            public int VertexStart;
+            public int VertexCount;
+        }
+
+        private GlyphBatch[] batches = Array.Empty<GlyphBatch>();
+        private int batchCount;
+
+        public override void ApplyState(Drawable source)
+        {
+            base.ApplyState(source);
+            var text = (SpriteText)source;
+
+            // Copy the custom text vertices (not the default 6-length base.Vertices)
+            if (Vertices.Length < text.currentVertexCount)
+            {
+                Vertices = new Vertex[text.currentVertexCount];
+            }
+            Array.Copy(text.textVertices, Vertices, text.currentVertexCount);
+
+            // Generate Texture Batches
+            batchCount = 0;
+
+            if (text.shapedText == null || text.shapedText.Glyphs.Count == 0)
+                return;
+
+            if (batches.Length < text.shapedText.Glyphs.Count)
+                batches = new GlyphBatch[text.shapedText.Glyphs.Count];
+
+            Texture? currentTexture = null;
+            int currentVertexStart = 0;
+            int currentVertexCount = 0;
+
+            for (int i = 0; i < text.shapedText.Glyphs.Count; i++)
+            {
+                var glyph = text.shapedText.Glyphs[i];
+
+                // If texture changes, flush the current batch
+                if (currentTexture != null && currentTexture.GlTexture.Handle != glyph.Texture.GlTexture.Handle)
+                {
+                    batches[batchCount++] = new GlyphBatch
+                    {
+                        Texture = currentTexture,
+                        VertexStart = currentVertexStart,
+                        VertexCount = currentVertexCount
+                    };
+                    currentVertexStart += currentVertexCount;
+                    currentVertexCount = 0;
+                }
+
+                currentTexture = glyph.Texture;
+                currentVertexCount += 6;
+            }
+
+            // Push the final batch
+            if (currentTexture != null && currentVertexCount > 0)
+            {
+                batches[batchCount++] = new GlyphBatch
+                {
+                    Texture = currentTexture,
+                    VertexStart = currentVertexStart,
+                    VertexCount = currentVertexCount
+                };
+            }
+        }
+
+        public override void Draw(IRenderer renderer)
+        {
+            if (DrawAlpha <= 0 || Vertices.Length == 0) return;
+
+            renderer.SetBlendMode(Blending);
+
+            // Loop over the pre-calculated batches and draw them
+            for (int i = 0; i < batchCount; i++)
+            {
+                var batch = batches[i];
+                var slice = Vertices.AsSpan(batch.VertexStart, batch.VertexCount);
+                renderer.DrawVertices(slice, batch.Texture);
+            }
+        }
     }
 }

--- a/Sakura.Framework/Graphics/Drawables/Triangle.cs
+++ b/Sakura.Framework/Graphics/Drawables/Triangle.cs
@@ -2,7 +2,6 @@
 // See the LICENSE file for full license text.
 
 using Sakura.Framework.Extensions.ColorExtensions;
-using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Rendering.Vertex;
 using Sakura.Framework.Maths;
 
@@ -34,7 +33,7 @@ public class Triangle : Drawable
         Vertices[0] = new Vertex
         {
             Position = new Vector2(screenP1.X, screenP1.Y),
-            TexCoords = new Vector2(0.5f, 0), // TexCoords can be mapped however you like
+            TexCoords = new Vector2(0.5f, 0),
             Color = calculatedColor
         };
         Vertices[1] = new Vertex
@@ -49,10 +48,5 @@ public class Triangle : Drawable
             TexCoords = new Vector2(1, 1),
             Color = calculatedColor
         };
-    }
-
-    public override void Draw(IRenderer renderer)
-    {
-        renderer.DrawVertices(Vertices, Texture ?? renderer.WhitePixel);
     }
 }

--- a/Sakura.Framework/Graphics/Performance/AudioMixerVisualiser.cs
+++ b/Sakura.Framework/Graphics/Performance/AudioMixerVisualiser.cs
@@ -36,7 +36,6 @@ public class AudioMixerVisualiser : FocusedOverlayContainer, IRemoveFromDrawVisu
         Size = new Vector2(1);
         Anchor = Anchor.TopLeft;
         Origin = Anchor.TopLeft;
-        AlwaysPresent = true;
 
         Add(new Box
         {

--- a/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
+++ b/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
@@ -52,7 +52,6 @@ public class DrawVisualiser : FocusedOverlayContainer, IRemoveFromDrawVisualiser
         Size = new Vector2(1);
         Anchor = Anchor.TopLeft;
         Origin = Anchor.TopLeft;
-        AlwaysPresent = true;
 
         Add(highlightBox = new Box
         {

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -12,7 +12,6 @@ using Sakura.Framework.Graphics.Text;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Timing;
-using Sakura.Framework.Utilities;
 
 namespace Sakura.Framework.Graphics.Performance;
 
@@ -230,9 +229,6 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
     {
         base.Update();
 
-        if (Precision.AlmostEqualZero(Alpha))
-            return;
-
         if (clock != null)
         {
             frameHistory[currentIndex] = clock.ElapsedFrameTime;
@@ -241,6 +237,9 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
             if (currentCount < max_history)
                 currentCount++;
         }
+
+        if (DrawAlpha <= 0)
+            return;
 
         updateGraph();
         updateFpsText();

--- a/Sakura.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
@@ -39,7 +39,6 @@ public class GlobalStatisticsDisplay : FocusedOverlayContainer, IRemoveFromDrawV
         Anchor = Anchor.TopLeft;
         Origin = Anchor.TopLeft;
         Size = new Vector2(1);
-        AlwaysPresent = true;
 
         Add(new Box
         {

--- a/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
@@ -49,7 +49,6 @@ public class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFromDrawVisu
         Anchor = Anchor.TopLeft;
         Origin = Anchor.TopLeft;
         Size = new Vector2(1);
-        AlwaysPresent = true;
 
         Add(new Box
         {

--- a/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
@@ -1,0 +1,67 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Collections.Generic;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Graphics.Rendering;
+
+public class ContainerDrawNode : DrawNode
+{
+    public long TopologyInvalidationID { get; internal set; }
+
+    public List<DrawNode> Children { get; } = new();
+    public bool Masking { get; private set; }
+    public float CornerRadius { get; private set; }
+    public float BorderThickness { get; private set; }
+    public Color BorderColor { get; private set; }
+
+    public RectangleF DrawRectangle { get; private set; }
+
+    public override void ApplyState(Drawable source)
+    {
+        base.ApplyState(source);
+        var container = (Container)source;
+        Masking = container.Masking;
+        CornerRadius = container.CornerRadius;
+        BorderThickness = container.BorderThickness;
+        BorderColor = container.BorderColor;
+        DrawRectangle = container.DrawRectangle;
+    }
+
+    public override void Draw(IRenderer renderer)
+    {
+        if (DrawAlpha <= 0) return;
+
+        if (Masking)
+            renderer.PushMask(DrawRectangle, CornerRadius);
+
+        foreach (var child in Children)
+        {
+            if (Masking)
+            {
+                var cr = DrawRectangle;
+                var dr = child.DrawRectangle;
+
+                bool isVisible = dr.X <= cr.X + cr.Width &&
+                                 dr.X + dr.Width >= cr.X &&
+                                 dr.Y <= cr.Y + cr.Height &&
+                                 dr.Y + dr.Height >= cr.Y;
+
+                if (!isVisible)
+                {
+                    GlobalStatistics.Get<int>("Drawables", "Culled").Value++;
+                    continue;
+                }
+            }
+
+            child.Draw(renderer);
+        }
+
+        if (Masking)
+            renderer.PopMask(DrawRectangle, CornerRadius, BorderThickness, BorderColor, Vertices);
+    }
+}

--- a/Sakura.Framework/Graphics/Rendering/DrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/DrawNode.cs
@@ -1,0 +1,49 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Graphics.Rendering;
+
+public class DrawNode
+{
+    public long InvalidationID { get; internal set; }
+
+    public Vertex.Vertex[] Vertices { get; protected set; } = Array.Empty<Vertex.Vertex>();
+    public Texture? Texture { get; protected set; }
+    public BlendingMode Blending { get; protected set; }
+    public float DrawAlpha { get; protected set; }
+    public RectangleF DrawRectangle { get; protected set; }
+
+    /// <summary>
+    /// Copies the required visual state from the source drawable.
+    /// This should execute on the update thread.
+    /// </summary>
+    public virtual void ApplyState(Drawable source)
+    {
+        DrawAlpha = source.DrawAlpha;
+        Texture = source.Texture;
+        Blending = source.Blending;
+        if (Vertices.Length != source.Vertices.Length)
+            Vertices = new Vertex.Vertex[source.Vertices.Length];
+        Array.Copy(source.Vertices, Vertices, source.Vertices.Length);
+        DrawRectangle = source.DrawRectangle;
+    }
+
+    /// <summary>
+    /// Submits the node's state to the renderer.
+    /// This should execute on the draw thread.
+    /// </summary>
+    public virtual void Draw(IRenderer renderer)
+    {
+        if (DrawAlpha <= 0 || Vertices.Length == 0)
+            return;
+        GlobalStatistics.Get<int>("Drawables", "Drawn Last Frame").Value++;
+        renderer.SetBlendMode(Blending);
+        renderer.DrawVertices(Vertices, Texture ?? renderer.WhitePixel);
+    }
+}

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -37,8 +37,6 @@ public class GLRenderer : IRenderer
 
     private TriangleBatch triangleBatch;
 
-    private Drawable root;
-
     private int stencilLevel;
 
     private uint lastBoundTextureHandle = uint.MaxValue;
@@ -56,6 +54,8 @@ public class GLRenderer : IRenderer
 
     private readonly Stack<ClipState> clipStack = new Stack<ClipState>();
     private ClipState currentClip;
+
+    private DrawNode rootNode;
 
     private struct ClipState
     {
@@ -111,9 +111,9 @@ public class GLRenderer : IRenderer
         lastBoundTextureHandle = uint.MaxValue;
     }
 
-    public void SetRoot(Drawable drawableRoot)
+    public void SetRoot(DrawNode node)
     {
-        root = drawableRoot;
+        rootNode = node;
     }
 
     public void Resize(int physicalWidth, int physicalHeight, int logicalWidth, int logicalHeight)
@@ -141,7 +141,7 @@ public class GLRenderer : IRenderer
 
     public void Draw(IClock clock)
     {
-        if (root == null) return;
+        if (rootNode == null) return;
 
         resetTextureSlots();
 
@@ -178,7 +178,7 @@ public class GLRenderer : IRenderer
         lastBoundTextureHandle = uint.MaxValue;
         SetBlendMode(BlendingMode.Alpha);
 
-        root.Draw(this);
+        rootNode.Draw(this);
         triangleBatch.Draw();
     }
 
@@ -242,14 +242,14 @@ public class GLRenderer : IRenderer
         triangleBatch.Draw(); // Flush *just* the mask
     }
 
-    private void drawBorder(Drawable maskDrawable, float cornerRadius, float borderThickness, Color borderColor)
+    private void drawBorder(RectangleF rect, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<SakuraVertex> vertices)
     {
-        if (borderThickness <= 0) return;
+        if (borderThickness <= 0 || vertices.Length == 0)
+            return;
 
         triangleBatch.Draw();
 
         shader.SetUniform("u_IsBorder", true);
-        var rect = maskDrawable.DrawRectangle;
         shader.SetUniform("u_MaskRect", new Vector4(rect.X, rect.Y, rect.Width, rect.Height));
         shader.SetUniform("u_CornerRadius", cornerRadius);
         shader.SetUniform("u_BorderThickness", borderThickness);
@@ -261,19 +261,19 @@ public class GLRenderer : IRenderer
             gl.ActiveTexture(TextureUnit.Texture0);
             GLTexture.WhitePixel.Bind();
             boundTextureHandles[0] = GLTexture.WhitePixel.Handle;
-            if (boundTextureCount == 0) boundTextureCount = 1;
+            if (boundTextureCount == 0)
+                boundTextureCount = 1;
         }
 
-        triangleBatch.AddRange(maskDrawable.Vertices, 0f, currentClip.Rect, currentClip.Radius);
+        triangleBatch.AddRange(vertices, 0f, currentClip.Rect, currentClip.Radius);
         triangleBatch.Draw();
 
         shader.SetUniform("u_IsBorder", false);
         lastBoundTextureHandle = uint.MaxValue;
     }
 
-    public void PushMask(Drawable maskDrawable, float cornerRadius)
+    public void PushMask(RectangleF rect, float cornerRadius)
     {
-        var rect = maskDrawable.DrawRectangle;
         float left = rect.X;
         float top = rect.Y;
         float right = rect.X + rect.Width;
@@ -292,11 +292,10 @@ public class GLRenderer : IRenderer
         currentClip = new ClipState { Rect = new Vector4(left, top, right, bottom), Radius = cornerRadius };
     }
 
-    public void PopMask(Drawable maskDrawable, float cornerRadius, float borderThickness, Color borderColor)
+    public void PopMask(RectangleF rect, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<SakuraVertex> maskVertices = default)
     {
         currentClip = clipStack.Pop();
-
-        drawBorder(maskDrawable, cornerRadius, borderThickness, borderColor);
+        drawBorder(rect, cornerRadius, borderThickness, borderColor, maskVertices);
     }
 
     public void SetBlendMode(BlendingMode blendingMode)

--- a/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
@@ -3,8 +3,8 @@
 
 using System;
 using Sakura.Framework.Graphics.Colors;
-using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Timing;
 
@@ -36,7 +36,7 @@ public class HeadlessRenderer : IRenderer
 
     }
 
-    public void SetRoot(Drawable root)
+    public void SetRoot(DrawNode rootNode)
     {
 
     }
@@ -56,12 +56,12 @@ public class HeadlessRenderer : IRenderer
 
     }
 
-    public void PushMask(Drawable maskDrawable, float cornerRadius)
+    public void PushMask(RectangleF rect, float cornerRadius)
     {
 
     }
 
-    public void PopMask(Drawable maskDrawable, float cornerRadius, float borderThickness, Color borderColor)
+    public void PopMask(RectangleF rect, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<Vertex.Vertex> maskVertices = default)
     {
 
     }

--- a/Sakura.Framework/Graphics/Rendering/IRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/IRenderer.cs
@@ -3,8 +3,8 @@
 
 using System;
 using Sakura.Framework.Graphics.Colors;
-using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Timing;
 
@@ -26,7 +26,7 @@ public interface IRenderer
 
     void StartFrame();
 
-    void SetRoot(Drawable root);
+    void SetRoot(DrawNode rootNode);
 
     void Resize(int physicalWidth, int physicalHeight, int logicalWidth, int logicalHeight);
 
@@ -34,9 +34,9 @@ public interface IRenderer
 
     void DrawVertices(ReadOnlySpan<Vertex.Vertex> vertices, Texture textureGl);
 
-    void PushMask(Drawable maskDrawable, float cornerRadius);
+    void PushMask(RectangleF rect, float cornerRadius);
 
-    void PopMask(Drawable maskDrawable, float cornerRadius, float borderThickness, Color borderColor);
+    void PopMask(RectangleF rect, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<Vertex.Vertex> maskVertices = default);
 
     /// <summary>
     /// Sets the blend mode for subsequent draw calls. This will affect how colors are blended when drawing.

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -40,6 +40,8 @@ public abstract class AppHost : IDisposable
     private double lastUpdateTime;
     private readonly Stopwatch gameLoopStopwatch = new Stopwatch();
 
+    private DrawNode currentFrameDrawNode;
+
     // TODO: This "should" not be accessible from outside the framework.
     public Storage FrameworkStorage { get; private set; } = new EmbeddedResourceStorage(typeof(AppHost).Assembly, "Sakura.Framework.Resources");
 
@@ -261,6 +263,7 @@ public abstract class AppHost : IDisposable
                     // Force an update and draw when requested
                     // during the resize operation since the loop is blocked.
                     app?.Update();
+                    currentFrameDrawNode = app?.GenerateDrawNodeSubtree();
                     if (!IsHeadless)
                         PerformDraw();
                 }
@@ -272,8 +275,6 @@ public abstract class AppHost : IDisposable
             onFrameLimiterChanged(new ValueChangedEvent<FrameSync>(default, FrameLimiter.Value));
 
             SetupRenderer();
-
-            Renderer?.SetRoot(this.app);
 
             onResize(Window.Width, Window.Height);
 
@@ -452,6 +453,7 @@ public abstract class AppHost : IDisposable
             // In unlimited mode, we just update once per loop iteration.
             app?.Update();
             lastUpdateTime = AppClock.CurrentTime;
+            currentFrameDrawNode = app?.GenerateDrawNodeSubtree();
             return;
         }
 
@@ -463,6 +465,7 @@ public abstract class AppHost : IDisposable
             // The update that happened in the drawable need to be aware of the timeStep.
             app?.Update();
             lastUpdateTime += timeStep;
+            currentFrameDrawNode = app?.GenerateDrawNodeSubtree();
         }
     }
 
@@ -475,6 +478,8 @@ public abstract class AppHost : IDisposable
         GlobalStatistics.Get<int>("Drawables", "Drawn Last Frame").Value = 0;
         Renderer?.Clear();
         Renderer?.StartFrame();
+        if (currentFrameDrawNode != null)
+            Renderer?.SetRoot(currentFrameDrawNode);
         Renderer?.Draw(AppClock);
         Window?.SwapBuffers();
     }


### PR DESCRIPTION
I have a plan to add support to make Sakura can run in multi-thread but now everything is run in one thread and now the draw data is mutable so now we need some "central data" between thread to make it thread-safe. Also improve performance in some place like reduce invalidation count in some essential drawable like some framework drawable.