### PR TITLE
Fix frame interpolation due to inconsistent clock

### DIFF
--- a/Sakura.Framework/Graphics/Drawables/SpriteText.cs
+++ b/Sakura.Framework/Graphics/Drawables/SpriteText.cs
@@ -272,36 +272,24 @@ public partial class SpriteText : Drawable
         private int batchCount;
 
         private int textVertexCount;
-        private bool hasPreviousTextState;
 
-        private Vertex[] textPreviousVertices = Array.Empty<Vertex>();
-        private Vertex[] textCurrentVertices = Array.Empty<Vertex>();
+        protected override void ApplyVertices(Drawable source)
+        {
+            var text = (SpriteText)source;
+
+            textVertexCount = text.currentVertexCount;
+
+            // make it grow only, draw only reads up to textVertexCount via the glyph batches
+            if (Vertices.Length < textVertexCount)
+                Vertices = new Vertex[textVertexCount];
+
+            Array.Copy(text.textVertices, Vertices, textVertexCount);
+        }
 
         public override void ApplyState(Drawable source)
         {
             base.ApplyState(source);
             var text = (SpriteText)source;
-
-            textVertexCount = text.currentVertexCount;
-
-            // check our isolated array instead of the base class's CurrentVertices
-            if (textCurrentVertices.Length < textVertexCount)
-            {
-                textPreviousVertices = new Vertex[textVertexCount];
-                textCurrentVertices = new Vertex[textVertexCount];
-                Vertices = new Vertex[textVertexCount];
-                hasPreviousTextState = false; // reset to snap on resize
-            }
-
-            Array.Copy(textCurrentVertices, textPreviousVertices, textVertexCount);
-            Array.Copy(text.textVertices, textCurrentVertices, textVertexCount);
-
-            // prevent the text from flying in from (0,0) on the very first frame
-            if (!hasPreviousTextState)
-            {
-                Array.Copy(textCurrentVertices, textPreviousVertices, textVertexCount);
-                hasPreviousTextState = true;
-            }
 
             batchCount = 0;
 
@@ -343,25 +331,6 @@ public partial class SpriteText : Drawable
                     VertexStart = currentVertexStart,
                     VertexCount = currentBatchVertexCount
                 };
-            }
-        }
-
-        public override void PrepareForDraw(double lastUpdateTime, double currentUpdateTime, double drawTime)
-        {
-            float interpolationFactor = 1.0f;
-            if (currentUpdateTime > lastUpdateTime)
-            {
-                interpolationFactor = (float)((drawTime - lastUpdateTime) / (currentUpdateTime - lastUpdateTime));
-                interpolationFactor = Math.Clamp(interpolationFactor, 0f, 1f);
-            }
-
-            DrawAlpha = PreviousDrawAlpha + (CurrentDrawAlpha - PreviousDrawAlpha) * interpolationFactor;
-
-            for (int i = 0; i < textVertexCount; i++)
-            {
-                Vertices[i] = textCurrentVertices[i];
-                Vertices[i].Position.X = textPreviousVertices[i].Position.X + (textCurrentVertices[i].Position.X - textPreviousVertices[i].Position.X) * interpolationFactor;
-                Vertices[i].Position.Y = textPreviousVertices[i].Position.Y + (textCurrentVertices[i].Position.Y - textPreviousVertices[i].Position.Y) * interpolationFactor;
             }
         }
 

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -314,6 +314,8 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
         private readonly AppHost host;
         private double lastRecordedTime;
         private double lastVisualUpdateTime;
+        private long dataVersion;
+        private long lastGraphVersion;
         private double bucketMaxTime;
         private double bucketSumTime;
         private int bucketFrameCount;
@@ -488,6 +490,7 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
 
                         currentIndex = (currentIndex + 1) % max_history;
                         if (currentCount < max_history) currentCount++;
+                        dataVersion++;
 
                         bucketMaxTime = 0;
                         bucketSumTime = 0;
@@ -496,16 +499,19 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
                     }
                 }
 
-                // throttle stats text to 10Hz (unreadable faster) and vertex rebuild to the same cadence
+                // Rebuild the graph whenever new data has been committed so it scrolls smoothly.
+                // propagateToParent is false because the graph's bounds never change with its data;
+                // only this drawable's vertices need regenerating.
+                if (currentState == PerformanceOverlayState.Expanded && dataVersion != lastGraphVersion)
+                {
+                    barGraph.Invalidate(InvalidationFlags.DrawInfo, false);
+                    lastGraphVersion = dataVersion;
+                }
+
+                // throttle stats text to 10Hz (unreadable faster)
                 if (Clock.CurrentTime - lastVisualUpdateTime >= 100.0)
                 {
                     updateStats();
-
-                    if (currentState == PerformanceOverlayState.Expanded)
-                    {
-                        barGraph.Invalidate(InvalidationFlags.DrawInfo);
-                    }
-
                     lastVisualUpdateTime = Clock.CurrentTime;
                 }
             }
@@ -557,8 +563,47 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
                 float w = DrawSize.X > 0 ? DrawSize.X : 1;
                 float h = DrawSize.Y > 0 ? DrawSize.Y : 1;
 
+                // rebuild runs once per committed data point (i.e. at update rate when expanded),
+                // so it must stay cheap. The model matrix is affine, so decompose it once:
+                // p' = origin + x * basisX + y * basisY — two multiply-adds per vertex instead of
+                // a full 4x4 matrix transform.
+                Vector2 origin = Vector2.Transform(new Vector2(0, 0), finalMatrix);
+                Vector2 unitX = Vector2.Transform(new Vector2(1, 0), finalMatrix);
+                Vector2 unitY = Vector2.Transform(new Vector2(0, 1), finalMatrix);
+                float bxX = unitX.X - origin.X, bxY = unitX.Y - origin.Y;
+                float byX = unitY.X - origin.X, byY = unitY.Y - origin.Y;
+
+                Vector2 map(float x, float y) => new Vector2(
+                    origin.X + x * bxX + y * byX,
+                    origin.Y + x * bxY + y * byY);
+
                 float barWidth = w / max_history;
                 int startIndex = display.currentCount == max_history ? display.currentIndex : 0;
+
+                // per-rebuild constants, hoisted out of the bar loop
+                var blueBgColor = new Vector4(0, 0, 0.5f, DrawAlpha * 0.4f);
+
+                Color color = display.baseColor;
+                var calculatedColor = new Vector4(
+                    ColorExtensions.SrgbToLinear(color.R),
+                    ColorExtensions.SrgbToLinear(color.G),
+                    ColorExtensions.SrgbToLinear(color.B),
+                    DrawAlpha * (color.A / 255f)
+                );
+
+                var gcYellow = new Vector4(
+                    ColorExtensions.SrgbToLinear(Color.Yellow.R),
+                    ColorExtensions.SrgbToLinear(Color.Yellow.G),
+                    ColorExtensions.SrgbToLinear(Color.Yellow.B),
+                    DrawAlpha);
+
+                var gcRed = new Vector4(
+                    ColorExtensions.SrgbToLinear(Color.Red.R),
+                    ColorExtensions.SrgbToLinear(Color.Red.G),
+                    ColorExtensions.SrgbToLinear(Color.Red.B),
+                    DrawAlpha);
+
+                float dotHeight = 3f / h;
 
                 float minX = float.MaxValue, minY = float.MaxValue;
                 float maxX = float.MinValue, maxY = float.MinValue;
@@ -582,11 +627,10 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
                     // inactive background
                     if (!frame.IsActive)
                     {
-                        var blueBgColor = new Vector4(0, 0, 0.5f, DrawAlpha * 0.4f);
-                        var bgTopLeft = Vector2.Transform(new Vector2(left / w, 0), finalMatrix);
-                        var bgTopRight = Vector2.Transform(new Vector2(right / w, 0), finalMatrix);
-                        var bgBottomLeft = Vector2.Transform(new Vector2(left / w, 1), finalMatrix);
-                        var bgBottomRight = Vector2.Transform(new Vector2(right / w, 1), finalMatrix);
+                        var bgTopLeft = map(left / w, 0);
+                        var bgTopRight = map(right / w, 0);
+                        var bgBottomLeft = map(left / w, 1);
+                        var bgBottomRight = map(right / w, 1);
 
                         Vertices[offset + 0] = new Vertex { Position = bgTopLeft, Color = blueBgColor };
                         Vertices[offset + 1] = new Vertex { Position = bgTopRight, Color = blueBgColor };
@@ -606,18 +650,10 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
                     float barHeight = barHeightRatio * h;
                     float top = h - barHeight;
 
-                    Color color = display.baseColor;
-                    var calculatedColor = new Vector4(
-                        ColorExtensions.SrgbToLinear(color.R),
-                        ColorExtensions.SrgbToLinear(color.G),
-                        ColorExtensions.SrgbToLinear(color.B),
-                        DrawAlpha * (color.A / 255f)
-                    );
-
-                    var pTopLeft = Vector2.Transform(new Vector2(left / w, top / h), finalMatrix);
-                    var pTopRight = Vector2.Transform(new Vector2(right / w, top / h), finalMatrix);
-                    var pBottomLeft = Vector2.Transform(new Vector2(left / w, 1), finalMatrix);
-                    var pBottomRight = Vector2.Transform(new Vector2(right / w, 1), finalMatrix);
+                    var pTopLeft = map(left / w, top / h);
+                    var pTopRight = map(right / w, top / h);
+                    var pBottomLeft = map(left / w, 1);
+                    var pBottomRight = map(right / w, 1);
 
                     minX = Math.Min(minX, Math.Min(pTopLeft.X, pBottomRight.X));
                     minY = Math.Min(minY, Math.Min(pTopLeft.Y, pBottomRight.Y));
@@ -634,20 +670,12 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
                     // GC event dt
                     if (frame.GcGeneration >= 0)
                     {
-                        Color gcColor = frame.GcGeneration == 2 ? Color.Red : Color.Yellow;
-                        var calcGcColor = new Vector4(
-                            ColorExtensions.SrgbToLinear(gcColor.R),
-                            ColorExtensions.SrgbToLinear(gcColor.G),
-                            ColorExtensions.SrgbToLinear(gcColor.B),
-                            DrawAlpha
-                        );
+                        var calcGcColor = frame.GcGeneration == 2 ? gcRed : gcYellow;
 
-                        float dotHeight = 3f / h;
-
-                        var gcTopLeft = Vector2.Transform(new Vector2(left / w, 0), finalMatrix);
-                        var gcTopRight = Vector2.Transform(new Vector2(right / w, 0), finalMatrix);
-                        var gcBottomLeft = Vector2.Transform(new Vector2(left / w, dotHeight), finalMatrix);
-                        var gcBottomRight = Vector2.Transform(new Vector2(right / w, dotHeight), finalMatrix);
+                        var gcTopLeft = map(left / w, 0);
+                        var gcTopRight = map(right / w, 0);
+                        var gcBottomLeft = map(left / w, dotHeight);
+                        var gcBottomRight = map(right / w, dotHeight);
 
                         Vertices[offset + 12] = new Vertex { Position = gcTopLeft, Color = calcGcColor };
                         Vertices[offset + 13] = new Vertex { Position = gcTopRight, Color = calcGcColor };

--- a/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
@@ -37,16 +37,6 @@ public class ContainerDrawNode : DrawNode
         ModelMatrix = container.ModelMatrix;
     }
 
-    public override void PrepareForDraw(double lastUpdateTime, double currentUpdateTime, double drawTime)
-    {
-        base.PrepareForDraw(lastUpdateTime, currentUpdateTime, drawTime);
-
-        foreach (var child in Children)
-        {
-            child.PrepareForDraw(lastUpdateTime, currentUpdateTime, drawTime);
-        }
-    }
-
     public override void Draw(IRenderer renderer)
     {
         if (DrawAlpha <= 0) return;

--- a/Sakura.Framework/Graphics/Rendering/DrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/DrawNode.cs
@@ -14,78 +14,40 @@ public class DrawNode
 {
     public long InvalidationID { get; internal set; }
 
-    public Vertex.Vertex[] PreviousVertices { get; protected set; } = Array.Empty<Vertex.Vertex>();
-    public Vertex.Vertex[] CurrentVertices { get; protected set; } = Array.Empty<Vertex.Vertex>();
     public Vertex.Vertex[] Vertices { get; protected set; } = Array.Empty<Vertex.Vertex>();
     public Texture? Texture { get; protected set; }
     public BlendingMode Blending { get; protected set; }
-    public float PreviousDrawAlpha { get; protected set; }
-    public float CurrentDrawAlpha { get; protected set; }
     public float DrawAlpha { get; protected set; }
     public TextureFillMode FillMode { get; protected set; }
     public RectangleF DrawRectangle { get; protected set; }
-    private bool hasPreviousState;
 
     /// <summary>
     /// Copies the required visual state from the source drawable.
     /// This should execute on the update thread.
+    /// The node is a plain snapshot of the drawable's latest updated state; the draw thread
+    /// renders it as-is without any cross-frame interpolation.
     /// </summary>
     public virtual void ApplyState(Drawable source)
     {
-        PreviousDrawAlpha = CurrentDrawAlpha;
-        CurrentDrawAlpha = source.DrawAlpha;
-
+        DrawAlpha = source.DrawAlpha;
         Texture = source.Texture;
         Blending = source.Blending;
         DrawRectangle = source.DrawRectangle;
         FillMode = source.FillMode;
 
-        if (CurrentVertices.Length != source.Vertices.Length)
-        {
-            PreviousVertices = new Vertex.Vertex[source.Vertices.Length];
-            CurrentVertices = new Vertex.Vertex[source.Vertices.Length];
-            Vertices = new Vertex.Vertex[source.Vertices.Length];
-        }
-
-        // Shift current to previous, then grab the new current
-        Array.Copy(CurrentVertices, PreviousVertices, CurrentVertices.Length);
-        Array.Copy(source.Vertices, CurrentVertices, source.Vertices.Length);
-
-        // Prevent interpolation from (0,0) on the very first frame this node exists
-        if (!hasPreviousState)
-        {
-            Array.Copy(CurrentVertices, PreviousVertices, CurrentVertices.Length);
-            PreviousDrawAlpha = CurrentDrawAlpha;
-            hasPreviousState = true;
-        }
+        ApplyVertices(source);
     }
 
     /// <summary>
-    /// Calculates the interpolated state before drawing.
+    /// Snapshots the source drawable's vertices into this node.
+    /// Subclasses with custom vertex storage can override this to copy from their own source.
     /// </summary>
-    public virtual void PrepareForDraw(double lastUpdateTime, double currentUpdateTime, double drawTime)
+    protected virtual void ApplyVertices(Drawable source)
     {
-        float interpolationFactor = 1.0f;
+        if (Vertices.Length != source.Vertices.Length)
+            Vertices = new Vertex.Vertex[source.Vertices.Length];
 
-        if (currentUpdateTime > lastUpdateTime)
-        {
-            interpolationFactor = (float)((drawTime - lastUpdateTime) / (currentUpdateTime - lastUpdateTime));
-            // clamp between 0 and 1 to prevent overshooting if the draw thread runs ahead of the update thread
-            interpolationFactor = Math.Clamp(interpolationFactor, 0f, 1f);
-        }
-
-        // interpolate the alpha
-        DrawAlpha = PreviousDrawAlpha + (CurrentDrawAlpha - PreviousDrawAlpha) * interpolationFactor;
-
-        for (int i = 0; i < CurrentVertices.Length; i++)
-        {
-            // copy base data (UVs, Colors)
-            Vertices[i] = CurrentVertices[i];
-
-            // interpolate Position
-            Vertices[i].Position.X = PreviousVertices[i].Position.X + (CurrentVertices[i].Position.X - PreviousVertices[i].Position.X) * interpolationFactor;
-            Vertices[i].Position.Y = PreviousVertices[i].Position.Y + (CurrentVertices[i].Position.Y - PreviousVertices[i].Position.Y) * interpolationFactor;
-        }
+        Array.Copy(source.Vertices, Vertices, source.Vertices.Length);
     }
 
     /// <summary>

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -48,9 +48,6 @@ public abstract class AppHost : IDisposable
     private readonly ConcurrentQueue<Action> inputQueue = new ConcurrentQueue<Action>();
     private readonly ConcurrentQueue<Action> mainThreadActions = new ConcurrentQueue<Action>();
 
-    private double lastUpdateProcessTime;
-    private double currentUpdateProcessTime;
-
     private readonly FrameBufferManager frameBufferManager = new FrameBufferManager();
     private readonly DrawNode[] rootDrawNodes = new DrawNode[3];
     private DrawNode currentFrameDrawNode;
@@ -597,9 +594,6 @@ public abstract class AppHost : IDisposable
     /// </summary>
     protected virtual void PerformUpdate()
     {
-        lastUpdateProcessTime = currentUpdateProcessTime;
-        currentUpdateProcessTime = UpdateClock.CurrentTime;
-
         while (inputQueue.TryDequeue(out var inputAction))
         {
             inputAction.Invoke();
@@ -649,7 +643,6 @@ public abstract class AppHost : IDisposable
 
         if (currentFrameNode != null)
         {
-            currentFrameNode.PrepareForDraw(lastUpdateProcessTime, currentUpdateProcessTime, DrawClock.CurrentTime);
             Renderer?.SetRoot(currentFrameNode);
         }
 


### PR DESCRIPTION
Our "clock" system is not syncing between update and draw loop, we use the interpolation between 0 to 1 on between frame, This just remove it to prevent a problem about the "jumping drawable" due to the position interpolation.

<img width="301" height="149" alt="Screenshot 2026-06-10 at 15 01 16" src="https://github.com/user-attachments/assets/91d95efc-10d7-4d5a-b83f-36e6c9dd59ea" />
