### PR TITLE
Add triple buffer support in drawable

### DIFF
--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -264,16 +264,16 @@ public class Container : Drawable
 
     protected override DrawNode CreateDrawNode() => new ContainerDrawNode();
 
-    public override DrawNode GenerateDrawNodeSubtree()
+    public override DrawNode GenerateDrawNodeSubtree(int frameIndex)
     {
-        var node = (ContainerDrawNode)base.GenerateDrawNodeSubtree();
+        var node = (ContainerDrawNode)base.GenerateDrawNodeSubtree(frameIndex);
 
         if (node.TopologyInvalidationID != TopologyVersion)
         {
             node.Children.Clear();
             foreach (var child in Children.OrderBy(c => c.Depth))
             {
-                node.Children.Add(child.GenerateDrawNodeSubtree());
+                node.Children.Add(child.GenerateDrawNodeSubtree(frameIndex));
             }
             node.TopologyInvalidationID = TopologyVersion;
         }
@@ -281,7 +281,7 @@ public class Container : Drawable
         {
             foreach (var child in Children)
             {
-                child.GenerateDrawNodeSubtree();
+                child.GenerateDrawNodeSubtree(frameIndex);
             }
         }
 

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -617,29 +617,37 @@ public abstract class Drawable
     }
 
     protected internal long DrawNodeInvalidationId { get; private set; } = 1;
+    private readonly DrawNode?[] drawNodes = new DrawNode?[3];
     private DrawNode? drawNode;
 
     protected virtual DrawNode CreateDrawNode() => new DrawNode();
 
-    public DrawNode GenerateDrawNode()
+    public DrawNode GenerateDrawNode(int frameIndex)
     {
-        drawNode ??= CreateDrawNode();
-        drawNode.ApplyState(this);
-        return drawNode;
+        drawNodes[frameIndex] ??= CreateDrawNode();
+        var node = drawNodes[frameIndex]!;
+        node.ApplyState(this);
+        return node;
     }
 
-    public virtual DrawNode GenerateDrawNodeSubtree()
+    public virtual DrawNode GenerateDrawNodeSubtree(int frameIndex)
     {
-        drawNode ??= CreateDrawNode();
+        drawNodes[frameIndex] ??= CreateDrawNode();
+        var node = drawNodes[frameIndex]!;
 
         // Only apply state if the drawable has been invalidated since last generation
-        if (drawNode.InvalidationID != DrawNodeInvalidationId)
+        if (node.InvalidationID != DrawNodeInvalidationId)
         {
-            drawNode.ApplyState(this);
-            drawNode.InvalidationID = DrawNodeInvalidationId;
+            node.ApplyState(this);
+            node.InvalidationID = DrawNodeInvalidationId;
+            GlobalStatistics.Get<int>("DrawNodes", "State Applied").Value++;
+        }
+        else
+        {
+            GlobalStatistics.Get<int>("DrawNodes", "State Reused (Clean)").Value++;
         }
 
-        return drawNode;
+        return node;
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Rendering/FrameBufferManager.cs
+++ b/Sakura.Framework/Graphics/Rendering/FrameBufferManager.cs
@@ -1,0 +1,68 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Graphics.Rendering;
+
+/// <summary>
+/// Manage the indices for triple buffering to safely hand off data between update and draw loop.
+/// </summary>
+public class FrameBufferManager
+{
+    private int updateIndex = 0;
+    private int drawIndex = 1;
+    private int waitingIndex = 2;
+
+    private bool hasWaitingFrame = false;
+    private readonly object swapLock = new object();
+
+    /// <summary>
+    /// Gets the index of the buffer the update thread should write to.
+    /// </summary>
+    public int GetUpdateIndex() => updateIndex;
+
+    /// <summary>
+    /// Marks the current update buffer as ready and swaps it into the waiting slot.
+    /// </summary>
+    public void FinishUpdate()
+    {
+        lock (swapLock)
+        {
+            if (hasWaitingFrame)
+            {
+                // The draw thread was too slow and missed the previous frame
+                // Means that update is faster than draw
+                GlobalStatistics.Get<int>("Buffers", "Dropped Frames").Value++;
+            }
+
+            // Swap the current update buffer with the waiting buffer
+            (updateIndex, waitingIndex) = (waitingIndex, updateIndex);
+            hasWaitingFrame = true;
+        }
+    }
+
+    /// <summary>
+    /// Gets the index of the buffer the draw thread should read from.
+    /// If a new frame is waiting, it swaps it into the draw slot.
+    /// </summary>
+    public int GetDrawIndex()
+    {
+        lock (swapLock)
+        {
+            if (hasWaitingFrame)
+            {
+                // new frame finished updating, swap it into the active draw slot
+                (drawIndex, waitingIndex) = (waitingIndex, drawIndex);
+                hasWaitingFrame = false;
+            }
+            else
+            {
+                // Update thread hasn't finished a new frame yet
+                // so the draw thread is forced to reuse the previous frame
+                GlobalStatistics.Get<int>("Buffers", "Draw Starvation").Value++;
+            }
+            return drawIndex;
+        }
+    }
+}

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -40,6 +40,8 @@ public abstract class AppHost : IDisposable
     private double lastUpdateTime;
     private readonly Stopwatch gameLoopStopwatch = new Stopwatch();
 
+    private readonly FrameBufferManager frameBufferManager = new FrameBufferManager();
+    private readonly DrawNode[] rootDrawNodes = new DrawNode[3];
     private DrawNode currentFrameDrawNode;
 
     // TODO: This "should" not be accessible from outside the framework.
@@ -262,8 +264,10 @@ public abstract class AppHost : IDisposable
                 {
                     // Force an update and draw when requested
                     // during the resize operation since the loop is blocked.
-                    app?.Update();
-                    currentFrameDrawNode = app?.GenerateDrawNodeSubtree();
+                    app.Update();
+                    int updateIndex = frameBufferManager.GetUpdateIndex();
+                    rootDrawNodes[updateIndex] = app.GenerateDrawNodeSubtree(updateIndex);
+                    frameBufferManager.FinishUpdate();
                     if (!IsHeadless)
                         PerformDraw();
                 }
@@ -453,7 +457,9 @@ public abstract class AppHost : IDisposable
             // In unlimited mode, we just update once per loop iteration.
             app?.Update();
             lastUpdateTime = AppClock.CurrentTime;
-            currentFrameDrawNode = app?.GenerateDrawNodeSubtree();
+            int updateIndex = frameBufferManager.GetUpdateIndex();
+            rootDrawNodes[updateIndex] = app?.GenerateDrawNodeSubtree(updateIndex);
+            frameBufferManager.FinishUpdate();
             return;
         }
 
@@ -465,7 +471,9 @@ public abstract class AppHost : IDisposable
             // The update that happened in the drawable need to be aware of the timeStep.
             app?.Update();
             lastUpdateTime += timeStep;
-            currentFrameDrawNode = app?.GenerateDrawNodeSubtree();
+            int updateIndex = frameBufferManager.GetUpdateIndex();
+            rootDrawNodes[updateIndex] = app?.GenerateDrawNodeSubtree(updateIndex);
+            frameBufferManager.FinishUpdate();
         }
     }
 
@@ -478,8 +486,10 @@ public abstract class AppHost : IDisposable
         GlobalStatistics.Get<int>("Drawables", "Drawn Last Frame").Value = 0;
         Renderer?.Clear();
         Renderer?.StartFrame();
-        if (currentFrameDrawNode != null)
-            Renderer?.SetRoot(currentFrameDrawNode);
+        int drawIndex = frameBufferManager.GetDrawIndex();
+        var currentFrameNode = rootDrawNodes[drawIndex];
+        if (currentFrameNode != null)
+            Renderer?.SetRoot(currentFrameNode);
         Renderer?.Draw(AppClock);
         Window?.SwapBuffers();
     }


### PR DESCRIPTION
Continue work for make Sakura able to run in multi-thread. Implement multi-buffer support so now it will be like this

- Buffer A : Written by update thread
- Buffer B : Read by draw thread
- Buffer C : Wait to be draw, so this allow update thread to continue running event the draw thread is lagging (means that draw thread will run the same frame)

But this PR only lying the foundation of it since we don't start a real implementation on thread-things yet. There are a lot of things need to do🦍

Also added global statistics support for this too bug is it update too fast?