### PR TITLE
Move more class out from OpenGL and support for multiple renderer in future

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="C#">
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestDrawablePool.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestDrawablePool.cs
@@ -59,7 +59,7 @@ public class TestDrawablePool : TestScene
 
         AddRepeatStep("Get new pooled drawables", () => consumeDrawable(), 50);
 
-        AddUntilStep("All returned to pool", () => pool.CountAvailable == pool.CurrentPoolSize);
+        AddUntilStep("All returned to pool", () => pool.CountAvailable == pool.CurrentPoolSize, 15000);
 
         AddAssert("Pool grew in size", () => pool.CountAvailable > pool_size);
         AddAssert("Consumed drawables report returned to pool", () => consumed.All(d => !d.IsInUse));

--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicDropdown.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicDropdown.cs
@@ -54,6 +54,7 @@ public class TestBasicDropdown : ManualInputManagerTestScene
 
         AddStep("Move to dropdown header", () => InputManager.MoveMouseTo(dropdown));
         AddStep("Click dropdown to open", () => InputManager.Click(MouseButton.Left));
+        AddWaitStep("Wait a bit", 50);
 
         // the header is 30 pixels high. B is the second item (index 1).
         // y offset = header height + (item Height * index) + (item Height / 2 for center)

--- a/Sakura.Framework/Configurations/FrameworkConfigManager.cs
+++ b/Sakura.Framework/Configurations/FrameworkConfigManager.cs
@@ -25,5 +25,9 @@ public class FrameworkConfigManager : ConfigManager<FrameworkSetting>
         Get(FrameworkSetting.WindowMode, WindowMode.Windowed);
         Get(FrameworkSetting.HardwareAcceleration, true);
         Get(FrameworkSetting.RendererType, RendererType.Automatic);
+        Get(FrameworkSetting.WindowX, -1);
+        Get(FrameworkSetting.WindowY, -1);
+        Get(FrameworkSetting.WindowWidth, -1);
+        Get(FrameworkSetting.WindowHeight, -1);
     }
 }

--- a/Sakura.Framework/Configurations/FrameworkConfigManager.cs
+++ b/Sakura.Framework/Configurations/FrameworkConfigManager.cs
@@ -24,5 +24,6 @@ public class FrameworkConfigManager : ConfigManager<FrameworkSetting>
         Get(FrameworkSetting.SampleVolume, 1.0);
         Get(FrameworkSetting.WindowMode, WindowMode.Windowed);
         Get(FrameworkSetting.HardwareAcceleration, true);
+        Get(FrameworkSetting.RendererType, RendererType.Automatic);
     }
 }

--- a/Sakura.Framework/Configurations/FrameworkSetting.cs
+++ b/Sakura.Framework/Configurations/FrameworkSetting.cs
@@ -13,5 +13,6 @@ public enum FrameworkSetting
     SampleVolume,
     WindowMode,
     ExecutionMode,
-    HardwareAcceleration
+    HardwareAcceleration,
+    RendererType
 }

--- a/Sakura.Framework/Configurations/FrameworkSetting.cs
+++ b/Sakura.Framework/Configurations/FrameworkSetting.cs
@@ -14,5 +14,9 @@ public enum FrameworkSetting
     WindowMode,
     ExecutionMode,
     HardwareAcceleration,
-    RendererType
+    RendererType,
+    WindowX,
+    WindowY,
+    WindowWidth,
+    WindowHeight
 }

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -38,6 +38,7 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
     private SpriteText limiterText;
     private SpriteText windowModeText;
     private SpriteText executionModeText;
+    private SpriteText rendererText;
 
     private FontUsage graphFontUsage = FontUsage.Default.With(size: 14);
     private FontUsage boldGraphFontUsage = FontUsage.Default.With(size: 14, weight: "Bold");
@@ -183,6 +184,36 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
                                     Text = "N/A"
                                 }
                             }
+                        },
+                        new FlowContainer()
+                        {
+                            Anchor = Anchor.TopLeft,
+                            Origin = Anchor.TopLeft,
+                            Direction = FlowDirection.Horizontal,
+                            Size = new Vector2(1, 20),
+                            RelativeSizeAxes = Axes.X,
+                            Spacing = new Vector2(10, 0),
+                            Children = new Drawable[]
+                            {
+                                new SpriteText()
+                                {
+                                    Anchor = Anchor.TopLeft,
+                                    Origin = Anchor.TopLeft,
+                                    Size = new Vector2(200, 10),
+                                    Color = Color.White,
+                                    Font = boldGraphFontUsage,
+                                    Text = "Renderer"
+                                },
+                                rendererText = new SpriteText()
+                                {
+                                    Anchor = Anchor.TopLeft,
+                                    Origin = Anchor.TopLeft,
+                                    Size = new Vector2(200, 10),
+                                    Color = Color.White,
+                                    Font = graphFontUsage,
+                                    Text = "N/A"
+                                }
+                            }
                         }
                     }
                 }
@@ -203,6 +234,17 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
         updateState(state.Value);
     }
 
+    private string getRendererText()
+    {
+        var configured = host.FrameworkConfigManager.Get<RendererType>(FrameworkSetting.RendererType).Value;
+        string actual = host.Renderer?.GetType().Name ?? "None";
+
+        if (actual.EndsWith("Renderer"))
+            actual = actual[..^"Renderer".Length];
+
+        return configured == RendererType.Automatic ? $"Automatic ({actual})" : actual;
+    }
+
     public override void LoadComplete()
     {
         base.LoadComplete();
@@ -210,6 +252,7 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
         windowModeText.Text = $"{host.Window?.WindowModeReactive.Value} ({host.Window?.Width}x{host.Window?.Height})";
         executionModeText.Text = $"{host.ExecutionMode.Value}";
         limiterText.Text = $"{host.FrameLimiter.Value}";
+        rendererText.Text = getRendererText();
 
         host.FrameLimiter.ValueChanged += value =>
         {

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -77,7 +77,7 @@ public class FpsGraph : Container, IRemoveFromDrawVisualiser
         {
             Anchor = Anchor.TopLeft,
             Origin = Anchor.TopLeft,
-            Size = new Vector2(extended_width, 80),
+            Size = new Vector2(extended_width, 100),
             Children = new Drawable[]
             {
                 new Box()

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -24,7 +24,7 @@ using Texture = Sakura.Framework.Graphics.Textures.Texture;
 namespace Sakura.Framework.Graphics.Rendering;
 
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-public class GLRenderer : IRenderer
+public class GLRenderer : IGLRenderer
 {
     private static GL gl;
 
@@ -33,6 +33,8 @@ public class GLRenderer : IRenderer
     public Texture WhitePixel { get; private set; }
     public Matrix4x4 ProjectionMatrix => projectionMatrix;
     public Storage ShaderStorage { get; set; }
+
+    private GLTexture whiteGLTexture => (GLTexture)WhitePixel.BackendTexture!;
 
     private GLShader shader;
 
@@ -174,6 +176,8 @@ public class GLRenderer : IRenderer
 
     public IShader CreateShader(Storage storage, string vertexPath, string fragmentPath) => new GLShader(gl, storage, vertexPath, fragmentPath);
 
+    public INativeVideoTexture CreateVideoTexture(int width, int height) => new VideoGLTexture(gl, width, height);
+
     public void DrawVerticesRaw(ReadOnlySpan<Vertex.Vertex> vertices)
     {
         triangleBatch.DrawRaw(vertices);
@@ -274,11 +278,11 @@ public class GLRenderer : IRenderer
 
     private void drawMaskShape(Drawable maskDrawable, float cornerRadius)
     {
-        if (boundTextureCount == 0 || GLTexture.WhitePixel.GLHandle != boundTextureHandles[0])
+        if (boundTextureCount == 0 || whiteGLTexture.GLHandle != boundTextureHandles[0])
         {
             triangleBatch.Draw();
-            GLTexture.WhitePixel.Bind(0);
-            boundTextureHandles[0] = GLTexture.WhitePixel.GLHandle;
+            whiteGLTexture.Bind(0);
+            boundTextureHandles[0] = whiteGLTexture.GLHandle;
             if (boundTextureCount == 0) boundTextureCount = 1;
         }
 
@@ -303,11 +307,11 @@ public class GLRenderer : IRenderer
         shader.SetUniform("u_BorderThickness", borderThickness);
         shader.SetUniform("u_BorderColor", borderColor);
 
-        if (boundTextureCount == 0 || GLTexture.WhitePixel.GLHandle != boundTextureHandles[0])
+        if (boundTextureCount == 0 || whiteGLTexture.GLHandle != boundTextureHandles[0])
         {
             triangleBatch.Draw();
-            GLTexture.WhitePixel.Bind();
-            boundTextureHandles[0] = GLTexture.WhitePixel.GLHandle;
+            whiteGLTexture.Bind();
+            boundTextureHandles[0] = whiteGLTexture.GLHandle;
             if (boundTextureCount == 0) boundTextureCount = 1;
         }
 
@@ -419,11 +423,11 @@ public class GLRenderer : IRenderer
 
         // Pre-fill all OpenGL texture units with a valid texture (WhitePixel)
         // to fix some strict driver that will complain about "unloadable texture"
-        if (GLTexture.WhitePixel != null)
+        if (WhitePixel?.BackendTexture != null)
         {
             for (int i = 0; i < 8; i++)
             {
-                GLTexture.WhitePixel.Bind(i);
+                whiteGLTexture.Bind(i);
             }
         }
 

--- a/Sakura.Framework/Graphics/Rendering/GLShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLShader.cs
@@ -82,7 +82,7 @@ public partial class GLShader : IShader
         GlobalStatistics.Get<int>("Graphics", "Loaded Shaders").Value++;
     }
 
-    public uint Handle => handle;
+    public nint Handle => (nint)handle;
 
     public void Use()
     {

--- a/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
@@ -77,10 +77,10 @@ public class HeadlessRenderer : IRenderer
     }
 
     public void FlushBatch() { }
+
     public void RestoreMainShader() { }
-    public void DrawVerticesRaw(ReadOnlySpan<Vertex.Vertex> vertices) { }
-    public void DisableSrgb() { }
-    public void RestoreSrgb() { }
 
     public IShader CreateShader(Storage storage, string vertexPath, string fragmentPath) => new HeadlessShader();
+
+    public INativeVideoTexture CreateVideoTexture(int width, int height) => new HeadlessNativeVideoTexture(width, height);
 }

--- a/Sakura.Framework/Graphics/Rendering/HeadlessShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/HeadlessShader.cs
@@ -8,7 +8,7 @@ namespace Sakura.Framework.Graphics.Rendering;
 
 public sealed class HeadlessShader : IShader
 {
-    public uint Handle => 0;
+    public nint Handle => 0;
 
     public void Use() { }
     public void SetUniform(string name, int value) { }

--- a/Sakura.Framework/Graphics/Rendering/IGLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/IGLRenderer.cs
@@ -1,0 +1,35 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Graphics.Rendering;
+
+/// <summary>
+/// OpenGL-specific renderer extensions.
+/// Only cast to this interface from code that is already GL-specific (e.g. VideoDrawNode on GL).
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public interface IGLRenderer : IRenderer
+{
+    /// <summary>
+    /// Disables sRGB framebuffer encoding for the next draw call.
+    /// Required for video rendering: YUV→RGB output is already gamma-encoded
+    /// and must not be re-encoded by the sRGB framebuffer path.
+    /// Call <see cref="RestoreSrgb"/> immediately after the draw call.
+    /// </summary>
+    void DisableSrgb();
+
+    /// <summary>
+    /// Re-enables sRGB framebuffer encoding after a <see cref="DisableSrgb"/> call.
+    /// </summary>
+    void RestoreSrgb();
+
+    /// <summary>
+    /// Uploads the given vertices into the shared VBO and issues a raw DrawArrays call
+    /// without touching any texture slots. Used by VideoDrawNode so it can bind its own
+    /// textures independently of the renderer's slot management.
+    /// </summary>
+    void DrawVerticesRaw(ReadOnlySpan<Vertex.Vertex> vertices);
+}

--- a/Sakura.Framework/Graphics/Rendering/IRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/IRenderer.cs
@@ -69,26 +69,6 @@ public interface IRenderer
     void RestoreMainShader();
 
     /// <summary>
-    /// Uploads the given vertices into the shared VBO and issues a raw DrawArrays call
-    /// without touching any texture slots. Used by VideoDrawNode so it can bind its own
-    /// textures independently of the renderer's slot management.
-    /// </summary>
-    void DrawVerticesRaw(ReadOnlySpan<Vertex.Vertex> vertices);
-
-    /// <summary>
-    /// Disables sRGB framebuffer encoding for the next draw call.
-    /// Required for video rendering: YUV→RGB output is already gamma-encoded
-    /// and must NOT be re-encoded by the sRGB framebuffer path.
-    /// Call <see cref="RestoreSrgb"/> immediately after the draw call.
-    /// </summary>
-    void DisableSrgb();
-
-    /// <summary>
-    /// Re-enables sRGB framebuffer encoding after a <see cref="DisableSrgb"/> call.
-    /// </summary>
-    void RestoreSrgb();
-
-    /// <summary>
     /// Storage pointing to the framework's built-in shader directory.
     /// Use this to load the framework's own shaders, or as a base for composite stores
     /// that overlay game shaders on top of framework utilities.
@@ -106,4 +86,10 @@ public interface IRenderer
     /// <param name="vertexPath">Path inside the storage to the vertex shader (e.g. "shader.vert").</param>
     /// <param name="fragmentPath">Path inside the storage to the fragment shader (e.g. "shader.frag").</param>
     IShader CreateShader(Storage storage, string vertexPath, string fragmentPath);
+
+    /// <summary>
+    /// Creates a backend-specific YUV420P video texture of the given dimensions.
+    /// Must be called on the render thread.
+    /// </summary>
+    INativeVideoTexture CreateVideoTexture(int width, int height);
 }

--- a/Sakura.Framework/Graphics/Rendering/IShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/IShader.cs
@@ -35,5 +35,5 @@ public interface IShader : IDisposable
     /// <summary>
     /// The native program handle. Used by backend-specific code that needs raw access.
     /// </summary>
-    uint Handle { get; }
+    nint Handle { get; }
 }

--- a/Sakura.Framework/Graphics/Rendering/Vertex/Vertex.cs
+++ b/Sakura.Framework/Graphics/Rendering/Vertex/Vertex.cs
@@ -3,12 +3,12 @@
 
 using System.Runtime.InteropServices;
 using Sakura.Framework.Maths;
-using Silk.NET.OpenGL;
 
 namespace Sakura.Framework.Graphics.Rendering.Vertex;
 
 /// <summary>
 /// A vertex with position, color, and texture coordinates.
+/// Each renderer maps the <see cref="VertexMemberAttribute"/> annotations to its own attribute layout API.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
 public struct Vertex
@@ -16,43 +16,43 @@ public struct Vertex
     /// <summary>
     /// The position of the vertex.
     /// </summary>
-    [VertexMember(2, VertexAttribPointerType.Float)]
+    [VertexMember(2, VertexMemberType.Float)]
     public Vector2 Position;
 
     /// <summary>
     /// The color of the vertex.
     /// </summary>
-    [VertexMember(4, VertexAttribPointerType.Float)]
+    [VertexMember(4, VertexMemberType.Float)]
     public Vector4 Color;
 
     /// <summary>
     /// The texture coordinates of the vertex.
     /// </summary>
-    [VertexMember(2, VertexAttribPointerType.Float)]
+    [VertexMember(2, VertexMemberType.Float)]
     public Vector2 TexCoords;
 
     /// <summary>
-    /// The index of the texture to use for this vertex to make it able to bind multiple textures in a single draw call.
+    /// Index of the texture to use, allowing multiple textures per draw call.
     /// </summary>
-    [VertexMember(1, VertexAttribPointerType.Float)]
+    [VertexMember(1, VertexMemberType.Float)]
     public float TexIndex;
 
     /// <summary>
     /// The clipping data (Center.X, Center.Y, HalfWidth, HalfHeight).
     /// </summary>
-    [VertexMember(4, VertexAttribPointerType.Float)]
+    [VertexMember(4, VertexMemberType.Float)]
     public Vector4 ClipData;
 
     /// <summary>
-    /// The horizontal shear modifier for clipping.
+    /// Horizontal shear modifier for clipping.
     /// </summary>
-    [VertexMember(1, VertexAttribPointerType.Float)]
+    [VertexMember(1, VertexMemberType.Float)]
     public float ClipShearX;
 
     /// <summary>
-    /// The radius for clipping corners, used for rounded rectangles. A value of 0 means no rounding.
+    /// Corner radius for clipping. 0 means no rounding.
     /// </summary>
-    [VertexMember(1, VertexAttribPointerType.Float)]
+    [VertexMember(1, VertexMemberType.Float)]
     public float ClipRadius;
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Rendering/Vertex/VertexMemberAttribute.cs
+++ b/Sakura.Framework/Graphics/Rendering/Vertex/VertexMemberAttribute.cs
@@ -2,20 +2,27 @@
 // See the LICENSE file for full license text.
 
 using System;
-using Silk.NET.OpenGL;
 
 namespace Sakura.Framework.Graphics.Rendering.Vertex;
 
 /// <summary>
-/// Attribute to describe a member of a vertex struct.
+/// Describes a single attribute member of a vertex struct.
+/// Each renderer reads this and maps to its own attribute API.
 /// </summary>
 [AttributeUsage(AttributeTargets.Field)]
 public class VertexMemberAttribute : Attribute
 {
+    /// <summary>
+    /// Number of components (e.g. 2 for a vec2, 4 for a vec4).
+    /// </summary>
     public int Count { get; }
-    public VertexAttribPointerType Type { get; }
 
-    public VertexMemberAttribute(int count, VertexAttribPointerType type)
+    /// <summary>
+    /// Primitive data type of each component.
+    /// </summary>
+    public VertexMemberType Type { get; }
+
+    public VertexMemberAttribute(int count, VertexMemberType type)
     {
         Count = count;
         Type = type;

--- a/Sakura.Framework/Graphics/Rendering/Vertex/VertexMemberType.cs
+++ b/Sakura.Framework/Graphics/Rendering/Vertex/VertexMemberType.cs
@@ -1,0 +1,15 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Graphics.Rendering.Vertex;
+
+/// <summary>
+/// Describes the primitive data type of vertex attribute member.
+/// Each renderer maps this to its own type enum.
+/// </summary>
+public enum VertexMemberType
+{
+    Float,
+    Int,
+    UnsignedByte,
+}

--- a/Sakura.Framework/Graphics/Textures/HeadlessNativeVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/HeadlessNativeVideoTexture.cs
@@ -1,0 +1,28 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using FFmpeg.AutoGen;
+
+namespace Sakura.Framework.Graphics.Textures;
+
+/// <summary>
+/// No-op <see cref="INativeVideoTexture"/> used by the headless renderer.
+/// All operations are silently ignored.
+/// </summary>
+internal sealed class HeadlessNativeVideoTexture : INativeVideoTexture
+{
+    public int Width { get; }
+    public int Height { get; }
+    public bool Available => false;
+
+    public HeadlessNativeVideoTexture(int width, int height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    public void BindPlanes() { }
+    public unsafe void Upload(AVFrame* frame) { }
+    public void MarkAvailable() { }
+    public void Dispose() { }
+}

--- a/Sakura.Framework/Graphics/Textures/INativeVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/INativeVideoTexture.cs
@@ -1,0 +1,42 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using FFmpeg.AutoGen;
+
+namespace Sakura.Framework.Graphics.Textures;
+
+/// <summary>
+/// Backend-agnostic contract for a YUV420P video texture.
+/// The GL implementation is <c>VideoGLTexture</c>; Metal will have its own.
+/// </summary>
+public interface INativeVideoTexture : IDisposable
+{
+    int Width { get; }
+    int Height { get; }
+
+    /// <summary>
+    /// True once at least one frame has been uploaded and is ready to draw.
+    /// </summary>
+    bool Available { get; }
+
+    /// <summary>
+    /// Binds the Y, U, V planes to the appropriate texture slots for the current backend.
+    /// For OpenGL: activates TextureUnit.Texture0/1/2 and binds each plane.
+    /// For Metal: records the plane textures on the current render command encoder.
+    /// Must be called on the render thread.
+    /// </summary>
+    void BindPlanes();
+
+    /// <summary>
+    /// Uploads a decoded YUV420P frame into the backend texture planes.
+    /// Must be called on the render thread.
+    /// </summary>
+    unsafe void Upload(AVFrame* frame);
+
+    /// <summary>
+    /// Marks the texture as having valid uploaded data.
+    /// Called by the upload path after all planes are transferred to the GPU.
+    /// </summary>
+    void MarkAvailable();
+}

--- a/Sakura.Framework/Graphics/Textures/IVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/IVideoTexture.cs
@@ -17,9 +17,4 @@ public interface IVideoTexture
     /// True once the GPU upload for the current frame is complete.
     /// </summary>
     bool UploadComplete { get; }
-
-    /// <summary>
-    /// The Y-plane GL texture handle, usable as a greyscale preview.
-    /// </summary>
-    uint YPlaneHandle { get; }
 }

--- a/Sakura.Framework/Graphics/Textures/VideoGLTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/VideoGLTexture.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
-using Sakura.Framework.Graphics.Video;
+using FFmpeg.AutoGen;
 using Silk.NET.OpenGL;
 
 namespace Sakura.Framework.Graphics.Textures;
@@ -15,7 +15,7 @@ namespace Sakura.Framework.Graphics.Textures;
 /// performs YUV→RGB conversion on the GPU.
 /// </summary>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-public sealed class VideoGLTexture : IDisposable
+public sealed class VideoGLTexture : INativeVideoTexture
 {
     public uint YHandle { get; private set; }
     public uint UHandle { get; private set; }
@@ -63,7 +63,40 @@ public sealed class VideoGLTexture : IDisposable
     }
 
     /// <summary>
-    /// Marks the texture as having valid data. Called by <see cref="VideoTextureUpload"/> after upload.
+    /// Uploads a decoded YUV420P frame into the Y, U, V planes.
+    /// Must be called on the render thread.
+    /// </summary>
+    public unsafe void Upload(AVFrame* frame)
+    {
+        int width = frame->width;
+        int height = frame->height;
+        int chromaWidth = (width + 1) / 2;
+        int chromaHeight = (height + 1) / 2;
+
+        uploadPlane(YHandle, frame->data[0], frame->linesize[0], width, height);
+        uploadPlane(UHandle, frame->data[1], frame->linesize[1], chromaWidth, chromaHeight);
+        uploadPlane(VHandle, frame->data[2], frame->linesize[2], chromaWidth, chromaHeight);
+        MarkAvailable();
+    }
+
+    private unsafe void uploadPlane(uint handle, byte* data, int linesize, int width, int height)
+    {
+        gl.BindTexture(TextureTarget.Texture2D, handle);
+        gl.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
+        gl.PixelStore(PixelStoreParameter.UnpackRowLength, linesize);
+
+        gl.TexImage2D(TextureTarget.Texture2D, 0, InternalFormat.R8, (uint)width, (uint)height, 0, PixelFormat.Red, PixelType.UnsignedByte, data);
+
+        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
+        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
+        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)TextureWrapMode.ClampToEdge);
+        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)TextureWrapMode.ClampToEdge);
+
+        gl.PixelStore(PixelStoreParameter.UnpackRowLength, 0);
+    }
+
+    /// <summary>
+    /// Marks the texture as having valid data. Called after a successful upload.
     /// </summary>
     public void MarkAvailable() => Volatile.Write(ref available, true);
 

--- a/Sakura.Framework/Graphics/Video/VideoDecoder.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDecoder.cs
@@ -14,7 +14,6 @@ using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Reactive;
 using Sakura.Framework.Statistic;
-using Silk.NET.OpenGL;
 using Texture = Sakura.Framework.Graphics.Textures.Texture;
 
 namespace Sakura.Framework.Graphics.Video;
@@ -75,7 +74,6 @@ public unsafe class VideoDecoder : IDisposable
     private readonly ConcurrentQueue<Action> decoderCommands = new();
 
     private readonly IRenderer renderer;
-    private readonly GL gl;
     private readonly ITextureManager textureManager;
 
     static VideoDecoder()
@@ -106,9 +104,6 @@ public unsafe class VideoDecoder : IDisposable
             throw new ArgumentException("Stream must be readable.", nameof(stream));
 
         this.renderer = renderer;
-        // GL is only needed inside the GL video layer. Retrieve it from GLRenderer so
-        // callers (VideoSprite) don't need to reference GL at all.
-        this.gl = GLRenderer.GL;
         this.textureManager = textureManager;
         videoStream = stream;
         selfHandle = GCHandle.Alloc(this);
@@ -587,7 +582,7 @@ public unsafe class VideoDecoder : IDisposable
                 renderer.ScheduleToDrawThread(() =>
                 {
                     while (availableTextures.Count < max_pending_frames)
-                        availableTextures.Enqueue(new VideoTexture(renderer, gl, textureManager, capturedW, capturedH));
+                        availableTextures.Enqueue(new VideoTexture(renderer, textureManager, capturedW, capturedH));
                 });
             }
 

--- a/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
@@ -35,6 +35,11 @@ internal class VideoDrawNode : DrawNode
         if (!videoTexture.UploadComplete)
             return;
 
+        // Video rendering requires GL-specific operations (sRGB toggle, raw vertex upload).
+        // On non-GL renderers video is silently skipped until a backend-agnostic path exists.
+        if (renderer is not IGLRenderer glRenderer)
+            return;
+
         renderer.FlushBatch();
 
         videoShader.Use();
@@ -50,7 +55,9 @@ internal class VideoDrawNode : DrawNode
         if (yuvMatrix != null)
             videoShader.SetUniform("u_YuvCoeff", yuvMatrix);
 
-        renderer.DrawVerticesRaw(Vertices);
+        glRenderer.DisableSrgb();
+        glRenderer.DrawVerticesRaw(Vertices);
+        glRenderer.RestoreSrgb();
         renderer.RestoreMainShader();
     }
 }

--- a/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
@@ -55,9 +55,7 @@ internal class VideoDrawNode : DrawNode
         if (yuvMatrix != null)
             videoShader.SetUniform("u_YuvCoeff", yuvMatrix);
 
-        glRenderer.DisableSrgb();
         glRenderer.DrawVerticesRaw(Vertices);
-        glRenderer.RestoreSrgb();
         renderer.RestoreMainShader();
     }
 }

--- a/Sakura.Framework/Graphics/Video/VideoTexture.cs
+++ b/Sakura.Framework/Graphics/Video/VideoTexture.cs
@@ -5,31 +5,28 @@ using System.Threading;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Statistic;
-using Silk.NET.OpenGL;
 
 namespace Sakura.Framework.Graphics.Video;
 
 /// <summary>
 /// A YUV420P video texture following the osu!framework upload pattern:
-/// <see cref="SetData"/> stores the upload request on the decode thread (no GL calls).
-/// The actual upload is performed lazily on the draw thread the first time this texture
+/// <see cref="SetData"/> stores the upload request on the decode thread (no render-thread calls).
+/// The actual upload is performed lazily on the render thread the first time this texture
 /// is about to be drawn. <see cref="UploadComplete"/> becomes true after the upload.
 /// </summary>
 public sealed class VideoTexture : IVideoTexture
 {
     /// <summary>
-    /// The GL-specific YUV plane container. Kept internal to the video layer;
-    /// higher-level code uses <see cref="BindPlanes"/> and <see cref="UploadComplete"/>.
+    /// The backend-specific YUV plane container.
+    /// Higher-level code uses <see cref="BindPlanes"/> and <see cref="UploadComplete"/>.
     /// </summary>
-    internal VideoGLTexture GlTexture { get; }
+    internal INativeVideoTexture NativeTexture { get; }
 
-    // IVideoTexture
-    public int Width  => GlTexture.Width;
-    public int Height => GlTexture.Height;
-    public uint YPlaneHandle => GlTexture.YHandle;
+    public int Width  => NativeTexture.Width;
+    public int Height => NativeTexture.Height;
 
     /// <summary>
-    /// True once the draw thread has flushed the pending upload.
+    /// True once the render thread has flushed the pending upload.
     /// Written via <see cref="Volatile"/> — safe to read from any thread.
     /// </summary>
     public bool UploadComplete => Volatile.Read(ref uploadComplete);
@@ -39,20 +36,18 @@ public sealed class VideoTexture : IVideoTexture
 
     private readonly ITextureManager textureManager;
     private readonly IRenderer renderer;
-    private readonly GL gl;
     private bool isDisposed;
 
-    public VideoTexture(IRenderer renderer, GL gl, ITextureManager textureManager, int width, int height)
+    public VideoTexture(IRenderer renderer, ITextureManager textureManager, int width, int height)
     {
         this.renderer = renderer;
-        this.gl = gl;
         this.textureManager = textureManager;
-        GlTexture = new VideoGLTexture(gl, width, height);
+        NativeTexture = renderer.CreateVideoTexture(width, height);
         textureManager.RegisterVideoTexture(this);
     }
 
     /// <summary>
-    /// Stores a pending upload. Called from the decode thread — no GL calls.
+    /// Stores a pending upload. Called from the decode thread — no render-thread calls.
     /// </summary>
     public void SetData(VideoTextureUpload upload)
     {
@@ -61,7 +56,7 @@ public sealed class VideoTexture : IVideoTexture
     }
 
     /// <summary>
-    /// If there is a pending upload, performs it now. Must be called on the draw thread.
+    /// If there is a pending upload, performs it now. Must be called on the render thread.
     /// </summary>
     public void FlushIfPending()
     {
@@ -69,17 +64,17 @@ public sealed class VideoTexture : IVideoTexture
         if (upload == null) return;
 
         pendingUpload = null;
-        upload.Upload(gl, GlTexture);
+        upload.Upload(NativeTexture);
         upload.Dispose();
         Volatile.Write(ref uploadComplete, true);
         GlobalStatistics.Get<int>("Video", "Frames Uploaded").Value++;
     }
 
     /// <summary>
-    /// Binds the Y, U, V planes to texture units 0, 1, 2.
-    /// Must be called on the draw thread. Keeps all GL calls inside the video layer.
+    /// Binds the Y, U, V planes to the appropriate texture slots for the current backend.
+    /// Must be called on the render thread.
     /// </summary>
-    public void BindPlanes() => GlTexture.BindPlanes();
+    public void BindPlanes() => NativeTexture.BindPlanes();
 
     /// <summary>
     /// Called when this texture is returned to the pool for reuse.
@@ -101,7 +96,7 @@ public sealed class VideoTexture : IVideoTexture
 
         textureManager.UnregisterVideoTexture(this);
 
-        var tex = GlTexture;
+        var tex = NativeTexture;
         renderer.ScheduleToDrawThread(tex.Dispose);
     }
 }

--- a/Sakura.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/Sakura.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -4,14 +4,14 @@
 using System;
 using FFmpeg.AutoGen;
 using Sakura.Framework.Graphics.Textures;
-using Silk.NET.OpenGL;
 
 namespace Sakura.Framework.Graphics.Video;
 
 /// <summary>
-/// Uploads a decoded YUV420P frame into a <see cref="VideoGLTexture"/>'s three single-channel planes
-/// without any CPU-side pixel conversion. The video shader performs YUV→RGB on the GPU.
-/// Disposing this upload returns the underlying <see cref="FFmpegFrame"/> to its pool.
+/// Carries a decoded YUV420P frame to the render thread for upload.
+/// The actual GPU upload is delegated to <see cref="INativeVideoTexture.Upload"/>
+/// so this class has no knowledge of the backend.
+/// Disposing returns the underlying <see cref="FFmpegFrame"/> to its pool.
 /// </summary>
 public sealed unsafe class VideoTextureUpload : IDisposable
 {
@@ -22,8 +22,6 @@ public sealed unsafe class VideoTextureUpload : IDisposable
 
     public int Width => Frame->width;
     public int Height => Frame->height;
-    public int ChromaWidth => (Frame->width + 1) / 2;
-    public int ChromaHeight => (Frame->height + 1) / 2;
 
     internal VideoTextureUpload(FFmpegFrame frame)
     {
@@ -31,33 +29,9 @@ public sealed unsafe class VideoTextureUpload : IDisposable
     }
 
     /// <summary>
-    /// Uploads Y, U, V planes into a <see cref="VideoGLTexture"/>. Must be called from the GL thread.
+    /// Uploads the frame into <paramref name="target"/>. Must be called on the render thread.
     /// </summary>
-    public void Upload(GL gl, VideoGLTexture target)
-    {
-        uploadPlane(gl, target.YHandle, Frame->data[0], Frame->linesize[0], Width, Height);
-        uploadPlane(gl, target.UHandle, Frame->data[1], Frame->linesize[1], ChromaWidth, ChromaHeight);
-        uploadPlane(gl, target.VHandle, Frame->data[2], Frame->linesize[2], ChromaWidth, ChromaHeight);
-        target.MarkAvailable();
-    }
-
-    private static void uploadPlane(GL gl, uint handle, byte* data, int linesize, int width, int height)
-    {
-        gl.BindTexture(TextureTarget.Texture2D, handle);
-        gl.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
-        gl.PixelStore(PixelStoreParameter.UnpackRowLength, linesize);
-
-        gl.TexImage2D(TextureTarget.Texture2D, 0, InternalFormat.R8,
-            (uint)width, (uint)height, 0,
-            PixelFormat.Red, PixelType.UnsignedByte, data);
-
-        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
-        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
-        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)TextureWrapMode.ClampToEdge);
-        gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)TextureWrapMode.ClampToEdge);
-
-        gl.PixelStore(PixelStoreParameter.UnpackRowLength, 0);
-    }
+    public void Upload(INativeVideoTexture target) => target.Upload(Frame);
 
     public void Dispose()
     {

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -185,6 +185,13 @@ public abstract class AppHost : IDisposable
     /// <returns>An instance of <see cref="IRenderer"/> that represents the renderer.</returns>
     protected abstract IRenderer CreateRenderer();
 
+    /// <summary>
+    /// Called between <see cref="IWindow.Initialize"/> and <see cref="IWindow.Create"/> to
+    /// configure the window for the chosen graphics API (e.g. call <see cref="SDLWindow.SetGraphicsApi"/>).
+    /// Override in platform-specific hosts. Default implementation is nothing to do.
+    /// </summary>
+    protected virtual void PrepareWindowForRenderer(IWindow window) { }
+
     private static readonly SemaphoreSlim host_running_mutex = new SemaphoreSlim(1);
 
     protected virtual void SetupForRun()
@@ -302,6 +309,7 @@ public abstract class AppHost : IDisposable
             };
 
             Window.Initialize();
+            PrepareWindowForRenderer(Window);
             Window.Create();
 
             onFrameLimiterChanged(new ValueChangedEvent<FrameSync>(default, FrameLimiter.Value));
@@ -548,8 +556,16 @@ public abstract class AppHost : IDisposable
     {
         Renderer = CreateRenderer();
         Renderer.ShaderStorage = FrameworkStorage.GetStorageForDirectory("Shaders");
+        InitializeGraphicsContext(Window, Renderer);
         Renderer.Initialize(Window.GraphicsSurface);
     }
+
+    /// <summary>
+    /// Initialises the backend graphics context on the window after the renderer is chosen.
+    /// Called inside <see cref="SetupRenderer"/>. Override to perform backend-specific setup
+    /// (e.g. creating the GL context or Metal surface). Default implementation is a no-op.
+    /// </summary>
+    protected virtual void InitializeGraphicsContext(IWindow window, IRenderer renderer) { }
 
     private void onFrameLimiterChanged(ValueChangedEvent<FrameSync> e)
     {

--- a/Sakura.Framework/Platform/DesktopAppHost.cs
+++ b/Sakura.Framework/Platform/DesktopAppHost.cs
@@ -4,8 +4,11 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using JetBrains.Annotations;
+using Sakura.Framework.Configurations;
 using Sakura.Framework.Extensions;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Logging;
@@ -16,6 +19,11 @@ public class DesktopAppHost : AppHost
 {
     public bool IsPortableInstallation { get; }
 
+    /// <summary>
+    /// Tracks the renderer type that was successfully selected, so context init knows what to do.
+    /// </summary>
+    private RendererType selectedRendererType = RendererType.OpenGL;
+
     public DesktopAppHost(string appName, HostOptions options = null) : base(appName, options)
     {
         IsPortableInstallation = Options.PortableInstallation;
@@ -23,7 +31,6 @@ public class DesktopAppHost : AppHost
 
     protected sealed override Storage GetDefaultAppStorage()
     {
-        // TODO: Replace the framework config file name with a ConfigManager for framework
         if (IsPortableInstallation || File.Exists(Path.Combine(RuntimeInfo.StartupDirectory, "framework.ini")))
             return GetStorage(RuntimeInfo.StartupDirectory);
 
@@ -34,7 +41,99 @@ public class DesktopAppHost : AppHost
 
     protected override IWindow CreateWindow() => new DesktopWindow();
 
-    protected override IRenderer CreateRenderer() => new GLRenderer();
+    /// <summary>
+    /// Returns the preferred renderer types in priority order for this platform.
+    /// Override to change backend preference.
+    /// </summary>
+    protected virtual IEnumerable<RendererType> GetPreferredRenderers()
+    {
+        // if (RuntimeInfo.IsMacOS)
+        //     return [RendererType.Metal, RendererType.OpenGL];
+
+        // TODO: Enable it back when Metal support added
+        return [RendererType.OpenGL];
+    }
+
+    /// <summary>
+    /// Creates a renderer instance for the given type. Return null to skip that type.
+    /// Override to register additional renderer backends.
+    /// </summary>
+    [CanBeNull]
+    protected virtual IRenderer CreateRendererForType(RendererType type)
+    {
+        switch (type)
+        {
+            case RendererType.OpenGL:
+                return new GLRenderer();
+            // case RendererType.Metal:
+            //     return new MetalRenderer();
+            default:
+                return null;
+        }
+    }
+
+    protected override IRenderer CreateRenderer()
+    {
+        var configured = FrameworkConfigManager.Get<RendererType>(FrameworkSetting.RendererType).Value;
+
+        var candidates = new List<RendererType>();
+
+        if (configured != RendererType.Automatic)
+            candidates.Add(configured);
+
+        foreach (var preferred in GetPreferredRenderers())
+        {
+            if (!candidates.Contains(preferred))
+                candidates.Add(preferred);
+        }
+
+        foreach (var type in candidates)
+        {
+            var renderer = CreateRendererForType(type);
+
+            if (renderer == null)
+            {
+                Logger.Verbose($"Renderer '{type}' is not available on this platform, skipping.");
+                continue;
+            }
+
+            selectedRendererType = type;
+            Logger.Verbose($"🖥️ Selected renderer: {type}");
+            return renderer;
+        }
+
+        throw new InvalidOperationException("No suitable renderer could be initialised.");
+    }
+
+    /// <summary>
+    /// Calls <see cref="SDLWindow.SetGraphicsApi"/> so the window creates with the correct flags
+    /// before <see cref="IWindow.Create"/> runs.
+    /// </summary>
+    protected override void PrepareWindowForRenderer(IWindow window)
+    {
+        if (window is SDLWindow sdlWindow)
+            sdlWindow.SetGraphicsApi(selectedRendererType);
+    }
+
+    /// <summary>
+    /// Initialises the backend-specific context (GL context or Metal surface) after
+    /// the SDL window exists but before the renderer's <c>Initialize</c> call.
+    /// </summary>
+    protected override void InitializeGraphicsContext(IWindow window, IRenderer renderer)
+    {
+        if (window is not SDLWindow sdlWindow) return;
+
+        switch (selectedRendererType)
+        {
+            case RendererType.Metal:
+                sdlWindow.InitializeMetalSurface();
+                break;
+
+            default:
+                sdlWindow.InitializeGLContext();
+                break;
+        }
+    }
 
     public override bool OpenFileExternally(string filename)
     {
@@ -65,7 +164,6 @@ public class DesktopAppHost : AppHost
 
     private static void openUsingShellExecute(string path) => Process.Start(new ProcessStartInfo
     {
-        // https://github.com/dotnet/runtime/issues/17938
         FileName = path,
         UseShellExecute = true
     });

--- a/Sakura.Framework/Platform/DesktopAppHost.cs
+++ b/Sakura.Framework/Platform/DesktopAppHost.cs
@@ -112,7 +112,10 @@ public class DesktopAppHost : AppHost
     protected override void PrepareWindowForRenderer(IWindow window)
     {
         if (window is SDLWindow sdlWindow)
+        {
             sdlWindow.SetGraphicsApi(selectedRendererType);
+            sdlWindow.SetWindowConfig(FrameworkConfigManager);
+        }
     }
 
     /// <summary>

--- a/Sakura.Framework/Platform/IMetalGraphicsSurface.cs
+++ b/Sakura.Framework/Platform/IMetalGraphicsSurface.cs
@@ -1,0 +1,18 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Platform;
+
+/// <summary>
+/// Extended surface contract for Metal rendering.
+/// <c>MetalRenderer</c> casts <see cref="IGraphicsSurface"/> to this interface during
+/// <c>Initialize</c> to obtain the native <c>CAMetalLayer</c> pointer.
+/// </summary>
+public interface IMetalGraphicsSurface : IGraphicsSurface
+{
+    /// <summary>
+    /// Pointer to the native <c>CAMetalLayer</c> associated with this window.
+    /// Obtained via <c>SDL_Metal_CreateView</c> + <c>SDL_Metal_GetLayer</c>.
+    /// </summary>
+    nint MetalLayer { get; }
+}

--- a/Sakura.Framework/Platform/MetalGraphicsSurface.cs
+++ b/Sakura.Framework/Platform/MetalGraphicsSurface.cs
@@ -1,0 +1,15 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Platform;
+
+/// <summary>
+/// <see cref="IMetalGraphicsSurface"/> implementation backed by an SDL2 window.
+/// The <see cref="MetalLayer"/> pointer is set by <see cref="SDLWindow.InitializeMetalSurface"/>.
+/// </summary>
+public class MetalGraphicsSurface : IMetalGraphicsSurface
+{
+    public GraphicsSurfaceType Type => GraphicsSurfaceType.Metal;
+
+    public nint MetalLayer { get; internal set; }
+}

--- a/Sakura.Framework/Platform/RendererType.cs
+++ b/Sakura.Framework/Platform/RendererType.cs
@@ -1,0 +1,16 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Platform;
+
+public enum RendererType
+{
+    Automatic,
+    Metal,
+    Direct3D11,
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    OpenGL
+}

--- a/Sakura.Framework/Platform/SDLWindow.cs
+++ b/Sakura.Framework/Platform/SDLWindow.cs
@@ -9,11 +9,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Sakura.Framework.Input;
+using Silk.NET.OpenGL;
 using Silk.NET.SDL;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Reactive;
-using Silk.NET.OpenGL;
 using SilkMouseButtonEvent = Silk.NET.SDL.MouseButtonEvent;
 using SakuraCursorState = Sakura.Framework.Input.CursorState;
 using SakuraMouseButtonEvent = Sakura.Framework.Input.MouseButtonEvent;
@@ -31,7 +31,13 @@ public class SDLWindow : IWindow
     private static unsafe Window* window;
     private PfnEventFilter resizeEventFilter;
 
-    private readonly SDLGraphicsSurface graphicsSurface = new SDLGraphicsSurface();
+    // Graphics surfaces — only one will be active depending on the selected renderer.
+    private readonly SDLGraphicsSurface glSurface = new SDLGraphicsSurface();
+    private readonly MetalGraphicsSurface metalSurface = new MetalGraphicsSurface();
+    private IGraphicsSurface activeSurface;
+
+    private RendererType graphicsApi = RendererType.OpenGL;
+
     private readonly MouseState mouseState = new MouseState();
 
     private bool initialized;
@@ -49,7 +55,8 @@ public class SDLWindow : IWindow
 
     private WindowMode windowMode = WindowMode.Windowed;
 
-    private WindowFlags windowFlags = WindowFlags.Opengl | WindowFlags.AllowHighdpi;
+    // Base flags — no graphics API flag yet; added by SetGraphicsApi() before Create().
+    private WindowFlags windowFlags = WindowFlags.AllowHighdpi;
 
     public string Title
     {
@@ -81,7 +88,29 @@ public class SDLWindow : IWindow
     public int Height => logicalHeight;
 
     public bool CursorInWindow { get; private set; }
-    public IGraphicsSurface GraphicsSurface => graphicsSurface;
+    public IGraphicsSurface GraphicsSurface => activeSurface;
+
+    /// <summary>
+    /// Must be called by <see cref="AppHost"/> before <see cref="Create()"/> to configure
+    /// which graphics API flag to apply to the SDL window.
+    /// </summary>
+    public void SetGraphicsApi(RendererType type)
+    {
+        graphicsApi = type;
+
+        switch (type)
+        {
+            case RendererType.Metal:
+                // Metal windows need no special SDL window flag on SDL2.
+                activeSurface = metalSurface;
+                break;
+
+            default:
+                windowFlags |= WindowFlags.Opengl;
+                activeSurface = glSurface;
+                break;
+        }
+    }
 
     public bool IsActive { get; private set; } = true;
     public bool IsExiting { get; private set; }
@@ -189,20 +218,12 @@ public class SDLWindow : IWindow
                 break;
         }
 
-        // Make sure SDL use OpenGL 3.3 or later
-        sdl.GLSetAttribute(GLattr.ContextMajorVersion, 3);
-        sdl.GLSetAttribute(GLattr.ContextMinorVersion, 3);
-        sdl.GLSetAttribute(GLattr.ContextFlags, (int)ContextFlagMask.ForwardCompatibleBit);
-        sdl.GLSetAttribute(GLattr.ContextProfileMask, (int)GLprofile.Core);
-
-        sdl.GLSetAttribute(GLattr.FramebufferSrgbCapable, 1);
-
         window = sdl.CreateWindow(
             title,
-            Sdl.WindowposCentered, // X position
-            Sdl.WindowposCentered, // Y position
-            800, // Width
-            600, // Height
+            Sdl.WindowposCentered,
+            Sdl.WindowposCentered,
+            800,
+            600,
             (uint)windowFlags
         );
 
@@ -212,7 +233,40 @@ public class SDLWindow : IWindow
             throw new Exception("SDL window creation failed.");
         }
 
-        // TODO: This should move to the renderer class but still need to figure out how to pass the context to the renderer
+        resizeEventFilter = new PfnEventFilter(resizeCallback);
+        sdl.AddEventWatch(resizeEventFilter, null);
+
+        DisplayHz = getDisplayRefreshRate();
+        Logger.Verbose($"Display refresh rate: {DisplayHz} Hz");
+
+        int w, h;
+        sdl.GetWindowSize(window, &w, &h);
+        logicalWidth = w;
+        logicalHeight = h;
+
+        // Physical size is resolved after the graphics context is initialised
+        // (GL: GLGetDrawableSize; Metal: GetDrawableSize falls back to logical).
+        currentWidth = w;
+        currentHeight = h;
+
+        Logger.Verbose("SDL window created successfully");
+
+        Resized.Invoke(logicalWidth, logicalHeight);
+    }
+
+    /// <summary>
+    /// Creates the OpenGL context and wires up the <see cref="SDLGraphicsSurface"/>.
+    /// Must be called after <see cref="Create()"/> when the selected renderer is OpenGL.
+    /// </summary>
+    public unsafe void InitializeGLContext()
+    {
+        // Set required OpenGL attributes before context creation.
+        sdl.GLSetAttribute(GLattr.ContextMajorVersion, 3);
+        sdl.GLSetAttribute(GLattr.ContextMinorVersion, 3);
+        sdl.GLSetAttribute(GLattr.ContextFlags, (int)ContextFlagMask.ForwardCompatibleBit);
+        sdl.GLSetAttribute(GLattr.ContextProfileMask, (int)GLprofile.Core);
+        sdl.GLSetAttribute(GLattr.FramebufferSrgbCapable, 1);
+
         glContext = sdl.GLCreateContext(window);
         if (glContext == null)
         {
@@ -222,31 +276,52 @@ public class SDLWindow : IWindow
 
         sdl.GLMakeCurrent(window, glContext);
 
-        resizeEventFilter = new PfnEventFilter(resizeCallback);
-        sdl.AddEventWatch(resizeEventFilter, null);
+        // Wire up the GL surface callbacks used by GLRenderer.
+        glSurface.GetFunctionAddress = proc => (nint)sdl.GLGetProcAddress(proc);
+        glSurface.MakeCurrent = () => sdl.GLMakeCurrent(window, glContext);
+        glSurface.ClearCurrent = () => sdl.GLMakeCurrent(window, null);
 
-        DisplayHz = getDisplayRefreshRate();
-        Logger.Verbose($"Display refresh rate: {DisplayHz} Hz");
-
-        GetDrawableSize(out currentWidth, out currentHeight);
-
-        int w, h, phyW, phyH;
-        sdl.GetWindowSize(window, &w, &h);
+        // GL drawable size may differ from logical size on HiDPI displays.
+        int phyW, phyH;
         sdl.GLGetDrawableSize(window, &phyW, &phyH);
-
-        logicalWidth = w;
-        logicalHeight = h;
         currentWidth = phyW;
         currentHeight = phyH;
 
-        Logger.Verbose("SDL window created successfully");
-
-        graphicsSurface.GetFunctionAddress = proc => (nint)sdl.GLGetProcAddress(proc);
-        graphicsSurface.MakeCurrent = () => sdl.GLMakeCurrent(window, glContext);
-        graphicsSurface.ClearCurrent = () => sdl.GLMakeCurrent(window, null);
-
-        Resized.Invoke(logicalWidth, logicalHeight);
+        Logger.Verbose("OpenGL context created successfully");
     }
+
+    /// <summary>
+    /// Creates the Metal view via SDL and stores the <c>CAMetalLayer</c> pointer
+    /// in the <see cref="MetalGraphicsSurface"/>. Must be called after <see cref="Create()"/>
+    /// when the selected renderer is Metal.
+    /// </summary>
+    public unsafe void InitializeMetalSurface()
+    {
+        void* view = SDL_Metal_CreateView(window);
+        if (view == null)
+        {
+            Logger.Error("Failed to create Metal view: " + sdl.GetErrorS());
+            throw new Exception("Metal view creation failed.");
+        }
+
+        void* layer = SDL_Metal_GetLayer(view);
+        if (layer == null)
+        {
+            Logger.Error("Failed to get CAMetalLayer from Metal view.");
+            throw new Exception("CAMetalLayer retrieval failed.");
+        }
+
+        metalSurface.MetalLayer = (nint)layer;
+
+        Logger.Verbose("Metal surface initialised successfully");
+    }
+
+    // SDL2 Metal API — not exposed by Silk.NET.SDL, so P/Invoke directly.
+    [DllImport("SDL2")]
+    private static extern unsafe void* SDL_Metal_CreateView(void* window);
+
+    [DllImport("SDL2")]
+    private static extern unsafe void* SDL_Metal_GetLayer(void* view);
 
     public void Close()
     {
@@ -259,10 +334,21 @@ public class SDLWindow : IWindow
         {
             width = 0;
             height = 0;
+            return;
         }
 
         int drawableWidth, drawableHeight;
-        sdl.GLGetDrawableSize(window, &drawableWidth, &drawableHeight);
+
+        if (graphicsApi == RendererType.Metal)
+        {
+            // Metal: drawable size equals the window's pixel size on HiDPI.
+            sdl.GetWindowSizeInPixels(window, &drawableWidth, &drawableHeight);
+        }
+        else
+        {
+            sdl.GLGetDrawableSize(window, &drawableWidth, &drawableHeight);
+        }
+
         width = drawableWidth;
         height = drawableHeight;
     }
@@ -287,7 +373,11 @@ public class SDLWindow : IWindow
         if (windowWidth == 0 || windowHeight == 0) return (1.0f, 1.0f);
 
         int drawableWidth, drawableHeight;
-        sdl.GLGetDrawableSize(window, &drawableWidth, &drawableHeight);
+
+        if (graphicsApi == RendererType.Metal)
+            sdl.GetWindowSizeInPixels(window, &drawableWidth, &drawableHeight);
+        else
+            sdl.GLGetDrawableSize(window, &drawableWidth, &drawableHeight);
 
         return ((float)drawableWidth / windowWidth, (float)drawableHeight / windowHeight);
     }
@@ -343,7 +433,11 @@ public class SDLWindow : IWindow
 
         int w, h, phyW, phyH;
         sdl.GetWindowSize(window, &w, &h);
-        sdl.GLGetDrawableSize(window, &phyW, &phyH);
+
+        if (graphicsApi == RendererType.Metal)
+            sdl.GetWindowSizeInPixels(window, &phyW, &phyH);
+        else
+            sdl.GLGetDrawableSize(window, &phyW, &phyH);
 
         logicalWidth = w;
         logicalHeight = h;
@@ -457,7 +551,10 @@ public class SDLWindow : IWindow
             case WindowEventID.Resized:
                 int drawableWidth, drawableHeight, windowWidth, windowHeight;
                 sdl.GetWindowSize(window, &windowWidth, &windowHeight);
-                sdl.GLGetDrawableSize(window, &drawableWidth, &drawableHeight);
+                if (graphicsApi == RendererType.Metal)
+                    sdl.GetWindowSizeInPixels(window, &drawableWidth, &drawableHeight);
+                else
+                    sdl.GLGetDrawableSize(window, &drawableWidth, &drawableHeight);
                 // SDL sometimes sends multiple resize events with the same size, ignore them
                 // to prevent resize event got invoke multiple times
                 if (drawableWidth == currentWidth && drawableHeight == currentHeight && windowWidth == logicalWidth && windowHeight == logicalHeight)
@@ -637,31 +734,50 @@ public class SDLWindow : IWindow
         handleSdlEvents();
     }
 
-    public void SwapBuffers()
+    public unsafe void SwapBuffers()
     {
-        swapBuffers();
+        if (graphicsApi == RendererType.Metal)
+        {
+            // Metal: presentation is handled by the renderer's command buffer commit.
+            // Nothing to do at the window layer.
+        }
+        else
+        {
+            if (window != null)
+                sdl.GLSwapWindow(window);
+        }
     }
 
-    public void MakeCurrent() => graphicsSurface.MakeCurrent();
-
-    public void ClearCurrent() => graphicsSurface.ClearCurrent();
+    /// <summary>
+    /// Makes the graphics context current on the calling thread.
+    /// For OpenGL: binds the GL context.
+    /// For Metal: no-op.
+    /// </summary>
+    public void MakeCurrent()
+    {
+        if (graphicsApi != RendererType.Metal)
+            glSurface.MakeCurrent?.Invoke();
+    }
 
     /// <summary>
-    /// Swap the front and back buffers to present the rendered frame.
+    /// Releases the graphics context from the calling thread.
+    /// For OpenGL: unbinds the GL context.
+    /// For Metal: no-op.
     /// </summary>
-    private unsafe void swapBuffers()
+    public void ClearCurrent()
     {
-        if (window != null)
-            sdl.GLSwapWindow(window);
+        if (graphicsApi != RendererType.Metal)
+            glSurface.ClearCurrent?.Invoke();
     }
 
     /// <summary>
     /// Enable or disable VSync.
     /// </summary>
-    /// <param name="enabled">True to enable VSync, false to disable.</param>
     public void SetVSync(bool enabled)
     {
-        sdl.GLSetSwapInterval(enabled ? 1 : 0);
+        if (graphicsApi != RendererType.Metal)
+            sdl.GLSetSwapInterval(enabled ? 1 : 0);
+        // Metal VSync is controlled via CAMetalLayer.displaySyncEnabled, will handled in MetalRenderer.
     }
 
     private unsafe void setTitle(string newTitle)
@@ -763,7 +879,7 @@ public class SDLWindow : IWindow
         }
         sdlCursors.Clear();
 
-        if (glContext != null)
+        if (glContext != null && graphicsApi != RendererType.Metal)
         {
             sdl.GLDeleteContext(glContext);
             glContext = null;

--- a/Sakura.Framework/Platform/SDLWindow.cs
+++ b/Sakura.Framework/Platform/SDLWindow.cs
@@ -106,8 +106,16 @@ public class SDLWindow : IWindow
                 break;
 
             default:
+                // OpenGL
                 windowFlags |= WindowFlags.Opengl;
                 activeSurface = glSurface;
+
+                // SDL requires GL attributes to be set before SDL_CreateWindow.
+                sdl.GLSetAttribute(GLattr.ContextMajorVersion, 3);
+                sdl.GLSetAttribute(GLattr.ContextMinorVersion, 3);
+                sdl.GLSetAttribute(GLattr.ContextFlags, (int)ContextFlagMask.ForwardCompatibleBit);
+                sdl.GLSetAttribute(GLattr.ContextProfileMask, (int)GLprofile.Core);
+                sdl.GLSetAttribute(GLattr.FramebufferSrgbCapable, 1);
                 break;
         }
     }
@@ -260,13 +268,6 @@ public class SDLWindow : IWindow
     /// </summary>
     public unsafe void InitializeGLContext()
     {
-        // Set required OpenGL attributes before context creation.
-        sdl.GLSetAttribute(GLattr.ContextMajorVersion, 3);
-        sdl.GLSetAttribute(GLattr.ContextMinorVersion, 3);
-        sdl.GLSetAttribute(GLattr.ContextFlags, (int)ContextFlagMask.ForwardCompatibleBit);
-        sdl.GLSetAttribute(GLattr.ContextProfileMask, (int)GLprofile.Core);
-        sdl.GLSetAttribute(GLattr.FramebufferSrgbCapable, 1);
-
         glContext = sdl.GLCreateContext(window);
         if (glContext == null)
         {

--- a/Sakura.Framework/Platform/SDLWindow.cs
+++ b/Sakura.Framework/Platform/SDLWindow.cs
@@ -258,8 +258,6 @@ public class SDLWindow : IWindow
         currentHeight = h;
 
         Logger.Verbose("SDL window created successfully");
-
-        Resized.Invoke(logicalWidth, logicalHeight);
     }
 
     /// <summary>

--- a/Sakura.Framework/Platform/SDLWindow.cs
+++ b/Sakura.Framework/Platform/SDLWindow.cs
@@ -8,12 +8,14 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Sakura.Framework.Configurations;
 using Sakura.Framework.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.SDL;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Reactive;
+using Silk.NET.Maths;
 using SilkMouseButtonEvent = Silk.NET.SDL.MouseButtonEvent;
 using SakuraCursorState = Sakura.Framework.Input.CursorState;
 using SakuraMouseButtonEvent = Sakura.Framework.Input.MouseButtonEvent;
@@ -37,6 +39,8 @@ public class SDLWindow : IWindow
     private IGraphicsSurface activeSurface;
 
     private RendererType graphicsApi = RendererType.OpenGL;
+
+    private FrameworkConfigManager windowConfig;
 
     private readonly MouseState mouseState = new MouseState();
 
@@ -89,6 +93,18 @@ public class SDLWindow : IWindow
 
     public bool CursorInWindow { get; private set; }
     public IGraphicsSurface GraphicsSurface => activeSurface;
+
+    /// <summary>
+    /// Provides the config manager so the window can persist and restore its position, size and mode.
+    /// Must be called before <see cref="Create()"/>.
+    /// </summary>
+    public void SetWindowConfig(FrameworkConfigManager config)
+    {
+        windowConfig = config;
+
+        var savedMode = config.Get<WindowMode>(FrameworkSetting.WindowMode).Value;
+        WindowModeReactive.Value = savedMode;
+    }
 
     /// <summary>
     /// Must be called by <see cref="AppHost"/> before <see cref="Create()"/> to configure
@@ -226,12 +242,43 @@ public class SDLWindow : IWindow
                 break;
         }
 
+        int spawnX = Sdl.WindowposCentered;
+        int spawnY = Sdl.WindowposCentered;
+        int spawnW = 800;
+        int spawnH = 600;
+
+        if (windowConfig != null && windowMode == WindowMode.Windowed)
+        {
+            int savedX = windowConfig.Get<int>(FrameworkSetting.WindowX).Value;
+            int savedY = windowConfig.Get<int>(FrameworkSetting.WindowY).Value;
+            int savedW = windowConfig.Get<int>(FrameworkSetting.WindowWidth).Value;
+            int savedH = windowConfig.Get<int>(FrameworkSetting.WindowHeight).Value;
+
+            if (savedX != -1 && savedY != -1 && isPositionOnConnectedDisplay(savedX, savedY))
+            {
+                spawnX = savedX;
+                spawnY = savedY;
+            }
+            else if (savedX != -1 && savedY != -1)
+            {
+                // fallback to center if the saved position is invalid (e.g. monitor was disconnected)
+                Logger.Warning($"Saved window position ({savedX},{savedY}) is not on any connected display. Resetting to center.");
+                windowConfig.Get<int>(FrameworkSetting.WindowX).Value = -1;
+                windowConfig.Get<int>(FrameworkSetting.WindowY).Value = -1;
+            }
+            if (savedW > 0 && savedH > 0)
+            {
+                spawnW = savedW;
+                spawnH = savedH;
+            }
+        }
+
         window = sdl.CreateWindow(
             title,
-            Sdl.WindowposCentered,
-            Sdl.WindowposCentered,
-            800,
-            600,
+            spawnX,
+            spawnY,
+            spawnW,
+            spawnH,
             (uint)windowFlags
         );
 
@@ -410,6 +457,16 @@ public class SDLWindow : IWindow
         windowMode = newMode;
         WindowModeReactive.Value = newMode;
 
+        if (windowConfig != null)
+        {
+            windowConfig.Get<WindowMode>(FrameworkSetting.WindowMode).Value = newMode;
+        }
+        else
+        {
+            Logger.Warning("windowConfig is null — WindowMode change will not be persisted.");
+        }
+
+
         if (window == null) return;
 
         switch (newMode)
@@ -417,7 +474,26 @@ public class SDLWindow : IWindow
             case WindowMode.Windowed:
                 sdl.SetWindowFullscreen(window, 0);
                 sdl.SetWindowBordered(window, SdlBool.True);
-                sdl.SetWindowPosition(window, Sdl.WindowposCentered, Sdl.WindowposCentered);
+
+                if (windowConfig != null)
+                {
+                    int savedX = windowConfig.Get<int>(FrameworkSetting.WindowX).Value;
+                    int savedY = windowConfig.Get<int>(FrameworkSetting.WindowY).Value;
+                    int savedW = windowConfig.Get<int>(FrameworkSetting.WindowWidth).Value;
+                    int savedH = windowConfig.Get<int>(FrameworkSetting.WindowHeight).Value;
+
+                    if (savedW > 0 && savedH > 0)
+                        sdl.SetWindowSize(window, savedW, savedH);
+
+                    if (savedX != -1 && savedY != -1 && isPositionOnConnectedDisplay(savedX, savedY))
+                        sdl.SetWindowPosition(window, savedX, savedY);
+                    else
+                        sdl.SetWindowPosition(window, Sdl.WindowposCentered, Sdl.WindowposCentered);
+                }
+                else
+                {
+                    sdl.SetWindowPosition(window, Sdl.WindowposCentered, Sdl.WindowposCentered);
+                }
                 break;
 
             case WindowMode.Borderless:
@@ -563,7 +639,24 @@ public class SDLWindow : IWindow
                 logicalWidth = windowWidth;
                 logicalHeight = windowHeight;
                 Logger.Verbose($"Window resized to {drawableWidth}x{drawableHeight} (logical size: {windowWidth}x{windowHeight})");
+
+                if (windowConfig != null && windowMode == WindowMode.Windowed)
+                {
+                    windowConfig.Get<int>(FrameworkSetting.WindowWidth).Value = windowWidth;
+                    windowConfig.Get<int>(FrameworkSetting.WindowHeight).Value = windowHeight;
+                }
+
                 Resized.Invoke(logicalWidth, logicalHeight);
+                break;
+
+            case WindowEventID.Moved:
+                if (windowConfig != null && windowMode == WindowMode.Windowed)
+                {
+                    int posX, posY;
+                    sdl.GetWindowPosition(window, &posX, &posY);
+                    windowConfig.Get<int>(FrameworkSetting.WindowX).Value = posX;
+                    windowConfig.Get<int>(FrameworkSetting.WindowY).Value = posY;
+                }
                 break;
 
             case WindowEventID.Enter:
@@ -680,6 +773,33 @@ public class SDLWindow : IWindow
         sdl.SetClipboardText(text);
     }
 
+    /// <summary>
+    /// Returns true if the given screen position falls within the bounds of any connected display.
+    /// Used to detect whether a saved window position is still valid after monitor changes.
+    /// </summary>
+    private static bool isPositionOnConnectedDisplay(int x, int y)
+    {
+        int numDisplays = sdl.GetNumVideoDisplays();
+
+        for (int i = 0; i < numDisplays; i++)
+        {
+            Rectangle<int> bounds = default;
+            if (sdl.GetDisplayBounds(i, ref bounds) != 0)
+                continue;
+
+            // Check if the position is within this display's bounds.
+            // Use a small margin (at least 64px of the title bar must be visible).
+            const int margin = 64;
+            if (x >= bounds.Origin.X - margin &&
+                x < bounds.Origin.X + bounds.Size.X &&
+                y >= bounds.Origin.Y - margin &&
+                y < bounds.Origin.Y + bounds.Size.Y)
+                return true;
+        }
+
+        return false;
+    }
+
     private unsafe int getDisplayRefreshRate()
     {
         DisplayMode mode = new DisplayMode();
@@ -755,7 +875,7 @@ public class SDLWindow : IWindow
     public void MakeCurrent()
     {
         if (graphicsApi != RendererType.Metal)
-            glSurface.MakeCurrent?.Invoke();
+            glSurface.MakeCurrent();
     }
 
     /// <summary>
@@ -766,7 +886,7 @@ public class SDLWindow : IWindow
     public void ClearCurrent()
     {
         if (graphicsApi != RendererType.Metal)
-            glSurface.ClearCurrent?.Invoke();
+            glSurface.ClearCurrent();
     }
 
     /// <summary>


### PR DESCRIPTION
Move vertex, IRenderer, IShader, video and vertex that still heavily stick to OpenGL out to more abstraction. Have a plan to implement Metal support in the near future (?) so add a config for now but on every case still initialize `GLRenderer`