### PR TITLE
Improve ScrollContainer development experience and UX on use

### DIFF
--- a/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
@@ -293,17 +293,32 @@ public class ScrollableContainer : Container
     {
         Vector2 clampedTarget = getClampedScroll(targetScroll);
 
+        float elapsedSeconds = (float)Clock.ElapsedFrameTime / 1000f;
+
+        // Kinetic momentum scrolling
+        float scrollBlend = 1f - MathF.Exp(-(1f / ScrollDrags) * elapsedSeconds);
+
+        // Bounce factor for over-scrolling
+        float bounceBlend = 1f - MathF.Exp(-10f * elapsedSeconds);
+
+        // Rubber-band bounce back when scrolled past the absolute edge
         if (!isDraggingContent && targetScroll != clampedTarget)
         {
-            targetScroll += (clampedTarget - targetScroll) * 0.15f;
+            targetScroll += (clampedTarget - targetScroll) * bounceBlend;
         }
 
         Vector2 dist = targetScroll - currentScroll;
 
+        // Snap to target if very close to prevent infinite micro-stutters
         if (dist.LengthSquared() < 0.1f && targetScroll == clampedTarget)
+        {
             currentScroll = targetScroll;
+        }
         else
-            currentScroll += dist * (1f - MathF.Pow(ScrollDrags, 0.5f));
+        {
+            // smooth momentum glide
+            currentScroll += dist * scrollBlend;
+        }
 
         ScrollContent.Position = -currentScroll;
     }
@@ -444,20 +459,31 @@ public class ScrollableContainer : Container
         Vector2 delta = Vector2.Zero;
 
         if (Direction == ScrollDirection.Vertical)
-        {
             delta.Y -= e.ScrollDelta.Y * ScrollDistance;
-        }
         else if (Direction == ScrollDirection.Horizontal)
-        {
-            delta.X -= e.ScrollDelta.Y * ScrollDistance;
-        }
+            delta.X -= e.ScrollDelta.X * ScrollDistance;
         else
         {
             delta.Y -= e.ScrollDelta.Y * ScrollDistance;
             delta.X -= e.ScrollDelta.X * ScrollDistance;
         }
 
+        // If the user scrolls in the opposite direction of the momentum, brake immediately
+        if (Direction == ScrollDirection.Vertical && Math.Sign(delta.Y) != Math.Sign(targetScroll.Y - currentScroll.Y))
+            targetScroll.Y = currentScroll.Y;
+
+        if (Direction == ScrollDirection.Horizontal && Math.Sign(delta.X) != Math.Sign(targetScroll.X - currentScroll.X))
+            targetScroll.X = currentScroll.X;
+
         targetScroll += delta;
+
+        // Prevent infinite tension when aggressively scrolling against a wall
+        Vector2 maxScroll = getMaxScroll();
+        float tensionLimit = 100f; // The maximum pixels the wheel can stretch past the edge
+
+        targetScroll.X = Math.Clamp(targetScroll.X, -tensionLimit, maxScroll.X + tensionLimit);
+        targetScroll.Y = Math.Clamp(targetScroll.Y, -tensionLimit, maxScroll.Y + tensionLimit);
+
         return true;
     }
 

--- a/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
@@ -527,6 +527,8 @@ public class ScrollableContainer : Container
     {
         public Action<Vector2>? OnDragged;
 
+        public override bool OnClick(MouseButtonEvent e) => true;
+
         public override bool OnDragStart(MouseButtonEvent e) => true;
 
         public override bool OnDrag(MouseEvent e)

--- a/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/ScrollableContainer.cs
@@ -15,6 +15,8 @@ namespace Sakura.Framework.Graphics.Containers;
 
 public class ScrollableContainer : Container
 {
+    protected override Container Content => ScrollContent;
+
     /// <summary>
     /// The container that holds the scrolling content.
     /// Children added to the ScrollableContainer are actually added here.
@@ -127,9 +129,9 @@ public class ScrollableContainer : Container
         };
         horizontalScrollbar.OnDragged = delta => handleScrollbarDrag(delta.X, false);
 
-        base.Add(ScrollContent);
-        base.Add(verticalScrollbar);
-        base.Add(horizontalScrollbar);
+        AddInternal(ScrollContent);
+        AddInternal(verticalScrollbar);
+        AddInternal(horizontalScrollbar);
     }
 
     private void updateContentAxes()

--- a/Sakura.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/Sakura.Framework/Graphics/Cursor/CursorContainer.cs
@@ -51,7 +51,7 @@ public class CursorContainer : Container, IRemoveFromDrawVisualiser
         if (Matrix4x4.Invert(ModelMatrix, out var inverse))
         {
             var localNormalized = Vector4.Transform(
-                new Vector4(e.MouseState.Position.X, e.MouseState.Position.Y, 0, 1),
+                new Vector4(e.ScreenSpaceMousePosition.X, e.ScreenSpaceMousePosition.Y, 0, 1),
                 inverse
             );
 
@@ -60,8 +60,7 @@ public class CursorContainer : Container, IRemoveFromDrawVisualiser
         }
         else
         {
-            // Fallback for non-invertible matrices
-            localPosition = e.MouseState.Position - new Vector2(DrawRectangle.X, DrawRectangle.Y);
+            localPosition = e.ScreenSpaceMousePosition - new Vector2(DrawRectangle.X, DrawRectangle.Y);
         }
 
         ActiveCursor.Position = localPosition;

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Input;
@@ -23,6 +24,13 @@ public class Container : Drawable
     internal long TopologyVersion { get; private set; } = 1;
 
     private readonly List<Drawable> children = new();
+
+    /// <summary>
+    /// The container that actually holds the children. By default, it is this container.
+    /// Derived classes (like <see cref="ScrollableContainer"/>) can override this to route children to an internal container.
+    /// </summary>
+    protected virtual Container Content => this;
+
     private Drawable? draggedChild;
 
     /// <summary>
@@ -52,10 +60,10 @@ public class Container : Drawable
 
     public IReadOnlyList<Drawable> Children
     {
-        get => children;
+        get => Content == this ? children : Content.Children;
         set
         {
-            children.Clear();
+            Clear();
             foreach (var child in value)
             {
                 Add(child);
@@ -84,17 +92,46 @@ public class Container : Drawable
 
     public virtual void Add(Drawable drawable)
     {
-        // A drawable cannot be its own parent.
+        if (Content != this)
+        {
+            Content.Add(drawable);
+            return;
+        }
+
+        AddInternal(drawable);
+    }
+
+    public virtual void Remove(Drawable drawable)
+    {
+        if (Content != this)
+        {
+            Content.Remove(drawable);
+            return;
+        }
+
+        RemoveInternal(drawable);
+    }
+
+    public virtual void Clear()
+    {
+        if (Content != this)
+        {
+            Content.Clear();
+            return;
+        }
+
+        ClearInternal();
+    }
+
+    protected void AddInternal(Drawable drawable)
+    {
         if (drawable == this)
             throw new InvalidOperationException("A container cannot be added to itself.");
 
-        // A drawable cannot be added to one of its own children, as this would create a circular dependency.
-        // To check, we walk up the hierarchy from the potential parent ('this'). If we find the `drawable`
-        // we're trying to add, it means 'this' is a descendant of `drawable`.
         for (var p = Parent; p != null; p = p.Parent)
         {
             if (p == drawable)
-                throw new InvalidOperationException("Cannot add an ancestor drawable as a child. This would create a circular dependency.");
+                throw new InvalidOperationException("Cannot add an ancestor drawable as a child.");
         }
 
         if (drawable.Parent != null)
@@ -103,14 +140,11 @@ public class Container : Drawable
         drawable.Parent = this;
         children.Add(drawable);
         InvalidateTopology();
+
         if (drawable.Clock is FramedClock framedClock)
-        {
             framedClock.Source = Clock;
-        }
         else
-        {
             drawable.Clock = new FramedClock(Clock, true);
-        }
 
         Invalidate(InvalidationFlags.DrawInfo);
 
@@ -122,7 +156,7 @@ public class Container : Drawable
         }
     }
 
-    public virtual void Remove(Drawable drawable)
+    protected void RemoveInternal(Drawable drawable)
     {
         if (children.Remove(drawable))
         {
@@ -132,7 +166,7 @@ public class Container : Drawable
         }
     }
 
-    public virtual void Clear()
+    protected void ClearInternal()
     {
         foreach (var child in children)
         {
@@ -318,7 +352,7 @@ public class Container : Drawable
     {
         var node = (ContainerDrawNode)base.GenerateDrawNodeSubtree(frameIndex);
         node.Children.Clear();
-        foreach (var child in Children.OrderBy(c => c.Depth))
+        foreach (var child in children.OrderBy(c => c.Depth))
         {
             if (!child.IsMaskedAway || child.AlwaysPresent)
             {

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -398,7 +398,7 @@ public class Container : Drawable
 
     public override bool OnMouseDown(MouseButtonEvent e)
     {
-        foreach (var c in children.OrderByDescending(d => d.Depth))
+        foreach (var c in children.OrderBy(d => d.Depth).Reverse())
         {
             if (c.IsLoaded && c.IsAlive && !c.IsHidden && c.Contains(e.ScreenSpaceMousePosition) && c.OnMouseDown(e))
             {
@@ -487,7 +487,7 @@ public class Container : Drawable
 
     public override bool OnDragDropFile(DragDropFileEvent e)
     {
-        foreach (var c in children.OrderByDescending(d => d.Depth).Reverse())
+        foreach (var c in children.OrderBy(d => d.Depth).Reverse())
         {
             if (c.IsLoaded && !c.IsHidden && c.Contains(e.Position))
             {
@@ -501,7 +501,7 @@ public class Container : Drawable
 
     public override bool OnDragDropText(DragDropTextEvent e)
     {
-        foreach (var c in children.OrderByDescending(d => d.Depth).Reverse())
+        foreach (var c in children.OrderBy(d => d.Depth).Reverse())
         {
             if (c.IsLoaded && !c.IsHidden && c.Contains(e.Position))
             {

--- a/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
+++ b/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
@@ -230,21 +230,18 @@ public class DrawVisualiser : FocusedOverlayContainer, IRemoveFromDrawVisualiser
             Origin = Anchor.TopLeft,
             Size = new Vector2(1),
             RelativePositionAxes = Axes.Both,
-            Name = "Tree View Container"
+            Name = "Tree View Container",
+            Child = treeFlow = new FlowContainer
+            {
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopLeft,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(0, 2),
+                Width = 1f,
+                Name = "Tree Flow"
+            }
         });
-
-        treeFlow = new FlowContainer
-        {
-            Anchor = Anchor.TopLeft,
-            Origin = Anchor.TopLeft,
-            RelativeSizeAxes = Axes.X,
-            AutoSizeAxes = Axes.Y,
-            Spacing = new Vector2(0, 2),
-            Width = 1f,
-            Name = "Tree Flow"
-        };
-
-        parentTreeFlow.Add(treeFlow);
 
         // Property (right)
         Add(rightContainer = new Container
@@ -275,21 +272,18 @@ public class DrawVisualiser : FocusedOverlayContainer, IRemoveFromDrawVisualiser
             Origin = Anchor.TopLeft,
             Size = new Vector2(1),
             RelativePositionAxes = Axes.Both,
-            Name = "Property View Container"
+            Name = "Property View Container",
+            Child = propertyFlow = new FlowContainer()
+            {
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopLeft,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(0, 5),
+                Width = 1f,
+                Name = "Property Flow"
+            }
         });
-
-        propertyFlow = new FlowContainer()
-        {
-            Anchor = Anchor.TopLeft,
-            Origin = Anchor.TopLeft,
-            RelativeSizeAxes = Axes.X,
-            AutoSizeAxes = Axes.Y,
-            Spacing = new Vector2(0, 5),
-            Width = 1f,
-            Name = "Property Flow"
-        };
-
-        parentPropertyFlow.Add(propertyFlow);
     }
 
     private double timeUntilNextTreeRefresh;

--- a/Sakura.Framework/Testing/Input/ManualInputManager.cs
+++ b/Sakura.Framework/Testing/Input/ManualInputManager.cs
@@ -1,7 +1,6 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
-using Sakura.Framework.Graphics.Cursor;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Input;
@@ -18,18 +17,15 @@ public class ManualInputManager : Container
     public bool UseParentInput { get; set; } = true;
 
     private readonly MouseState currentMouseState = new MouseState();
-    private CursorContainer cursorContainer;
 
     public ManualInputManager()
     {
         RelativeSizeAxes = Axes.Both;
         Size = new Vector2(1);
-        Add(cursorContainer = new CursorContainer());
     }
 
     public override bool OnMouseMove(MouseEvent e)
     {
-        cursorContainer.OnMouseMove(e);
         if (!UseParentInput)
             return true;
 
@@ -85,7 +81,6 @@ public class ManualInputManager : Container
         Vector2 delta = position - currentMouseState.Position;
         currentMouseState.Position = position;
         var syntheticEvent = new MouseEvent(currentMouseState, delta);
-        cursorContainer.OnMouseMove(syntheticEvent);
         base.OnMouseMove(syntheticEvent);
     }
 

--- a/Sakura.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/Sakura.Framework/Testing/ManualInputManagerTestScene.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Cursor;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.UserInterface;
@@ -43,6 +44,11 @@ public abstract class ManualInputManagerTestScene : TestScene
         };
 
         InputManager.Add(TestContent);
+
+        InputManager.Add(new CursorContainer
+        {
+            Depth = float.MaxValue
+        });
 
         var inputToggleOverlay = new Container
         {


### PR DESCRIPTION
At first if you need to use the `ScrollContainer` in Sakura Framework you need to do something like this

```csharp
rightContainer.Add(parentPropertyFlow = new ScrollableContainer() { ... });
propertyFlow = new FlowContainer() { ... };
parentPropertyFlow.Add(propertyFlow);
```

Since if you override the `Child` or `Children` property using object initializer it will break the child inside the `ScrollContainer`  (scrollbar, inner container etc.) So that's why the concept of "proxy" container. Now `Container` will have a "proxy container" that can seperate a list of internal drawable and a drawable that user can touch. So now it's safe to do something like this.

```csharp
rightContainer.Add(parentPropertyFlow = new ScrollableContainer
{
    Child = propertyFlow = new FlowContainer { ... }
});
```

Note : About the old code you can still using it but I really recommend to using the new syntax for better readibility.

Other change :

- Fix `CursorContainer` in manual input test scene still following the real cursor of the real cursor is in the test container due to the wrong level and wrong usage of position (not use screen space mouse position)
- Fix scroll bar in `ScrollContainer` will be unusable if the drawable below receive the input.
- Add kinetic momentum on scroll and improve rubber-band feeling when scroll exceed.

TODO:

- [x] Update breaking change doc