### PR TITLE
Change usage of .NET thread sleep to native sleep (nanosleep)

### DIFF
--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -42,8 +42,8 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
     private FontUsage graphFontUsage = FontUsage.Default.With(size: 14);
     private FontUsage boldGraphFontUsage = FontUsage.Default.With(size: 14, weight: "Bold");
 
-    private const float extended_width = 350;
-    private const float compact_width = 300;
+    private const float extended_width = 400;
+    private const float compact_width = 340;
 
     [Resolved]
     private AppHost host { get; set; }

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -191,10 +191,10 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
 
         displaysFlow.Add(currentContextFlow);
 
-        displaysFlow.Add(new ThreadStatisticsDisplay("Input", host.InputClock, Color.LimeGreen, host));
-        displaysFlow.Add(new ThreadStatisticsDisplay("Audio", host.AudioClock, Color.Yellow, host));
-        displaysFlow.Add(new ThreadStatisticsDisplay("Update", host.UpdateClock, Color.Purple, host));
-        displaysFlow.Add(new ThreadStatisticsDisplay("Draw", host.DrawClock, Color.Cyan, host));
+        displaysFlow.Add(new ThreadStatisticsDisplay("Input", host.InputClock, Color.LimeGreen, host, host.GetInputTargetHz));
+        displaysFlow.Add(new ThreadStatisticsDisplay("Audio", host.AudioClock, Color.Yellow, host, host.GetAudioTargetHz));
+        displaysFlow.Add(new ThreadStatisticsDisplay("Update", host.UpdateClock, Color.Purple, host, host.GetUpdateTargetHz));
+        displaysFlow.Add(new ThreadStatisticsDisplay("Draw", host.DrawClock, Color.Cyan, host, host.GetDrawTargetHz));
 
         state = host.FrameworkConfigManager.Get(FrameworkSetting.ShowFpsGraph, PerformanceOverlayState.Hidden);
         state.ValueChanged += e => updateState(e.NewValue);
@@ -266,6 +266,7 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
         private readonly string name;
         private readonly IClock clock;
         private readonly Color baseColor;
+        private readonly Func<double> getTargetHz;
 
         private readonly AppHost host;
         private double lastRecordedTime;
@@ -275,18 +276,26 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
         private int bucketFrameCount;
         private int bucketHighestGc = -1;
 
+        private const int jitter_ring_size = 128;
+        private readonly double[] jitterRing = new double[jitter_ring_size];
+        private int jitterRingIndex;
+        private double jitterRingSum;
+        private double jitterRingSumOfSquares;
+        private int jitterRingCount;
+
         private SpriteText statsText;
         private ThreadBarGraph barGraph;
         private Box textBackground;
 
         private PerformanceOverlayState currentState;
 
-        public ThreadStatisticsDisplay(string name, IClock clock, Color baseColor, AppHost host)
+        public ThreadStatisticsDisplay(string name, IClock clock, Color baseColor, AppHost host, Func<double> getTargetHz)
         {
             this.name = name;
             this.clock = clock;
             this.baseColor = baseColor;
             this.host = host;
+            this.getTargetHz = getTargetHz;
 
             for (int i = 0; i < max_history; i++)
             {
@@ -392,9 +401,18 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
                         }
                     }
 
+                    double rawFrame = clock.ElapsedFrameTime;
+                    double evicted = jitterRing[jitterRingIndex];
+                    jitterRingSum += rawFrame - evicted;
+                    jitterRingSumOfSquares += rawFrame * rawFrame - evicted * evicted;
+                    jitterRing[jitterRingIndex] = rawFrame;
+                    jitterRingIndex = (jitterRingIndex + 1) % jitter_ring_size;
+                    if (jitterRingCount < jitter_ring_size)
+                        jitterRingCount++;
+
                     bucketHighestGc = Math.Max(bucketHighestGc, highestGcGen);
-                    bucketMaxTime = Math.Max(bucketMaxTime, clock.ElapsedFrameTime);
-                    bucketSumTime += clock.ElapsedFrameTime;
+                    bucketMaxTime = Math.Max(bucketMaxTime, rawFrame);
+                    bucketSumTime += rawFrame;
                     bucketFrameCount++;
 
                     lastRecordedTime = clock.CurrentTime;
@@ -435,8 +453,8 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
                     }
                 }
 
-                // throttle the heavy vertex rendering to ~60Hz to protect the CPU
-                if (Clock.CurrentTime - lastVisualUpdateTime >= 16.6)
+                // throttle stats text to 10Hz (unreadable faster) and vertex rebuild to the same cadence
+                if (Clock.CurrentTime - lastVisualUpdateTime >= 100.0)
                 {
                     updateStats();
 
@@ -454,27 +472,29 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
         {
             if (currentCount == 0) return;
 
-            // mean (average frame time)
+            // FPS
             double sum = 0;
             for (int i = 0; i < currentCount; i++)
-            {
                 sum += frameHistory[i].ElapsedTime;
-            }
             double meanFrameTime = sum / currentCount;
-
-            // jitter via standard deviation
-            double varianceSum = 0;
-            for (int i = 0; i < currentCount; i++)
-            {
-                double diff = frameHistory[i].ElapsedTime - meanFrameTime;
-                varianceSum += diff * diff;
-            }
-            double stdDev = Math.Sqrt(varianceSum / currentCount);
-
-            // safeguard against division by zero for FPS
             double fps = meanFrameTime > 0.0001 ? 1000.0 / meanFrameTime : 0;
 
-            statsText.Text = $"{fps,4:F0}fps ({meanFrameTime,4:F2}ms ±{stdDev,4:F2}ms)";
+            // Jitter from the raw ring using the one-pass computational variance formula:
+            // Var(x) = E[x²] - E[x]²
+            // This operates on raw (pre-bucket) frame times, so spikes are never averaged away.
+            double jitter = 0;
+            if (jitterRingCount > 0)
+            {
+                int n = jitterRingCount < jitter_ring_size ? jitterRingCount : jitter_ring_size;
+                double mean = jitterRingSum / n;
+                double variance = jitterRingSumOfSquares / n - mean * mean;
+                // Clamp to 0 to guard against tiny floating-point negatives.
+                jitter = Math.Sqrt(Math.Max(0, variance));
+            }
+
+            double targetHz = getTargetHz();
+            string hzText = targetHz is > 0 and < 10_000 ? $"{targetHz:0}hz" : "∞hz";
+            statsText.Text = $"{fps,4:F0}fps ({meanFrameTime,4:F2}ms ±{jitter,4:F2}ms) {hzText,5}";
         }
 
         private class ThreadBarGraph : Drawable

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -374,6 +374,7 @@ public abstract class AppHost : IDisposable
             double msPerTick = 1000.0 / timestampFrequency;
             long lastMainFrameTime = Stopwatch.GetTimestamp();
             double mainSleepError = 0.0;
+            const double main_min_sleep_ms = 0.5;
 
             INativeSleep mainNativeSleep = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? new WindowsNativeSleep()
@@ -417,7 +418,7 @@ public abstract class AppHost : IDisposable
                         double elapsedMs = (nowTicks - lastMainFrameTime) * msPerTick;
                         double sleepMs = targetMainFrameTimeMs - elapsedMs + mainSleepError;
 
-                        if (sleepMs > 0)
+                        if (sleepMs >= main_min_sleep_ms)
                         {
                             var sleepSpan = TimeSpan.FromMilliseconds(sleepMs);
                             double beforeMs = Stopwatch.GetTimestamp() * msPerTick;
@@ -427,12 +428,13 @@ public abstract class AppHost : IDisposable
 
                             double actualSleepMs = Stopwatch.GetTimestamp() * msPerTick - beforeMs;
                             mainSleepError += sleepMs - actualSleepMs;
-                            mainSleepError = Math.Max(-1000.0 / 30.0, mainSleepError);
                         }
                         else
                         {
-                            mainSleepError = 0;
+                            mainSleepError += sleepMs;
                         }
+
+                        mainSleepError = Math.Clamp(mainSleepError, -1000.0 / 30.0, 2.0);
 
                         lastMainFrameTime += targetMainTicks;
 
@@ -644,10 +646,14 @@ public abstract class AppHost : IDisposable
         Window?.SwapBuffers();
     }
 
-    /// <summary>
-    /// Get the target update rate in Hz based on the current frame limiter setting.
-    /// </summary>
-    /// <returns>The target update rate in Hz, or 0 for unlimited.</returns>
+    // In single-thread mode all threads run together at targetUpdateHz (= draw Hz, locked 1:1).
+    // In multi-thread mode each thread runs at its own independent rate.
+    private bool isMultiThread => ExecutionMode?.Value == Threading.ExecutionMode.MultiThread;
+    internal double GetInputTargetHz()  => isMultiThread ? 1000.0              : targetUpdateHz;
+    internal double GetAudioTargetHz()  => isMultiThread ? 1000.0              : targetUpdateHz;
+    internal double GetUpdateTargetHz() => isMultiThread ? getUpdateTargetHz() : targetUpdateHz;
+    internal double GetDrawTargetHz()   => isMultiThread ? getDrawTargetHz()   : targetUpdateHz;
+
     private double getDrawTargetHz()
     {
         // In headless mode, default to a sensible refresh rate for update calculations.

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -646,13 +646,11 @@ public abstract class AppHost : IDisposable
         Window?.SwapBuffers();
     }
 
-    // In single-thread mode all threads run together at targetUpdateHz (= draw Hz, locked 1:1).
-    // In multi-thread mode each thread runs at its own independent rate.
     private bool isMultiThread => ExecutionMode?.Value == Threading.ExecutionMode.MultiThread;
-    internal double GetInputTargetHz()  => isMultiThread ? 1000.0              : targetUpdateHz;
-    internal double GetAudioTargetHz()  => isMultiThread ? 1000.0              : targetUpdateHz;
+    internal double GetInputTargetHz() => isMultiThread ? 1000.0 : targetUpdateHz;
+    internal double GetAudioTargetHz() => isMultiThread ? 1000.0 : targetUpdateHz;
     internal double GetUpdateTargetHz() => isMultiThread ? getUpdateTargetHz() : targetUpdateHz;
-    internal double GetDrawTargetHz()   => isMultiThread ? getDrawTargetHz()   : targetUpdateHz;
+    internal double GetDrawTargetHz() => isMultiThread ? getDrawTargetHz() : targetUpdateHz;
 
     private double getDrawTargetHz()
     {

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Runtime;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -372,6 +373,11 @@ public abstract class AppHost : IDisposable
             long timestampFrequency = Stopwatch.Frequency;
             double msPerTick = 1000.0 / timestampFrequency;
             long lastMainFrameTime = Stopwatch.GetTimestamp();
+            double mainSleepError = 0.0;
+
+            INativeSleep mainNativeSleep = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new WindowsNativeSleep()
+                : UnixNativeSleep.IsAvailable ? new UnixNativeSleep() : null;
 
             try
             {
@@ -406,23 +412,26 @@ public abstract class AppHost : IDisposable
                     {
                         double targetMainFrameTimeMs = 1000.0 / currentHz;
                         long targetMainTicks = (long)(targetMainFrameTimeMs / msPerTick);
-                        long targetFrameTimeTimestamp = lastMainFrameTime + targetMainTicks;
 
-                        while (true)
+                        long nowTicks = Stopwatch.GetTimestamp();
+                        double elapsedMs = (nowTicks - lastMainFrameTime) * msPerTick;
+                        double sleepMs = targetMainFrameTimeMs - elapsedMs + mainSleepError;
+
+                        if (sleepMs > 0)
                         {
-                            long currentTimestamp = Stopwatch.GetTimestamp();
-                            long remainingTicks = targetFrameTimeTimestamp - currentTimestamp;
+                            var sleepSpan = TimeSpan.FromMilliseconds(sleepMs);
+                            double beforeMs = Stopwatch.GetTimestamp() * msPerTick;
 
-                            if (remainingTicks <= 0)
-                                break;
+                            if (mainNativeSleep?.Sleep(sleepSpan) != true)
+                                Thread.Sleep(sleepSpan);
 
-                            double timeRemainingMs = remainingTicks * msPerTick;
-                            if (timeRemainingMs >= 1.0)
-                                Thread.Sleep(TimeSpan.FromMilliseconds(timeRemainingMs - 0.2));
-                            else if (timeRemainingMs > 0.1)
-                                Thread.Yield();
-                            else
-                                Thread.SpinWait(10);
+                            double actualSleepMs = Stopwatch.GetTimestamp() * msPerTick - beforeMs;
+                            mainSleepError += sleepMs - actualSleepMs;
+                            mainSleepError = Math.Max(-1000.0 / 30.0, mainSleepError);
+                        }
+                        else
+                        {
+                            mainSleepError = 0;
                         }
 
                         lastMainFrameTime += targetMainTicks;
@@ -431,18 +440,24 @@ public abstract class AppHost : IDisposable
                         if ((currentAfterWait - lastMainFrameTime) * msPerTick > targetMainFrameTimeMs * 5)
                         {
                             lastMainFrameTime = currentAfterWait;
+                            mainSleepError = 0;
                         }
                     }
                     else
                     {
                         lastMainFrameTime = Stopwatch.GetTimestamp();
-                        Thread.Yield();
+                        mainSleepError = 0;
+                        Thread.Sleep(0);
                     }
                 }
             }
             catch (OutOfMemoryException ex)
             {
                 Logger.Error("The application has run out of memory and needs to close.", ex);
+            }
+            finally
+            {
+                mainNativeSleep?.Dispose();
             }
         }
         catch (Exception ex)

--- a/Sakura.Framework/RuntimeInfo.cs
+++ b/Sakura.Framework/RuntimeInfo.cs
@@ -56,6 +56,7 @@ public static class RuntimeInfo
     public static bool IsDesktop => OS == Platform.Linux || OS == Platform.macOS || OS == Platform.Windows;
     public static bool IsMobile => OS == Platform.iOS || OS == Platform.Android;
     public static bool IsApple => OS == Platform.iOS || OS == Platform.macOS;
+    public static bool IsWindows => OS == Platform.Windows;
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static bool IsMacOS => OS == Platform.macOS;

--- a/Sakura.Framework/Threading/AppThread.cs
+++ b/Sakura.Framework/Threading/AppThread.cs
@@ -97,8 +97,9 @@ public class AppThread
 
         long lastFrameTime = System.Diagnostics.Stopwatch.GetTimestamp();
 
-        // Accumulated sleep error for drift correction (same approach as osu!framework's ThrottledFrameClock).
         double accumulatedSleepError = 0.0;
+
+        const double min_sleep_ms = 0.5;
 
         while (isRunning)
         {
@@ -121,7 +122,7 @@ public class AppThread
                 // Excess = how long we should sleep (with drift correction).
                 double sleepMs = targetFrameTimeMs - elapsedMs + accumulatedSleepError;
 
-                if (sleepMs > 0)
+                if (sleepMs >= min_sleep_ms)
                 {
                     var sleepSpan = TimeSpan.FromMilliseconds(sleepMs);
                     double beforeMs = System.Diagnostics.Stopwatch.GetTimestamp() * msPerTick;
@@ -131,21 +132,26 @@ public class AppThread
 
                     double actualSleepMs = System.Diagnostics.Stopwatch.GetTimestamp() * msPerTick - beforeMs;
 
-                    // Correct for overshoot/undershoot; clamp to avoid runaway catch-up.
+                    // Fold overshoot/undershoot back into the accumulator.
                     accumulatedSleepError += sleepMs - actualSleepMs;
-                    accumulatedSleepError = Math.Max(-1000.0 / 30.0, accumulatedSleepError);
                 }
                 else
                 {
-                    // Already late — reset error so we don't double-compensate.
-                    accumulatedSleepError = 0;
+                    // Frame is late or remainder is below the sleep precision floor.
+                    // Carry the deficit forward so the next frame compensates, rather than discarding it.
+                    accumulatedSleepError += sleepMs;
                 }
+
+                // Clamp the accumulator: allow at most ~33 ms of catch-up debt (one missed 30fps frame),
+                // and allow up to +2 ms of credit (so a frame that finished early can donate it forward).
+                accumulatedSleepError = Math.Clamp(accumulatedSleepError, -1000.0 / 30.0, 2.0);
 
                 // Advance the frame anchor by one frame quantum (keeps cadence locked).
                 long targetTicks = (long)(targetFrameTimeMs / msPerTick);
                 lastFrameTime += targetTicks;
 
-                // If we've slipped more than 5 frames behind, reset to avoid a catch-up avalanche.
+                // If we've slipped more than 5 frames behind (e.g. after a GC pause or window drag),
+                // snap the anchor forward to avoid a long catch-up avalanche of back-to-back frames.
                 long currentAfterWait = System.Diagnostics.Stopwatch.GetTimestamp();
                 double thresholdMs = Math.Max(targetFrameTimeMs * 5, 50.0);
                 if ((currentAfterWait - lastFrameTime) * msPerTick > thresholdMs)
@@ -156,10 +162,11 @@ public class AppThread
             }
             else
             {
-                // Unlimited rate — yield once so we don't monopolise the CPU.
+                // Truly unlimited — don't sleep or yield. The frame runs back-to-back as fast as
+                // the work allows. Users who want CPU relief in unlimited mode should enable
+                // LimitUnlimitedUpdateRate in HostOptions, which caps at 1000 Hz with nanosleep.
                 lastFrameTime = System.Diagnostics.Stopwatch.GetTimestamp();
                 accumulatedSleepError = 0;
-                Thread.Sleep(0);
             }
         }
 

--- a/Sakura.Framework/Threading/AppThread.cs
+++ b/Sakura.Framework/Threading/AppThread.cs
@@ -2,8 +2,11 @@
 // See the LICENSE file for full license text.
 
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Sakura.Framework.Timing;
+using Logger = Sakura.Framework.Logging.Logger;
+using OSPlatform = System.Runtime.InteropServices.OSPlatform;
 
 namespace Sakura.Framework.Threading;
 
@@ -21,12 +24,26 @@ public class AppThread
     private volatile bool isRunning;
     private volatile bool isPaused;
 
+    /// <summary>
+    /// Platform-specific high-precision sleep. Null if unavailable (falls back to Thread.Sleep)
+    /// </summary>
+    private readonly INativeSleep? nativeSleep;
+
     public AppThread(string name, Action frameAction, Func<double> getTargetHz)
     {
         Name = name;
         FrameAction = frameAction;
         GetTargetHz = getTargetHz;
         Clock = new Clock(true);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // Use Sakura's RuntimeInfo here make CA1416 warning
+            // CA1416: This call site is reachable on all platforms. 'WindowsNativeSleep' is only supported on: 'windows'.
+            nativeSleep = new WindowsNativeSleep();
+        else if (UnixNativeSleep.IsAvailable)
+            nativeSleep = new UnixNativeSleep();
+
+        Logger.Debug($"AppThread '{Name}' initialized with native sleep: {(nativeSleep != null ? nativeSleep.GetType().Name : "none")}");
     }
 
     public void StartMultiThreaded()
@@ -80,6 +97,9 @@ public class AppThread
 
         long lastFrameTime = System.Diagnostics.Stopwatch.GetTimestamp();
 
+        // Accumulated sleep error for drift correction (same approach as osu!framework's ThrottledFrameClock).
+        double accumulatedSleepError = 0.0;
+
         while (isRunning)
         {
             pauseEvent.Wait();
@@ -93,48 +113,56 @@ public class AppThread
             if (currentHz > 0)
             {
                 double targetFrameTimeMs = 1000.0 / currentHz;
-                long targetTicks = (long)(targetFrameTimeMs / msPerTick);
-                long targetFrameTimeTimestamp = lastFrameTime + targetTicks;
 
-                while (true)
+                // How much time has elapsed since the last frame started?
+                long nowTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+                double elapsedMs = (nowTicks - lastFrameTime) * msPerTick;
+
+                // Excess = how long we should sleep (with drift correction).
+                double sleepMs = targetFrameTimeMs - elapsedMs + accumulatedSleepError;
+
+                if (sleepMs > 0)
                 {
-                    long currentTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
-                    long remainingTicks = targetFrameTimeTimestamp - currentTimestamp;
+                    var sleepSpan = TimeSpan.FromMilliseconds(sleepMs);
+                    double beforeMs = System.Diagnostics.Stopwatch.GetTimestamp() * msPerTick;
 
-                    if (remainingTicks <= 0)
-                        break;
+                    if (nativeSleep?.Sleep(sleepSpan) != true)
+                        Thread.Sleep(sleepSpan);
 
-                    double timeRemainingMs = remainingTicks * msPerTick;
+                    double actualSleepMs = System.Diagnostics.Stopwatch.GetTimestamp() * msPerTick - beforeMs;
 
-                    if (timeRemainingMs >= 1.0)
-                    {
-                        Thread.Sleep(TimeSpan.FromMilliseconds(timeRemainingMs - 0.2));
-                    }
-                    else if (timeRemainingMs > 0.1)
-                    {
-                        Thread.Yield();
-                    }
-                    else
-                    {
-                        Thread.SpinWait(10);
-                    }
+                    // Correct for overshoot/undershoot; clamp to avoid runaway catch-up.
+                    accumulatedSleepError += sleepMs - actualSleepMs;
+                    accumulatedSleepError = Math.Max(-1000.0 / 30.0, accumulatedSleepError);
+                }
+                else
+                {
+                    // Already late — reset error so we don't double-compensate.
+                    accumulatedSleepError = 0;
                 }
 
+                // Advance the frame anchor by one frame quantum (keeps cadence locked).
+                long targetTicks = (long)(targetFrameTimeMs / msPerTick);
                 lastFrameTime += targetTicks;
 
-                double thresholdLimitMs = Math.Max(targetFrameTimeMs * 5, 50.0);
-
+                // If we've slipped more than 5 frames behind, reset to avoid a catch-up avalanche.
                 long currentAfterWait = System.Diagnostics.Stopwatch.GetTimestamp();
-                if ((currentAfterWait - lastFrameTime) * msPerTick > thresholdLimitMs)
+                double thresholdMs = Math.Max(targetFrameTimeMs * 5, 50.0);
+                if ((currentAfterWait - lastFrameTime) * msPerTick > thresholdMs)
                 {
                     lastFrameTime = currentAfterWait;
+                    accumulatedSleepError = 0;
                 }
             }
             else
             {
+                // Unlimited rate — yield once so we don't monopolise the CPU.
                 lastFrameTime = System.Diagnostics.Stopwatch.GetTimestamp();
-                Thread.Yield();
+                accumulatedSleepError = 0;
+                Thread.Sleep(0);
             }
         }
+
+        nativeSleep?.Dispose();
     }
 }

--- a/Sakura.Framework/Threading/INativeSleep.cs
+++ b/Sakura.Framework/Threading/INativeSleep.cs
@@ -1,0 +1,18 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.Threading;
+
+/// <summary>
+/// Provides a platform-specific high-precision sleep primitive.
+/// </summary>
+internal interface INativeSleep : IDisposable
+{
+    /// <summary>
+    /// Sleep for the given duration.
+    /// </summary>
+    /// <returns>True if sleep succeeded; false if it should fall back to <see cref="System.Threading.Thread.Sleep"/>.</returns>
+    bool Sleep(TimeSpan duration);
+}

--- a/Sakura.Framework/Threading/UnixNativeSleep.cs
+++ b/Sakura.Framework/Threading/UnixNativeSleep.cs
@@ -1,0 +1,73 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Sakura.Framework.Threading;
+
+/// <summary>
+/// High-precision sleep on Unix/macOS using nanosleep(2).
+/// Falls back gracefully if libc cannot be found.
+/// </summary>
+internal class UnixNativeSleep : INativeSleep
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct TimeSpec
+    {
+        public nint Seconds;
+        public nint NanoSeconds;
+    }
+
+    [DllImport("libc", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+    private static extern int nanosleep(in TimeSpec duration, out TimeSpec remaining);
+
+    private const int eintr = 4;
+
+    public static bool IsAvailable { get; } = probe();
+
+    /// <summary>
+    /// Probes whether nanosleep is available by calling it with a short duration.
+    /// </summary>
+    /// <returns>True if nanosleep is available; false if it throws (e.g. due to missing libc).</returns>
+    private static bool probe()
+    {
+        try
+        {
+            var t = new TimeSpec
+            {
+                Seconds = 0,
+                NanoSeconds = 1
+            };
+            nanosleep(in t, out _);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public bool Sleep(TimeSpan duration)
+    {
+        const long ns_per_second = 1_000_000_000L;
+        long totalNs = (long)duration.TotalNanoseconds;
+
+        var ts = new TimeSpec
+        {
+            Seconds = (nint)(totalNs / ns_per_second),
+            NanoSeconds = (nint)(totalNs % ns_per_second),
+        };
+
+        int ret;
+        while ((ret = nanosleep(in ts, out var rem)) == -1 && Marshal.GetLastPInvokeError() == eintr)
+        {
+            // Interrupted by a signal — sleep the remaining time.
+            ts = rem;
+        }
+
+        return ret == 0;
+    }
+
+    public void Dispose() { }
+}

--- a/Sakura.Framework/Threading/WindowsNativeSleep.cs
+++ b/Sakura.Framework/Threading/WindowsNativeSleep.cs
@@ -1,0 +1,45 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Sakura.Framework.Threading;
+
+/// <summary>
+/// High-precision sleep on Windows using NtDelayExecution via ntdll.
+/// Requests a 1 ms timer resolution for the lifetime of the instance.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal class WindowsNativeSleep : INativeSleep
+{
+    // Sets the system timer resolution (100-ns units).
+    [DllImport("ntdll.dll", SetLastError = false)]
+    private static extern int NtSetTimerResolution(uint desiredResolution, bool setResolution, out uint currentResolution);
+
+    // Alertable, relative sleep in 100-ns units (negative = relative).
+    [DllImport("ntdll.dll", SetLastError = false)]
+    private static extern int NtDelayExecution(bool alertable, ref long delayInterval);
+
+    // 1 ms in 100-ns units.
+    private const uint resolution1_ms = 10_000;
+
+    public WindowsNativeSleep()
+    {
+        _ = NtSetTimerResolution(resolution1_ms, true, out _);
+    }
+
+    public bool Sleep(TimeSpan duration)
+    {
+        // NtDelayExecution uses negative 100-ns intervals for relative delays.
+        long interval = -(long)(duration.TotalNanoseconds / 100);
+        _ = NtDelayExecution(false, ref interval);
+        return true;
+    }
+
+    public void Dispose()
+    {
+        _ = NtSetTimerResolution(resolution1_ms, false, out _);
+    }
+}


### PR DESCRIPTION
If you run Sakura app before this PR (in MacOS or UNIX system) you will notice that the Sakura's multithreaded take about 200%++ CPU usage. This is because the flow that we use the .NET's thread method to limit the CPU loop (`Thread.Yield()`, `Thread.Sleep(0)`) these method really block the CPU's entire thread lead to OS report that 200%++ CPU usage. This PR change usage of .NET thread to using native method (a.k.a. nanosleep) the CPU efficiency and performance should be increase a lot .

`main`:
<img width="379" height="120" alt="Screenshot 2026-06-02 at 15 27 34" src="https://github.com/user-attachments/assets/42c94362-625f-4935-9473-641634d0cf7b" />
<img width="462" height="315" alt="Screenshot 2026-06-02 at 15 27 50" src="https://github.com/user-attachments/assets/e4d37a16-f728-4a23-9583-e04c67f35f42" />

This branch :
<img width="389" height="122" alt="Screenshot 2026-06-02 at 15 28 39" src="https://github.com/user-attachments/assets/09cb2d53-46f9-4854-b808-483084e1a4c4" />
<img width="463" height="320" alt="Screenshot 2026-06-02 at 15 29 00" src="https://github.com/user-attachments/assets/8cb01203-d822-46fe-af30-ab6bdcffa00a" />
