### PR TITLE
Add precise clock chain from framework core and real usage

### DIFF
--- a/Sakura.Framework.Tests/Timing/DecouplingFramedClockTest.cs
+++ b/Sakura.Framework.Tests/Timing/DecouplingFramedClockTest.cs
@@ -1,0 +1,219 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+/// <summary>
+/// Tests for <see cref="DecouplingFramedClock"/>.
+/// </summary>
+[TestFixture]
+public class DecouplingFramedClockTest
+{
+    private TestAdjustableClock source = null!;
+    private ManualClock reference = null!;
+    private DecouplingFramedClock decoupled = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        source = new TestAdjustableClock();
+        reference = new ManualClock { CurrentTime = 0, IsRunning = true };
+        decoupled = new DecouplingFramedClock(source, reference);
+    }
+
+    #region Basic behaviour
+
+    [Test]
+    public void TestStartStartsSource()
+    {
+        Assert.That(source.IsRunning, Is.False);
+        Assert.That(decoupled.IsRunning, Is.False);
+
+        decoupled.Start();
+        decoupled.ProcessFrame();
+
+        Assert.That(source.IsRunning, Is.True);
+        Assert.That(decoupled.IsRunning, Is.True);
+    }
+
+    [Test]
+    public void TestStopStopsSource()
+    {
+        decoupled.Start();
+        decoupled.ProcessFrame();
+
+        decoupled.Stop();
+
+        Assert.That(decoupled.IsRunning, Is.False);
+        Assert.That(source.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void TestSeekForwardsWhileRunning()
+    {
+        decoupled.Start();
+        decoupled.Seek(1000);
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.CurrentTime, Is.EqualTo(1000).Within(1));
+        Assert.That(source.CurrentTime, Is.EqualTo(1000).Within(1));
+    }
+
+    [Test]
+    public void TestResetGoesToZeroAndStops()
+    {
+        source.Start();
+        source.AdvanceBy(2000);
+        decoupled.Start();
+        decoupled.ProcessFrame();
+
+        decoupled.Reset();
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.IsRunning, Is.False);
+        Assert.That(decoupled.CurrentTime, Is.EqualTo(0).Within(1));
+        Assert.That(source.CurrentTime, Is.EqualTo(0).Within(1));
+    }
+
+    #endregion
+
+    #region Decoupled (negative lead-in) behaviour
+
+    [Test]
+    public void TestSeekNegativeEntersDecoupledMode()
+    {
+        decoupled.Start();
+        decoupled.Seek(-500);
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.CurrentTime, Is.EqualTo(-500).Within(1));
+        Assert.That(decoupled.IsDecoupled, Is.True);
+        Assert.That(source.IsRunning, Is.False);
+        Assert.That(source.CurrentTime, Is.EqualTo(0).Within(1));
+    }
+
+    [Test]
+    public void TestDecoupledTimeAdvancesWithReference()
+    {
+        decoupled.Start();
+        decoupled.Seek(-300);
+        decoupled.ProcessFrame();
+
+        double timeBefore = decoupled.CurrentTime;
+
+        // Advance the reference by 100 ms.
+        reference.CurrentTime += 100;
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.CurrentTime, Is.GreaterThan(timeBefore));
+        Assert.That(decoupled.CurrentTime, Is.EqualTo(timeBefore + 100).Within(2));
+    }
+
+    [Test]
+    public void TestSourceStartsAutomaticallyWhenDecoupledTimeCrossesZero()
+    {
+        decoupled.Start();
+        decoupled.Seek(-50);
+        decoupled.ProcessFrame();
+
+        Assert.That(source.IsRunning, Is.False);
+
+        // Advance reference past zero.
+        reference.CurrentTime += 100;
+        decoupled.ProcessFrame();
+
+        Assert.That(source.IsRunning, Is.True);
+
+        // IsDecoupled is updated on the *next* ProcessFrame after the source starts,
+        // because the handover happens mid-frame and the flag reflects what drove the
+        // *current* frame's time value.
+        reference.CurrentTime += 10;
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.IsDecoupled, Is.False);
+    }
+
+    [Test]
+    public void TestDecoupledDoesNotDriftFromReference()
+    {
+        var realReference = new ManualClock { CurrentTime = 0, IsRunning = true };
+        var clock = new DecouplingFramedClock(source, realReference);
+        clock.Start();
+        clock.Seek(-200);
+        clock.ProcessFrame();
+
+        double clockTime = clock.CurrentTime;
+
+        for (int i = 0; i < 20; i++)
+        {
+            realReference.CurrentTime += 10;
+            clock.ProcessFrame();
+
+            Assert.That(clock.CurrentTime, Is.EqualTo(clockTime + (i + 1) * 10).Within(1),
+                "Decoupled time must track the reference with no drift");
+        }
+    }
+
+    [Test]
+    public void TestChangeSourceUpdatesToNewSourceTime()
+    {
+        // Start the decoupled clock first (CurrentTime = 0), then advance the source
+        // so ProcessFrame picks it up at 1000 without a mid-start seek clobbering it.
+        decoupled.Start();
+        source.Start();
+        source.AdvanceBy(1000);
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.CurrentTime, Is.EqualTo(1000).Within(1));
+
+        var secondSource = new TestAdjustableClock();
+        secondSource.AdvanceBy(500);
+        secondSource.Start();
+
+        decoupled.ChangeSource(secondSource);
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.CurrentTime, Is.EqualTo(500).Within(5));
+    }
+
+    [Test]
+    public void TestElapsedFrameTimeIsZeroWhenStopped()
+    {
+        decoupled.Start();
+        decoupled.ProcessFrame();
+        decoupled.Stop();
+        reference.CurrentTime += 100;
+        decoupled.ProcessFrame();
+
+        Assert.That(decoupled.ElapsedFrameTime, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void TestStartFromNegativeTimeIncrementsCorrectlyWithRealClock()
+    {
+        // Use a real reference clock this time to test actual timing behaviour.
+        Thread.Sleep(100);
+
+        var realDecoupled = new DecouplingFramedClock(source);
+        realDecoupled.Start();
+        realDecoupled.Seek(-200);
+        realDecoupled.ProcessFrame();
+
+        Assert.That(realDecoupled.IsRunning, Is.True);
+        Assert.That(realDecoupled.CurrentTime, Is.LessThan(0));
+
+        double previousTime = realDecoupled.CurrentTime;
+
+        Thread.Sleep(50);
+        realDecoupled.ProcessFrame();
+
+        Assert.That(realDecoupled.CurrentTime, Is.GreaterThan(previousTime));
+        Assert.That(realDecoupled.ElapsedFrameTime, Is.GreaterThan(0));
+    }
+
+    #endregion
+}

--- a/Sakura.Framework.Tests/Timing/FramedClockTest.cs
+++ b/Sakura.Framework.Tests/Timing/FramedClockTest.cs
@@ -1,0 +1,94 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+[TestFixture]
+public class FramedClockTest
+{
+    private TestAdjustableClock source = null!;
+    private FramedClock framed = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        source = new TestAdjustableClock();
+        framed = new FramedClock(source);
+    }
+
+    [Test]
+    public void TestTimeDoesNotMoveUntilProcessFrame()
+    {
+        source.Start();
+        double timeBefore = framed.CurrentTime;
+        source.AdvanceBy(100);
+        Assert.That(framed.CurrentTime, Is.EqualTo(timeBefore), "Time must not change until ProcessFrame is called");
+    }
+
+    [Test]
+    public void TestProcessFrameAdvancesTime()
+    {
+        source.Start();
+        source.AdvanceBy(100);
+        framed.ProcessFrame();
+        Assert.That(framed.CurrentTime, Is.EqualTo(100).Within(1));
+    }
+
+    [Test]
+    public void TestElapsedFrameTimeReflectsSourceDelta()
+    {
+        source.Start();
+        source.AdvanceBy(16);
+        framed.ProcessFrame();
+        Assert.That(framed.ElapsedFrameTime, Is.EqualTo(16).Within(1));
+    }
+
+    [Test]
+    public void TestElapsedFrameTimeIsZeroWhenStopped()
+    {
+        source.Start();
+        source.AdvanceBy(50);
+        framed.Stop();
+        framed.ProcessFrame();
+        Assert.That(framed.ElapsedFrameTime, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void TestRateScalesElapsedTime()
+    {
+        source.Start();
+        framed.Rate = 2.0;
+        source.AdvanceBy(50);
+        framed.ProcessFrame();
+        Assert.That(framed.CurrentTime, Is.EqualTo(100).Within(1));
+    }
+
+    [Test]
+    public void TestStartFromZeroIgnoresSourceCurrentTime()
+    {
+        source.AdvanceBy(5000);
+        var zeroed = new FramedClock(source, startFromZero: true);
+        Assert.That(zeroed.CurrentTime, Is.EqualTo(0).Within(1));
+    }
+
+    [Test]
+    public void TestChangeSourceUpdatesToNewSource()
+    {
+        source.Start();
+        source.AdvanceBy(200);
+        framed.ProcessFrame();
+        Assert.That(framed.CurrentTime, Is.EqualTo(200).Within(1));
+
+        var secondSource = new TestAdjustableClock();
+        secondSource.AdvanceBy(500);
+        framed.ChangeSource(secondSource);
+        secondSource.AdvanceBy(100);
+        framed.ProcessFrame();
+
+        // After source change, elapsed is measured from the new source's position at change time.
+        Assert.That(framed.ElapsedFrameTime, Is.EqualTo(100).Within(1));
+    }
+}

--- a/Sakura.Framework.Tests/Timing/GameplayClockTest.cs
+++ b/Sakura.Framework.Tests/Timing/GameplayClockTest.cs
@@ -1,0 +1,199 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+/// <summary>
+/// Tests for <see cref="GameplayClock"/> — the full precision chain used for rhythm gameplay.
+/// All tests use a <see cref="ManualClock"/> as the real-time reference for determinism.
+/// </summary>
+[TestFixture]
+public class GameplayClockTest
+{
+    private TestAdjustableClock source = null!;
+    private ManualClock reference = null!;
+    private GameplayClock gameplay = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        source = new TestAdjustableClock();
+        reference = new ManualClock { CurrentTime = 0, IsRunning = true };
+        gameplay = new GameplayClock(source, reference);
+    }
+
+    #region Basic controls
+
+    [Test]
+    public void TestStartAndStop()
+    {
+        Assert.That(gameplay.IsRunning, Is.False);
+
+        gameplay.Start();
+        gameplay.ProcessFrame();
+        Assert.That(gameplay.IsRunning, Is.True);
+
+        gameplay.Stop();
+        Assert.That(gameplay.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void TestSeekForward()
+    {
+        gameplay.Start();
+        gameplay.Seek(3000);
+        gameplay.ProcessFrame();
+
+        Assert.That(gameplay.CurrentTime, Is.EqualTo(3000).Within(5));
+    }
+
+    [Test]
+    public void TestReset()
+    {
+        source.Start();
+        source.AdvanceBy(1000);
+        gameplay.Start();
+        gameplay.ProcessFrame();
+        gameplay.Reset();
+        gameplay.ProcessFrame();
+
+        Assert.That(gameplay.IsRunning, Is.False);
+        Assert.That(gameplay.CurrentTime, Is.EqualTo(0).Within(1));
+    }
+
+    #endregion
+
+    #region Offset
+
+    [Test]
+    public void TestOffsetShiftsCurrentTime()
+    {
+        source.Start();
+        source.AdvanceBy(1000);
+        gameplay.Start();
+        gameplay.ProcessFrame();
+
+        double baseTime = gameplay.CurrentTime;
+        gameplay.Offset = 20;
+
+        Assert.That(gameplay.CurrentTime, Is.EqualTo(baseTime + 20).Within(2));
+    }
+
+    [Test]
+    public void TestOffsetDoesNotAffectDecoupledOrInterpolatedInternals()
+    {
+        gameplay.Offset = 50;
+        source.Start();
+        source.AdvanceBy(500);
+        gameplay.Start();
+        gameplay.ProcessFrame();
+
+        // Internals are unaffected; only the exposed CurrentTime shifts.
+        Assert.That(gameplay.InterpolatedClock.CurrentTime, Is.EqualTo(gameplay.CurrentTime - 50).Within(2));
+    }
+
+    #endregion
+
+    #region Lead-in (negative time)
+
+    [Test]
+    public void TestNegativeLeadIn()
+    {
+        gameplay.Start();
+        gameplay.Seek(-500);
+        gameplay.ProcessFrame();
+
+        Assert.That(gameplay.CurrentTime, Is.EqualTo(-500).Within(5));
+        Assert.That(gameplay.DecoupledClock.IsDecoupled, Is.True);
+        Assert.That(source.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void TestSourceStartsAfterLeadIn()
+    {
+        gameplay.Start();
+        gameplay.Seek(-100);
+        gameplay.ProcessFrame();
+
+        reference.CurrentTime += 200;
+        gameplay.ProcessFrame();
+
+        Assert.That(source.IsRunning, Is.True);
+        Assert.That(gameplay.CurrentTime, Is.GreaterThan(0));
+    }
+
+    #endregion
+
+    #region Rate
+
+    [Test]
+    public void TestRatePropagatesToChain()
+    {
+        gameplay.Rate = 1.5;
+        Assert.That(gameplay.Rate, Is.EqualTo(1.5).Within(0.001));
+        Assert.That(gameplay.DecoupledClock.Rate, Is.EqualTo(1.5).Within(0.001));
+    }
+
+    #endregion
+
+    #region GetTimeAt
+
+    [Test]
+    public void TestGetTimeAtCurrentReferenceEqualsCurrentTime()
+    {
+        source.Start();
+        source.AdvanceBy(500);
+        gameplay.Start();
+        gameplay.ProcessFrame();
+
+        // An event that happened exactly at this frame's reference time maps to CurrentTime.
+        double result = gameplay.GetTimeAt(reference.CurrentTime);
+        Assert.That(result, Is.EqualTo(gameplay.CurrentTime).Within(2));
+    }
+
+    [Test]
+    public void TestGetTimeAtEarlierTimestampProducesEarlierGameplayTime()
+    {
+        source.Start();
+        source.AdvanceBy(1000);
+        gameplay.Start();
+        gameplay.ProcessFrame();
+
+        // An event that happened 10 ms before this frame should map to 10 ms earlier.
+        double result = gameplay.GetTimeAt(reference.CurrentTime - 10);
+        Assert.That(result, Is.LessThan(gameplay.CurrentTime));
+        Assert.That(gameplay.CurrentTime - result, Is.EqualTo(10).Within(1));
+    }
+
+    #endregion
+
+    #region Smooth interpolation through chain
+
+    [Test]
+    public void TestCurrentTimeNeverRunsBackwardsDuringPlayback()
+    {
+        source.Start();
+        source.AdvanceBy(100);
+        gameplay.Start();
+        gameplay.ProcessFrame();
+
+        double last = gameplay.CurrentTime;
+
+        for (int i = 0; i < 20; i++)
+        {
+            // Advance source and reference by the same amount so the interpolator
+            // stays in smooth mode and never snaps backwards.
+            source.AdvanceBy(8);
+            reference.CurrentTime += 8;
+            gameplay.ProcessFrame();
+
+            Assert.That(gameplay.CurrentTime, Is.GreaterThanOrEqualTo(last), "Gameplay time must never run backwards");
+            last = gameplay.CurrentTime;
+        }
+    }
+
+    #endregion
+}

--- a/Sakura.Framework.Tests/Timing/InterpolatingFramedClockTest.cs
+++ b/Sakura.Framework.Tests/Timing/InterpolatingFramedClockTest.cs
@@ -1,0 +1,213 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+/// <summary>
+/// Tests for <see cref="InterpolatingFramedClock"/>.
+/// A <see cref="ManualClock"/> reference lets tests control time precisely without
+/// relying on wall-clock sleeps except where real-time behaviour is explicitly tested.
+/// </summary>
+[TestFixture]
+public class InterpolatingFramedClockTest
+{
+    private TestAdjustableClock source = null!;
+    private ManualClock reference = null!;
+    private InterpolatingFramedClock interpolating = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        source = new TestAdjustableClock();
+        reference = new ManualClock { CurrentTime = 0, IsRunning = true };
+        interpolating = new InterpolatingFramedClock(source, reference);
+    }
+
+    #region Stopped source
+
+    [Test]
+    public void TestReportsSourceTimeWhenStopped()
+    {
+        source.Seek(500);
+        reference.CurrentTime += 50;
+        interpolating.ProcessFrame();
+
+        Assert.That(interpolating.CurrentTime, Is.EqualTo(500).Within(1));
+        Assert.That(interpolating.IsInterpolating, Is.False);
+    }
+
+    #endregion
+
+    #region Basic interpolation
+
+    [Test]
+    public void TestFirstFrameSnapsToSource()
+    {
+        source.Start();
+        source.AdvanceBy(200);
+        interpolating.ProcessFrame();
+
+        Assert.That(interpolating.CurrentTime, Is.EqualTo(200).Within(1));
+        Assert.That(interpolating.IsInterpolating, Is.False);
+    }
+
+    [Test]
+    public void TestSmoothlyInterpolatesBetweenChunkySourceUpdates()
+    {
+        source.Start();
+        source.AdvanceBy(10);
+        interpolating.ProcessFrame(); // First frame: snap to source.
+
+        // Advance reference as if 5 ms has elapsed — source hasn't updated.
+        reference.CurrentTime += 5;
+        interpolating.ProcessFrame();
+
+        Assert.That(interpolating.IsInterpolating, Is.True);
+        Assert.That(interpolating.CurrentTime, Is.EqualTo(15).Within(2));
+    }
+
+    [Test]
+    public void TestNeverRunsBackwardsWhilePlayingForward()
+    {
+        source.Start();
+        source.AdvanceBy(100);
+        interpolating.ProcessFrame();
+
+        double last = interpolating.CurrentTime;
+
+        for (int i = 0; i < 20; i++)
+        {
+            // Both source and reference advance by the same amount — no divergence that would
+            // trigger a snap. The invariant under test is that CurrentTime never decreases.
+            source.AdvanceBy(8);
+            reference.CurrentTime += 8;
+            interpolating.ProcessFrame();
+
+            Assert.That(interpolating.CurrentTime, Is.GreaterThanOrEqualTo(last),
+                "Interpolated time must never run backwards");
+            last = interpolating.CurrentTime;
+        }
+    }
+
+    [Test]
+    public void TestStaysWithinAllowableError()
+    {
+        source.Start();
+        source.AdvanceBy(100);
+        interpolating.ProcessFrame();
+
+        for (int i = 0; i < 30; i++)
+        {
+            source.AdvanceBy(8);
+            reference.CurrentTime += 8;
+            interpolating.ProcessFrame();
+
+            Assert.That(Math.Abs(interpolating.CurrentTime - source.CurrentTime),
+                Is.LessThanOrEqualTo(interpolating.AllowableErrorMilliseconds),
+                "Interpolated time must stay within allowable error of source");
+        }
+    }
+
+    #endregion
+
+    #region Seek / discontinuity
+
+    [Test]
+    public void TestSeekForwardSnaps()
+    {
+        source.Start();
+        source.AdvanceBy(100);
+        interpolating.ProcessFrame(); // Baseline.
+
+        source.Seek(10000);
+        interpolating.ProcessFrame();
+
+        Assert.That(interpolating.CurrentTime, Is.EqualTo(10000).Within(1));
+        Assert.That(interpolating.IsInterpolating, Is.False);
+    }
+
+    [Test]
+    public void TestSeekBackwardSnaps()
+    {
+        source.Start();
+        source.AdvanceBy(5000);
+        interpolating.ProcessFrame();
+        source.Seek(0);
+        interpolating.ProcessFrame();
+
+        Assert.That(interpolating.CurrentTime, Is.EqualTo(0).Within(1));
+        Assert.That(interpolating.IsInterpolating, Is.False);
+    }
+
+    [Test]
+    public void TestSeekBackwardAfterInterpolatingDoesNotGoForward()
+    {
+        // Advance enough to trigger real interpolation.
+        source.Start();
+        source.AdvanceBy(100);
+        interpolating.ProcessFrame();
+        reference.CurrentTime += 5;
+        interpolating.ProcessFrame();
+        Assert.That(interpolating.IsInterpolating, Is.True);
+
+        source.Stop();
+        source.Seek(50);
+        interpolating.ProcessFrame();
+
+        Assert.That(interpolating.CurrentTime, Is.EqualTo(50).Within(1));
+        Assert.That(interpolating.IsInterpolating, Is.False);
+    }
+
+    #endregion
+
+    #region Change source
+
+    [Test]
+    public void TestChangeSourceAdoptsNewSourceTime()
+    {
+        source.Start();
+        source.AdvanceBy(1000);
+        interpolating.ProcessFrame();
+
+        var secondSource = new TestAdjustableClock();
+        secondSource.AdvanceBy(300);
+
+        interpolating.ChangeSource(secondSource);
+        interpolating.ProcessFrame();
+
+        Assert.That(interpolating.CurrentTime, Is.EqualTo(300).Within(1));
+        Assert.That(interpolating.IsInterpolating, Is.False);
+    }
+
+    #endregion
+
+    #region Real-time drift guard
+
+    [Test]
+    public void TestNoInterpolationDriftAgainstRealClock()
+    {
+        // Use a real StopwatchClock as source so we can verify there is no
+        // accumulated drift when the source and reference run at the same rate.
+        var realSource = new StopwatchClock(start: true);
+        var realInterpolating = new InterpolatingFramedClock(realSource);
+
+        realInterpolating.ProcessFrame(); // First frame baseline.
+
+        for (int i = 0; i < 10; i++)
+        {
+            Thread.Sleep(10);
+            realInterpolating.ProcessFrame();
+
+            Assert.That(realInterpolating.CurrentTime,
+                Is.EqualTo(realSource.CurrentTime).Within(realInterpolating.AllowableErrorMilliseconds),
+                "Interpolated time must not drift beyond allowable error");
+        }
+    }
+
+    #endregion
+}

--- a/Sakura.Framework.Tests/Timing/StopwatchClockTest.cs
+++ b/Sakura.Framework.Tests/Timing/StopwatchClockTest.cs
@@ -1,0 +1,111 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+[TestFixture]
+public class StopwatchClockTest
+{
+    [Test]
+    public void TestStartsAtZero()
+    {
+        var clock = new StopwatchClock();
+        Assert.That(clock.CurrentTime, Is.EqualTo(0).Within(1));
+        Assert.That(clock.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void TestAdvancesWhenRunning()
+    {
+        var clock = new StopwatchClock(start: true);
+        Thread.Sleep(50);
+        Assert.That(clock.CurrentTime, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void TestDoesNotAdvanceWhenStopped()
+    {
+        var clock = new StopwatchClock(start: true);
+        Thread.Sleep(30);
+        clock.Stop();
+        double stoppedTime = clock.CurrentTime;
+        Thread.Sleep(30);
+        Assert.That(clock.CurrentTime, Is.EqualTo(stoppedTime).Within(1));
+    }
+
+    [Test]
+    public void TestResetReturnsToZero()
+    {
+        var clock = new StopwatchClock(start: true);
+        Thread.Sleep(30);
+        clock.Stop();
+        Assert.That(clock.CurrentTime, Is.GreaterThan(0));
+        clock.Reset();
+        Assert.That(clock.CurrentTime, Is.EqualTo(0).Within(1));
+        Assert.That(clock.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void TestSeekWhileStopped()
+    {
+        var clock = new StopwatchClock();
+        clock.Seek(5000);
+        Assert.That(clock.CurrentTime, Is.EqualTo(5000).Within(1));
+        Assert.That(clock.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void TestSeekWhileRunning()
+    {
+        var clock = new StopwatchClock(start: true);
+        Thread.Sleep(30);
+        clock.Seek(9000);
+        Assert.That(clock.CurrentTime, Is.EqualTo(9000).Within(5));
+        Assert.That(clock.IsRunning, Is.True);
+        Thread.Sleep(30);
+        Assert.That(clock.CurrentTime, Is.GreaterThan(9000));
+    }
+
+    [Test]
+    public void TestSeekNegative()
+    {
+        var clock = new StopwatchClock();
+        clock.Seek(-2000);
+        Assert.That(clock.CurrentTime, Is.EqualTo(-2000).Within(1));
+    }
+
+    [Test]
+    public void TestRateChangeDoesNotJumpTime()
+    {
+        var clock = new StopwatchClock(start: true);
+        Thread.Sleep(30);
+        clock.Stop();
+        double timeBefore = clock.CurrentTime;
+        clock.Rate = 2.0;
+        Assert.That(clock.CurrentTime, Is.EqualTo(timeBefore).Within(1));
+    }
+
+    [Test]
+    public void TestDoubleRateRunsFaster()
+    {
+        var clock = new StopwatchClock { Rate = 2.0 };
+        clock.Start();
+        Thread.Sleep(100);
+        clock.Stop();
+        Assert.That(clock.CurrentTime, Is.GreaterThan(150));
+    }
+
+    [Test]
+    public void TestNegativeRateRunsBackwards()
+    {
+        var clock = new StopwatchClock { Rate = -1.0 };
+        clock.Start();
+        Thread.Sleep(50);
+        clock.Stop();
+        Assert.That(clock.CurrentTime, Is.LessThan(0));
+    }
+}

--- a/Sakura.Framework.Tests/Timing/TestAdjustableClock.cs
+++ b/Sakura.Framework.Tests/Timing/TestAdjustableClock.cs
@@ -1,0 +1,44 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+/// <summary>
+/// A fully manual <see cref="IAdjustableClock"/> simulating an audio track:
+/// time only advances when the test explicitly calls <see cref="AdvanceBy"/>,
+/// mimicking the coarse buffer-step behavior of a real audio position.
+/// </summary>
+public class TestAdjustableClock : IAdjustableClock
+{
+    public double CurrentTime { get; private set; }
+
+    public double Rate { get; set; } = 1.0;
+
+    public bool IsRunning { get; private set; }
+
+    public int SeekCount { get; private set; }
+
+    public void Start() => IsRunning = true;
+
+    public void Stop() => IsRunning = false;
+
+    public bool Seek(double position)
+    {
+        CurrentTime = position;
+        SeekCount++;
+        return true;
+    }
+
+    public void Reset()
+    {
+        IsRunning = false;
+        CurrentTime = 0;
+    }
+
+    /// <summary>
+    /// Simulates audio playback progressing by the given amount of milliseconds.
+    /// </summary>
+    public void AdvanceBy(double milliseconds) => CurrentTime += milliseconds;
+}

--- a/Sakura.Framework.Tests/Timing/TimeSourceTest.cs
+++ b/Sakura.Framework.Tests/Timing/TimeSourceTest.cs
@@ -1,0 +1,54 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Diagnostics;
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+[TestFixture]
+public class TimeSourceTest
+{
+    [Test]
+    public void TestMonotonic()
+    {
+        double last = TimeSource.CurrentTime;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            double now = TimeSource.CurrentTime;
+            Assert.That(now, Is.GreaterThanOrEqualTo(last), "TimeSource must never run backwards");
+            last = now;
+        }
+    }
+
+    [Test]
+    public void TestFromStopwatchTimestampMatchesCurrentTime()
+    {
+        long timestamp = Stopwatch.GetTimestamp();
+        double converted = TimeSource.FromStopwatchTimestamp(timestamp);
+        double now = TimeSource.CurrentTime;
+
+        // The conversion of "now" must land between the two surrounding reads.
+        Assert.That(converted, Is.LessThanOrEqualTo(now));
+        Assert.That(now - converted, Is.LessThan(50), "Conversion should be on the same timeline");
+    }
+
+    [Test]
+    public void TestClocksCreatedAtDifferentTimesShareTimeline()
+    {
+        // The core guarantee that makes cross-thread time comparison valid:
+        // two always-running clocks report (almost) identical absolute times,
+        // regardless of when they were constructed.
+        var first = new Clock(true);
+        Thread.Sleep(20);
+        var second = new Clock(true);
+
+        first.ProcessFrame();
+        second.ProcessFrame();
+
+        Assert.That(first.CurrentTime, Is.EqualTo(second.CurrentTime).Within(20), "Always-running clocks must share the same timeline");
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestVideoSprite.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestVideoSprite.cs
@@ -47,6 +47,28 @@ public partial class TestVideoSprite : TestScene
     }
 
     [Test]
+    public void TestSyncToClock()
+    {
+        createVideo();
+
+        AddStep("Enable SyncToClock", () => videoSprite.SyncToClock = true);
+        AddAssert("SyncToClock is on", () => videoSprite.SyncToClock);
+
+        // When SyncToClock is true, CurrentTime IS Clock.CurrentTime by definition —
+        // no accumulator, no drift. The delta must be exactly 0.
+        AddAssert("Video time equals sprite's own clock time",
+            () => videoSprite.CurrentTime == videoSprite.Clock.CurrentTime);
+
+        // Seek re-anchors the decoder but CurrentTime still tracks the clock in sync mode.
+        AddStep("Seek via VideoSprite.Seek(0)", () => videoSprite.Seek(0));
+        AddAssert("CurrentTime still equals clock after seek",
+            () => videoSprite.CurrentTime == videoSprite.Clock.CurrentTime);
+
+        AddStep("Disable SyncToClock", () => videoSprite.SyncToClock = false);
+        AddAssert("SyncToClock is off", () => !videoSprite.SyncToClock);
+    }
+
+    [Test]
     public void TestPlaybackControls()
     {
         createVideo();

--- a/Sakura.Framework.Tests/Visuals/Timing/TestClockVisualiser.cs
+++ b/Sakura.Framework.Tests/Visuals/Timing/TestClockVisualiser.cs
@@ -1,0 +1,310 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Testing;
+using Sakura.Framework.Tests.Timing;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Visuals.Timing;
+
+public partial class TestClockVisualiser : TestScene
+{
+    private StopwatchClock stopwatch = null!;
+    private ManualClock manualClock = null!;
+    private FramedClock framedClock = null!;
+
+    private TestAdjustableClock fakeTrack = null!;
+    private DecouplingFramedClock decoupled = null!;
+    private InterpolatingFramedClock interpolated = null!;
+    private GameplayClock gameplay = null!;
+
+    private ClockPanel stopwatchPanel = null!;
+    private ClockPanel manualPanel = null!;
+    private ClockPanel framedPanel = null!;
+    private ClockPanel interpolatedPanel = null!;
+    private ClockPanel gameplayPanel = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        AddStep("Build clock chain", () =>
+        {
+            Clear();
+
+            stopwatch = new StopwatchClock();
+            manualClock = new ManualClock { CurrentTime = 0, Rate = 1, IsRunning = false };
+            framedClock = new FramedClock(stopwatch);
+
+            fakeTrack = new TestAdjustableClock();
+            decoupled = new DecouplingFramedClock(fakeTrack);
+            interpolated = new InterpolatingFramedClock(decoupled);
+            gameplay = new GameplayClock(fakeTrack);
+
+            var row = new FlowContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Direction = FlowDirection.Horizontal,
+                Spacing = new Vector2(8),
+                Padding = new MarginPadding(12)
+            };
+
+            row.Add(stopwatchPanel = new ClockPanel("StopwatchClock", Color.SteelBlue));
+            row.Add(manualPanel = new ClockPanel("ManualClock", Color.MediumPurple));
+            row.Add(framedPanel = new ClockPanel("FramedClock", Color.SeaGreen));
+            row.Add(interpolatedPanel = new ClockPanel("InterpolatingFramedClock", Color.DarkOrange));
+            row.Add(gameplayPanel = new ClockPanel("GameplayClock", Color.Crimson));
+
+            Add(row);
+        });
+    }
+
+    public override void Update()
+    {
+        base.Update();
+
+        if (stopwatch == null) return;
+
+        // Pump framed clocks.
+        framedClock.ProcessFrame();
+        decoupled.ProcessFrame();
+        interpolated.ProcessFrame();
+        gameplay.ProcessFrame();
+
+        // Sync fake track with stopwatch so interpolated / gameplay have something to chase.
+        if (stopwatch.IsRunning && fakeTrack.IsRunning)
+            fakeTrack.AdvanceBy(framedClock.ElapsedFrameTime);
+
+        // Refresh display panels.
+        stopwatchPanel.SetTime(stopwatch.CurrentTime, stopwatch.IsRunning);
+        manualPanel.SetTime(manualClock.CurrentTime, manualClock.IsRunning);
+        framedPanel.SetTime(framedClock.CurrentTime, framedClock.IsRunning);
+        interpolatedPanel.SetTime(interpolated.CurrentTime, interpolated.IsRunning, interpolated.IsInterpolating);
+        gameplayPanel.SetTime(gameplay.CurrentTime, gameplay.IsRunning);
+    }
+
+    [Test]
+    public void TestStopwatchStartStop()
+    {
+        AddStep("Start StopwatchClock", () => stopwatch.Start());
+        AddWaitStep("Run for 1 second", 1000);
+        AddAssert("Time > 0", () => stopwatch.CurrentTime > 0);
+        AddStep("Stop StopwatchClock", () => stopwatch.Stop());
+        AddWaitStep("Verify frozen", 300);
+        AddAssert("Time is frozen", () => stopwatch.CurrentTime > 0 && !stopwatch.IsRunning);
+    }
+
+    [Test]
+    public void TestStopwatchSeek()
+    {
+        AddStep("Start StopwatchClock", () => stopwatch.Start());
+        AddStep("Seek to 5000 ms", () => stopwatch.Seek(5000));
+        // Use UntilStep — the clock is running, so time advances between steps.
+        AddUntilStep("Time is near 5000", () => stopwatch.CurrentTime >= 5000);
+        AddWaitStep("Run briefly", 200);
+        AddAssert("Time advanced past 5000", () => stopwatch.CurrentTime > 5000);
+    }
+
+    [Test]
+    public void TestStopwatchSeekWhileStopped()
+    {
+        AddStep("Seek to 3000 ms while stopped", () => stopwatch.Seek(3000));
+        AddAssert("Time = 3000", () => Math.Abs(stopwatch.CurrentTime - 3000) < 1);
+        AddAssert("Clock is not running", () => !stopwatch.IsRunning);
+    }
+
+    [Test]
+    public void TestDoubleRate()
+    {
+        // Visual test: verify the rate property is accepted and the clock runs.
+        // Exact timing math is covered by the unit test (StopwatchClockTest.TestDoubleRate).
+        AddStep("Set rate to 2× and start", () => { stopwatch.Rate = 2.0; stopwatch.Start(); });
+        AddAssert("Rate is 2×", () => stopwatch.Rate == 2.0);
+        AddAssert("Clock is running", () => stopwatch.IsRunning);
+        AddWaitStep("Observe 2× speed visually", 500);
+        AddStep("Reset rate to 1×", () => stopwatch.Rate = 1.0);
+        AddAssert("Rate is back to 1", () => stopwatch.Rate == 1.0);
+    }
+
+    [Test]
+    public void TestRateChangeDoesNotJumpTime()
+    {
+        // Stop the clock, change rate, assert time is unchanged — no wall-time dependency.
+        AddStep("Start clock", () => stopwatch.Start());
+        AddWaitStep("Accumulate some time", 200);
+        double timeBefore = 0;
+        AddStep("Stop and capture time", () => { stopwatch.Stop(); timeBefore = stopwatch.CurrentTime; });
+        AddAssert("Time did not jump on rate change",
+            () => Math.Abs(stopwatch.CurrentTime - timeBefore) < 1);
+        AddStep("Change rate to 0.5× while stopped", () => stopwatch.Rate = 0.5);
+        AddAssert("Time still unchanged after rate set",
+            () => Math.Abs(stopwatch.CurrentTime - timeBefore) < 1);
+        AddStep("Reset rate", () => { stopwatch.Rate = 1.0; stopwatch.Start(); });
+    }
+
+    [Test]
+    public void TestNegativeRate()
+    {
+        AddStep("Seek to 500 ms, rate -1×, start",
+            () => { stopwatch.Seek(500); stopwatch.Rate = -1.0; stopwatch.Start(); });
+        AddWaitStep("Run 300 ms real time", 300);
+        AddAssert("Time ran backwards", () => stopwatch.CurrentTime < 500);
+        AddStep("Reset rate", () => stopwatch.Rate = 1.0);
+    }
+
+    [Test]
+    public void TestManualClockControl()
+    {
+        AddStep("Set ManualClock to 1000", () => { manualClock.CurrentTime = 1000; manualClock.IsRunning = true; });
+        AddAssert("Manual time = 1000", () => Math.Abs(manualClock.CurrentTime - 1000) < 1);
+        AddStep("Advance to 2500", () => manualClock.CurrentTime = 2500);
+        AddAssert("Manual time = 2500", () => Math.Abs(manualClock.CurrentTime - 2500) < 1);
+        AddStep("Stop manual clock", () => manualClock.IsRunning = false);
+        AddAssert("Manual clock stopped", () => !manualClock.IsRunning);
+    }
+
+    [Test]
+    public void TestFramedClockFollowsSource()
+    {
+        AddStep("Start stopwatch source", () => stopwatch.Start());
+        AddWaitStep("Wait for framing", 200);
+        AddAssert("FramedClock > 0", () => framedClock.CurrentTime > 0);
+        AddAssert("Elapsed > 0", () => framedClock.ElapsedFrameTime > 0);
+    }
+
+    [Test]
+    public void TestGameplayClockLeadIn()
+    {
+        AddStep("Seek gameplay to -500 ms then start",
+            () => { gameplay.Seek(-500); gameplay.Start(); });
+        AddAssert("Time is negative", () => gameplay.CurrentTime < 0);
+        AddAssert("Decoupled from source", () => gameplay.DecoupledClock.IsDecoupled);
+        AddUntilStep("Time crosses zero", () => gameplay.CurrentTime >= 0);
+    }
+
+    [Test]
+    public void TestGameplayClockOffset()
+    {
+        AddStep("Start gameplay at 0", () =>
+        {
+            gameplay.Seek(0);
+            gameplay.Start();
+            fakeTrack.Start();
+            stopwatch.Start();
+        });
+        AddWaitStep("Run briefly", 300);
+        AddStep("Apply +50 ms offset", () => gameplay.Offset = 50);
+        AddAssert("Offset visible", () => gameplay.CurrentTime > gameplay.InterpolatedClock.CurrentTime);
+        AddStep("Remove offset", () => gameplay.Offset = 0);
+    }
+
+    [Test]
+    public void TestInterpolatedClockSmoothing()
+    {
+        AddStep("Start track and gameplay", () =>
+        {
+            fakeTrack.Start();
+            stopwatch.Start();
+            gameplay.Start();
+        });
+        AddWaitStep("Run 1 second", 1000);
+        AddAssert("Interpolated clock is interpolating", () => gameplay.InterpolatedClock.IsInterpolating);
+    }
+
+    private partial class ClockPanel : Container
+    {
+        private readonly SpriteText timeLabel;
+        private readonly SpriteText statusLabel;
+        private readonly Box tickBar;
+        private double tickOffset;
+
+        private const float panel_width  = 200;
+        private const float panel_height = 160;
+
+        public ClockPanel(string name, Color accentColor)
+        {
+            Width  = panel_width;
+            Height = panel_height;
+
+            AddRange(new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Color = Color.Gray
+                },
+                new Box
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 4,
+                    Color = accentColor,
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft
+                },
+                new SpriteText
+                {
+                    Text = name,
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Position = new Vector2(8, 10),
+                    Color = accentColor
+                },
+                timeLabel = new SpriteText
+                {
+                    Text = "0.00 ms",
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Position = new Vector2(8, 34),
+                    Color = Color.White
+                },
+                statusLabel = new SpriteText
+                {
+                    Text = "stopped",
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Position = new Vector2(8, 58),
+                    Color = Color.Gray
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 20,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Masking = true,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Color = Color.Gray
+                        },
+                        tickBar = new Box
+                        {
+                            Width = 4,
+                            Height = 16,
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.Centre,
+                            Color = accentColor
+                        }
+                    }
+                }
+            });
+        }
+
+        public void SetTime(double time, bool running, bool interpolating = false)
+        {
+            timeLabel.Text = $"{time:F1} ms";
+            statusLabel.Text = running ? (interpolating ? "interpolating" : "running") : "stopped";
+            statusLabel.Color = running ? Color.LimeGreen : Color.DimGray;
+            tickOffset = time % 1000;
+            tickBar.X = (float)(tickOffset / 1000.0 * panel_width);
+        }
+    }
+}

--- a/Sakura.Framework/Audio/TrackClock.cs
+++ b/Sakura.Framework/Audio/TrackClock.cs
@@ -1,0 +1,65 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Audio;
+
+/// <summary>
+/// A track clock that use for precise timing.
+/// Adapts an <see cref="IAudioChannel"/> (typically a music track) to the
+/// <see cref="IAdjustableClock"/> contract so it can drive the timing clock chain
+/// (<see cref="DecouplingFramedClock"/> → <see cref="InterpolatingFramedClock"/> /
+/// <see cref="GameplayClock"/>).
+/// The reported time is the audio engine's playback position, which advances in coarse
+/// steps (per audio buffer) — always wrap this clock in the chain above rather than
+/// reading it directly for gameplay.
+/// </summary>
+public class TrackClock : IAdjustableClock
+{
+    private readonly IAudioChannel channel;
+
+    public TrackClock(IAudioChannel channel)
+    {
+        this.channel = channel;
+    }
+
+    public double CurrentTime => channel.CurrentTime;
+
+    public bool IsRunning => channel.IsRunning.Value;
+
+    public double Rate
+    {
+        get => channel.Frequency.Value;
+        set => channel.Frequency.Value = value;
+    }
+
+    public void Start()
+    {
+        if (!channel.IsRunning.Value)
+            channel.Play();
+    }
+
+    public void Stop()
+    {
+        if (channel.IsRunning.Value)
+            channel.Pause();
+    }
+
+    public bool Seek(double position)
+    {
+        if (position < 0 || position > channel.Length)
+            return false;
+
+        channel.CurrentTime = position;
+        return true;
+    }
+
+    public void Reset()
+    {
+        Stop();
+        channel.CurrentTime = 0;
+    }
+
+    public override string ToString() => $"TrackClock: {CurrentTime:F2}ms (running: {IsRunning}, rate: {Rate})";
+}

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -101,6 +101,15 @@ public partial class Container : Drawable
         AddInternal(drawable);
     }
 
+    /// <summary>
+    /// Adds a collection of drawables to this container.
+    /// </summary>
+    public void AddRange(IEnumerable<Drawable> drawables)
+    {
+        foreach (var drawable in drawables)
+            Add(drawable);
+    }
+
     public virtual void Remove(Drawable drawable)
     {
         if (Content != this)

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -91,12 +91,13 @@ public abstract partial class Drawable : Allocation.IDependencyInjectionCandidat
     private bool alwaysPresent;
     private Texture? texture;
     private TextureFillMode fillMode = TextureFillMode.Stretch;
-    private IClock clock = null!;
+    private IFrameBasedClock clock = null!;
 
     /// <summary>
-    /// A clock for this drawable, time is relative to the parent's clock
+    /// A clock for this drawable, time is relative to the parent's clock.
+    /// All times are in milliseconds.
     /// </summary>
-    public virtual IClock Clock
+    public virtual IFrameBasedClock Clock
     {
         get => clock;
         set

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -307,7 +307,7 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
         private readonly IWindow window;
 
         private readonly string name;
-        private readonly IClock clock;
+        private readonly IFrameBasedClock clock;
         private readonly Color baseColor;
         private readonly Func<double> getTargetHz;
 
@@ -334,7 +334,7 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
 
         private PerformanceOverlayState currentState;
 
-        public ThreadStatisticsDisplay(string name, IClock clock, Color baseColor, AppHost host, Func<double> getTargetHz)
+        public ThreadStatisticsDisplay(string name, IFrameBasedClock clock, Color baseColor, AppHost host, Func<double> getTargetHz)
         {
             this.name = name;
             this.clock = clock;

--- a/Sakura.Framework/Graphics/Video/VideoSprite.cs
+++ b/Sakura.Framework/Graphics/Video/VideoSprite.cs
@@ -10,6 +10,7 @@ using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Statistic;
+using Sakura.Framework.Timing;
 
 namespace Sakura.Framework.Graphics.Video;
 
@@ -38,6 +39,7 @@ public partial class VideoSprite : Drawable, IDisposable
     private readonly string? filePath;
     private readonly Stream? stream;
     private readonly VideoDecoder? providedDecoder;
+    private bool syncToClock;
 
     private VideoDecoder decoder = null!;
     private IShader? videoShader;
@@ -67,19 +69,43 @@ public partial class VideoSprite : Drawable, IDisposable
     public bool Buffering { get; private set; }
 
     /// <summary>
+    /// When <see langword="true"/>, video playback time is driven by the drawable's
+    /// <see cref="Clock"/> rather than the internal real-time accumulator.
+    /// This keeps the video frame perfectly in sync with whatever clock is assigned to
+    /// this drawable — an audio track clock, the gameplay clock, or a rate-scaled test
+    /// clock without any manual resync loop. When false (default) the video is self-contained
+    /// and uses its own elapsed-time accumulator.
+    /// <remarks>
+    /// <see cref="Seek"/> and <see cref="IsPlaying"/> still work normally when enabled.
+    /// The internal accumulator is not used, so there is no drift between the video
+    /// and the master clock regardless of frame timing jitter.
+    /// </remarks>
+    /// </summary>
+    public bool SyncToClock
+    {
+        get => syncToClock;
+        set
+        {
+            syncToClock = value;
+            // Reset the jump-detection baseline so the first frame after switching
+            // modes doesn't falsely look like a seek.
+            lastSyncTime = double.NaN;
+        }
+    }
+
+    /// <summary>
     /// Gets the current playback position of the video in milliseconds.
     /// </summary>
     /// <remarks>
-    /// By default, this is driven by an internal clock that accumulates elapsed real-time
-    /// since the last seek (<c>seekBaseMs</c> + <c>elapsedMs</c>).
+    /// When <see cref="SyncToClock"/> is <see langword="false"/> (default), this is
+    /// driven by an internal accumulator: <c>seekBaseMs + elapsedMs</c>.
+    /// When <see cref="SyncToClock"/> is <see langword="true"/>, this returns
+    /// <c>Clock.CurrentTime</c> directly — no manual resync code needed.
     /// <para>
-    /// This property is <see langword="virtual"/> so it can be overridden to synchronize video
-    /// playback with an external master clock (such as an audio track's time). When overridden,
-    /// the video's update loop will automatically drop or hold frames to maintain perfect sync
-    /// with the provided time.
+    /// This property is <see langword="virtual"/> for easier customization.
     /// </para>
     /// </remarks>
-    public virtual double CurrentTime => seekBaseMs + elapsedMs;
+    public virtual double CurrentTime => SyncToClock ? Clock.CurrentTime : seekBaseMs + elapsedMs;
 
     public double Duration => decoder?.Duration ?? 0;
     public double OriginalWidth => decoder?.Width ?? 0;
@@ -167,6 +193,10 @@ public partial class VideoSprite : Drawable, IDisposable
         seekBaseMs = absoluteMs;
         elapsedMs = 0;
 
+        // Reset jump-detection baseline so the frame right after a seek is not
+        // mistaken for another seek in SyncToClock mode.
+        lastSyncTime = double.NaN;
+
         // The decoder's Seek() takes a raw PTS value.
         // If we know ptsBias (the container's PTS offset), use it.
         // Otherwise pass absoluteMs directly — the decoder will seek close enough
@@ -184,19 +214,51 @@ public partial class VideoSprite : Drawable, IDisposable
         ptsBias = double.NaN;
     }
 
+    /// <summary>
+    /// Last clock time seen in <see cref="SyncToClock"/> mode, used to detect external seeks.
+    /// </summary>
+    private double lastSyncTime = double.NaN;
+
+    /// <summary>
+    /// How far the clock must jump (in ms) before it is treated as a seek rather
+    /// than normal elapsed time in <see cref="SyncToClock"/> mode.
+    /// Covers one worst-case audio buffer step (~10 ms) plus a frame at 30 fps (~33 ms).
+    /// </summary>
+    private const double sync_seek_threshold_ms = 50.0;
+
     public override void Update()
     {
         base.Update();
 
         if (!IsLoaded || decoder == null) return;
 
-        // Advance elapsed time. Cap per-update advance at 100ms to avoid
-        // skipping frames during GC pauses or OS scheduler hiccups.
-        if (IsPlaying)
+        if (syncToClock)
         {
-            elapsedMs += Math.Min(Clock.ElapsedFrameTime, 100.0);
-            if (Duration > 0 && seekBaseMs + elapsedMs >= Duration)
-                elapsedMs = Duration - seekBaseMs;
+            double clockTime = Clock.CurrentTime;
+
+            if (!double.IsNaN(lastSyncTime))
+            {
+                double delta = clockTime - lastSyncTime;
+
+                // A jump larger than the threshold (backwards or large forward) means the
+                // master clock was seeked externally — flush and re-anchor the decoder.
+                if (Math.Abs(delta) > sync_seek_threshold_ms)
+                    seekTo(Math.Max(0, clockTime));
+            }
+
+            lastSyncTime = clockTime;
+            // No accumulator to advance — CurrentTime returns Clock.CurrentTime directly.
+        }
+        else
+        {
+            // Internal accumulator mode: advance elapsed time, capped at 100 ms to
+            // avoid large jumps during GC pauses or OS scheduler hiccups.
+            if (IsPlaying)
+            {
+                elapsedMs += Math.Min(Clock.ElapsedFrameTime, 100.0);
+                if (Duration > 0 && seekBaseMs + elapsedMs >= Duration)
+                    elapsedMs = Duration - seekBaseMs;
+            }
         }
 
         // Pull newly decoded frames and schedule their GL upload on the draw thread.

--- a/Sakura.Framework/Input/KeyEvent.cs
+++ b/Sakura.Framework/Input/KeyEvent.cs
@@ -1,6 +1,8 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using Sakura.Framework.Timing;
+
 namespace Sakura.Framework.Input;
 
 /// <summary>
@@ -23,12 +25,25 @@ public readonly struct KeyEvent
     /// </summary>
     public readonly bool IsRepeat;
 
+    /// <summary>
+    /// The time at which this event physically occurred, in milliseconds on the shared
+    /// <see cref="TimeSource"/> timeline. Captured from the OS event
+    /// timestamp where available, making it more accurate than the time the event is processed.
+    /// <see cref="double.NaN"/> when no timestamp was available (e.g. synthesized test input).
+    /// <remarks>
+    /// For rhythm game implementation, use <see cref="GameplayClock.GetTimeAt"/> to translate this
+    /// into gameplay time for hit judgement.
+    /// </remarks>
+    /// </summary>
+    public readonly double Timestamp;
+
     public bool ControlPressed => (Modifiers & KeyModifiers.Control) != 0;
 
-    public KeyEvent(Key key, KeyModifiers modifiers, bool isRepeat)
+    public KeyEvent(Key key, KeyModifiers modifiers, bool isRepeat, double timestamp = double.NaN)
     {
         Key = key;
         Modifiers = modifiers;
         IsRepeat = isRepeat;
+        Timestamp = timestamp;
     }
 }

--- a/Sakura.Framework/Input/MouseButtonEvent.cs
+++ b/Sakura.Framework/Input/MouseButtonEvent.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file for full license text.
 
 using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
 
 namespace Sakura.Framework.Input;
 
@@ -12,11 +13,19 @@ public readonly struct MouseButtonEvent : IMouseEvent
     public int Clicks { get; }
     public Vector2 ScreenSpaceMousePosition => MouseState.Position;
 
-    public MouseButtonEvent(MouseState mouseState, MouseButton button, int clicks)
+    /// <summary>
+    /// The time at which this event physically occurred, in milliseconds on the shared
+    /// <see cref="TimeSource"/> timeline. Captured from the OS event
+    /// timestamp where available. <see cref="double.NaN"/> when no timestamp was available.
+    /// </summary>
+    public double Timestamp { get; }
+
+    public MouseButtonEvent(MouseState mouseState, MouseButton button, int clicks, double timestamp = double.NaN)
     {
         MouseState = mouseState;
         Button = button;
         Clicks = clicks;
+        Timestamp = timestamp;
     }
 
     public override string ToString()

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -38,10 +38,10 @@ public abstract class AppHost : IDisposable
 
     public Reactive<FrameSync> FrameLimiter { get; set; }
     public Reactive<ExecutionMode> ExecutionMode { get; set; }
-    protected internal IClock UpdateClock { get; private set; }
-    protected internal IClock DrawClock { get; private set; }
-    protected internal IClock AudioClock { get; private set; }
-    public IClock InputClock { get; private set; }
+    protected internal IFrameBasedClock UpdateClock { get; private set; }
+    protected internal IFrameBasedClock DrawClock { get; private set; }
+    protected internal IFrameBasedClock AudioClock { get; private set; }
+    public IFrameBasedClock InputClock { get; private set; }
     private readonly ThrottledFrameClock soundClock = new ThrottledFrameClock(1000);
     private double lastUpdateTime;
     private readonly Stopwatch appLoopStopwatch = new Stopwatch();
@@ -569,7 +569,7 @@ public abstract class AppHost : IDisposable
     /// </summary>
     protected virtual void PerformInput()
     {
-        InputClock.Update();
+        InputClock.ProcessFrame();
     }
 
     /// <summary>

--- a/Sakura.Framework/Platform/SDLWindow.cs
+++ b/Sakura.Framework/Platform/SDLWindow.cs
@@ -14,6 +14,7 @@ using Sakura.Framework.Input;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Reactive;
+using Sakura.Framework.Timing;
 using SDL;
 using static SDL.SDL3;
 using SakuraCursorState = Sakura.Framework.Input.CursorState;
@@ -72,6 +73,9 @@ public class SDLWindow : IWindow
 
     // SDL_WINDOWPOS_CENTERED — kept as a local constant (it's a C macro: SDL_WINDOWPOS_CENTERED_MASK | 0).
     private const int windowpos_centered = 0x2FFF0000;
+
+    // Offset mapping SDL's event timestamp timeline onto the shared TimeSource timeline (ms).
+    private double sdlTimestampOffset;
 
     public SDLWindow()
     {
@@ -218,6 +222,11 @@ public class SDLWindow : IWindow
         }
 
         int version = SDL_GetVersion();
+
+        // Anchor SDL's event timestamp timeline (SDL_GetTicksNS, ns since SDL init) onto the
+        // framework's shared TimeSource timeline so input event timestamps are directly
+        // comparable with every framework clock.
+        sdlTimestampOffset = TimeSource.CurrentTime - SDL_GetTicksNS() / 1_000_000.0;
 
         Logger.Verbose("🪟 SDL initialized");
         Logger.Verbose($"SDL Version: {version / 1000000}.{version / 1000 % 1000}.{version % 1000}");
@@ -720,12 +729,12 @@ public class SDLWindow : IWindow
         if ((modState & SDL_Keymod.SDL_KMOD_SHIFT) != 0) modifiers |= KeyModifiers.Shift;
         if ((modState & SDL_Keymod.SDL_KMOD_ALT) != 0) modifiers |= KeyModifiers.Alt;
 
-        // Note: keyboardEvent.timestamp is nanosecond-resolution (SDL_GetTicksNS timeline).
-        // When the input pipeline gains timestamped events (see Docs/Clock-Timing-Review.md),
-        // this is the value to carry through.
         bool isRepeat = keyboardEvent.repeat;
 
-        action.Invoke(new KeyEvent(key, modifiers, isRepeat));
+        // The event carries a nanosecond hardware/OS timestamp — far closer to the physical
+        // press than our processing time. Mapped onto the shared TimeSource timeline so
+        // gameplay can judge against it (see GameplayClock.GetTimeAt).
+        action.Invoke(new KeyEvent(key, modifiers, isRepeat, convertEventTimestamp(keyboardEvent.timestamp)));
     }
 
     private void handleMouseButtonEvent(SDL_MouseButtonEvent buttonEvent, Action<SakuraMouseButtonEvent> action)
@@ -735,8 +744,14 @@ public class SDLWindow : IWindow
         // SDL3 reports mouse coordinates as floats (subpixel precision).
         mouseState.Position = new Vector2(buttonEvent.x, buttonEvent.y);
         mouseState.SetPressed(button, buttonEvent.down);
-        action.Invoke(new Input.MouseButtonEvent(mouseState.Clone(), button, buttonEvent.clicks));
+        action.Invoke(new SakuraMouseButtonEvent(mouseState.Clone(), button, buttonEvent.clicks, convertEventTimestamp(buttonEvent.timestamp)));
     }
+
+    /// <summary>
+    /// Converts an SDL event timestamp (nanoseconds on the SDL_GetTicksNS timeline)
+    /// onto the shared <see cref="TimeSource"/> timeline in milliseconds.
+    /// </summary>
+    private double convertEventTimestamp(ulong timestampNs) => timestampNs / 1_000_000.0 + sdlTimestampOffset;
 
     private void handleMouseMotionEvent(SDL_MouseMotionEvent motionEvent)
     {

--- a/Sakura.Framework/Testing/TestBrowserApp.cs
+++ b/Sakura.Framework/Testing/TestBrowserApp.cs
@@ -37,10 +37,18 @@ public partial class TestBrowserApp : App
     private Container headerContainer;
     private ScrollableContainer stepScrollContainer;
     private BasicSliderBar<double> volumeSlider;
+    private BasicSliderBar<double> clockRateSlider;
+    private SpriteText clockRateLabel;
     private BasicCheckbox autoRunCheckbox;
     private BasicTextBox searchTextBox;
 
     private readonly Assembly testAssembly;
+
+    /// <summary>
+    /// A rate-adjustable clock that drives all test content.
+    /// Wraps the app clock so the sidebars and header are unaffected by rate changes.
+    /// </summary>
+    private FramedClock testClock = null!;
 
     private const int sidebar_width = 150;
 
@@ -50,6 +58,19 @@ public partial class TestBrowserApp : App
 
     private bool isWaitingForStep;
     private double stepWaitStartTime;
+
+    /// <summary>
+    /// Incremented every time a new test is loaded. Stale <see cref="runNextStep"/>
+    /// callbacks captured an older generation and exit immediately, preventing
+    /// double-speed execution when a test is switched mid-run.
+    /// </summary>
+    private int runGeneration;
+
+    /// <summary>
+    /// Initial rate for the test clock. Useful for headless CI runs where you want
+    /// tests to execute faster than real-time (e.g. pass 2.0 for 2× speed).
+    /// </summary>
+    public double InitialClockRate { get; init; } = 1.0;
 
     public TestBrowserApp(Assembly testAssembly = null!)
     {
@@ -61,6 +82,9 @@ public partial class TestBrowserApp : App
         TestScene.IsVisualRunner = true;
         base.Load();
 
+        // Build the rate-adjustable clock that drives test content only.
+        // InitialClockRate can be set to >1 for headless/CI runs to speed up tests.
+        testClock = new FramedClock(Clock) { Rate = InitialClockRate };
         testContentContainer = new Container
         {
             RelativeSizeAxes = Axes.Both,
@@ -128,7 +152,7 @@ public partial class TestBrowserApp : App
             if (e.NewValue)
             {
                 currentAutoRunStep = 0;
-                runNextStep();
+                runNextStep(runGeneration);
             }
         };
 
@@ -162,6 +186,43 @@ public partial class TestBrowserApp : App
         volumeSlider.Current.Value = volumeReactive.Value;
 
         volumeReactive.BindTo(volumeSlider.Current);
+
+        headerFlow.Add(new SpriteText
+        {
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
+            Text = "Rate",
+            Font = FontUsage.Default.With(size: 15),
+            Margin = new MarginPadding { Left = 10, Right = 10 }
+        });
+
+        headerFlow.Add(clockRateSlider = new BasicSliderBar<double>
+        {
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
+            Size = new Vector2(120, 20),
+            MinValue = 0.0,
+            MaxValue = 4.0
+        });
+
+        clockRateSlider.Current.Value = InitialClockRate;
+
+        headerFlow.Add(clockRateLabel = new SpriteText
+        {
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
+            Text = "1.00×",
+            Font = FontUsage.Default.With(size: 14),
+            Color = Color.LightGreen,
+            Margin = new MarginPadding { Left = 4 },
+            Width = 45
+        });
+
+        clockRateSlider.Current.ValueChanged += e =>
+        {
+            testClock.Rate = e.NewValue;
+            clockRateLabel.Text = $"{e.NewValue:F2}×";
+        };
 
         headerContainer.Add(headerFlow);
         Add(headerContainer);
@@ -314,6 +375,12 @@ public partial class TestBrowserApp : App
         };
     }
 
+    public override void Update()
+    {
+        base.Update();
+        testClock.ProcessFrame();
+    }
+
     private void loadTestClasses(string searchQuery = "")
     {
         var testGroups = testAssembly.GetTypes()
@@ -376,10 +443,15 @@ public partial class TestBrowserApp : App
             stepsFlow.Remove(child);
         }
 
+        // cancel any in-flight runNextStep callbacks from the previous test.
+        runGeneration++;
+        isWaitingForStep = false;
+        currentAutoRunStep = 0;
+
         currentTest = (TestScene)Activator.CreateInstance(testSceneType);
         testContentContainer.Add(currentTest);
 
-        currentTest.Clock = new FramedClock(Clock, true);
+        currentTest.Clock = new FramedClock(testClock, true);
         currentTest.CurrentStepContext = StepContext.OneTimeSetUp;
         currentTest.RunOneTimeSetUpMethods();
 
@@ -470,7 +542,7 @@ public partial class TestBrowserApp : App
         if (autoRunEnabled)
         {
             currentAutoRunStep = 0;
-            Scheduler.AddDelayed(runNextStep, 200);
+            scheduleNextStep(200, runGeneration);
         }
     }
 
@@ -513,8 +585,17 @@ public partial class TestBrowserApp : App
         }
     }
 
-    private void runNextStep()
+    private void scheduleNextStep(double delayMs, int generation)
     {
+        double rate = testClock.Rate > 0 ? testClock.Rate : 1.0;
+        Scheduler?.AddDelayed(() => runNextStep(generation), delayMs / rate);
+    }
+
+    private void runNextStep(int generation)
+    {
+        // Stale callback — a new test was loaded after this was scheduled.
+        if (generation != runGeneration) return;
+
         if (!autoRunEnabled || currentTest == null || currentAutoRunStep >= currentTest.Steps.Count)
             return;
 
@@ -530,14 +611,14 @@ public partial class TestBrowserApp : App
         if (step.IsLabel)
         {
             currentAutoRunStep++;
-            Scheduler.AddDelayed(runNextStep, 10);
+            scheduleNextStep(10, generation);
             return;
         }
 
         if (step.GetType().IsGenericType && step.GetType().GetGenericTypeDefinition() == typeof(SliderStep<>))
         {
             currentAutoRunStep++;
-            Scheduler.AddDelayed(runNextStep, 10);
+            scheduleNextStep(10, generation);
             return;
         }
 
@@ -556,7 +637,7 @@ public partial class TestBrowserApp : App
 
                     if (repeatStep.CurrentIteration < repeatStep.RepeatCount)
                     {
-                        Scheduler?.AddDelayed(runNextStep, 10);
+                        scheduleNextStep(10, generation);
                         return;
                     }
 
@@ -595,7 +676,7 @@ public partial class TestBrowserApp : App
 
             if (currentWaitStep.WaitTime > 0 && elapsed < currentWaitStep.WaitTime)
             {
-                Scheduler?.AddDelayed(runNextStep, 10);
+                scheduleNextStep(10, generation);
                 return;
             }
 
@@ -608,7 +689,7 @@ public partial class TestBrowserApp : App
                     autoRunEnabled.Value = false;
                     return;
                 }
-                Scheduler?.AddDelayed(runNextStep, 10);
+                scheduleNextStep(10, generation);
                 return;
             }
 
@@ -617,7 +698,7 @@ public partial class TestBrowserApp : App
         }
 
         currentAutoRunStep++;
-        Scheduler?.AddDelayed(runNextStep, 200);
+        scheduleNextStep(200, generation);
     }
 
     private void generateStepVisual(ActionStep step)

--- a/Sakura.Framework/Testing/TestScene.cs
+++ b/Sakura.Framework/Testing/TestScene.cs
@@ -12,6 +12,7 @@ using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Platform;
+using Sakura.Framework.Timing;
 using Vector2 = Sakura.Framework.Maths.Vector2;
 
 namespace Sakura.Framework.Testing;
@@ -23,6 +24,14 @@ public abstract partial class TestScene : Container
     /// Tells the TestScene to bypass spinning up a headless host because the visual is running it.
     /// </summary>
     public static bool IsVisualRunner { get; set; }
+
+    /// <summary>
+    /// Clock rate multiplier used by the headless NUnit runner.
+    /// The entire test clock runs at this rate, so transforms, waits, and all drawable
+    /// timing are uniformly scaled. Set to 2.0 to run tests at 2× speed.
+    /// Default is 2.0.
+    /// </summary>
+    public static double HeadlessClockRate { get; set; } = 2.0;
 
     public IReadOnlyList<TestStep> Steps => steps;
     private readonly List<TestStep> steps = new List<TestStep>();
@@ -244,6 +253,10 @@ public abstract partial class TestScene : Container
 
         private bool isExecutingStep;
         private double currentStepStartTime;
+        private FramedClock? scaledClock;
+
+        // The clock used to measure WaitStep elapsed time, same as scaledClock when rate != 1.
+        private IFrameBasedClock stepClock = null!;
 
         public Exception? TestException { get; private set; }
 
@@ -263,11 +276,28 @@ public abstract partial class TestScene : Container
             Logger.Debug($"Starting test scene: {testScene.GetType().Name}");
             Logger.Debug($"Resource assembly: {ResourceAssembly.FullName}");
             Logger.Debug($"Resource root namespace: {ResourceRootNamespace}");
+
+            // Wrap the app clock in a rate-scaled FramedClock and assign it to the
+            // test scene only. The app's own clock is left alone so base.Update() and
+            // the host loop continue to work normally. stepClock is used to measure
+            // WaitStep elapsed time so it matches the scene's scaled time.
+            if (HeadlessClockRate != 1.0)
+            {
+                scaledClock = new FramedClock(Clock) { Rate = HeadlessClockRate };
+                testScene.Clock = scaledClock;
+                stepClock = scaledClock;
+            }
+            else
+            {
+                stepClock = Clock;
+            }
+
             Add(testScene);
         }
 
         public override void Update()
         {
+            scaledClock?.ProcessFrame();
             base.Update();
 
             if (TestException != null) return;
@@ -285,7 +315,7 @@ public abstract partial class TestScene : Container
             if (!isExecutingStep)
             {
                 isExecutingStep = true;
-                currentStepStartTime = Clock.CurrentTime;
+                currentStepStartTime = stepClock.CurrentTime;
 
                 Logger.Verbose($"Executing test step {currentStepIndex + 1}/{testScene.Steps.Count}: {step.Description}");
 
@@ -317,7 +347,7 @@ public abstract partial class TestScene : Container
                 }
             }
 
-            double elapsed = Clock.CurrentTime - currentStepStartTime;
+            double elapsed = stepClock.CurrentTime - currentStepStartTime;
 
             if (step is WaitStep waitStep)
             {

--- a/Sakura.Framework/Timing/Clock.cs
+++ b/Sakura.Framework/Timing/Clock.cs
@@ -1,45 +1,74 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
-using System.Diagnostics;
-
 namespace Sakura.Framework.Timing;
 
 /// <summary>
-/// A high-precision clock implementation.
+/// A framed clock backed by the process-wide <see cref="TimeSource"/>.
+/// A <see cref="Clock"/> that has never been stopped reports the shared timeline exactly,
+/// meaning the times of any two such clocks are directly comparable across threads.
+/// Stopping a clock excludes the paused duration from its reported time.
 /// </summary>
-public class Clock : IClock
+public class Clock : IFrameBasedClock
 {
-    private readonly Stopwatch stopwatch = new Stopwatch();
-    private double lastTime;
+    /// <summary>
+    /// Total time excluded from the shared timeline due to this clock being stopped.
+    /// </summary>
+    private double pausedTotal;
+
+    /// <summary>
+    /// The shared-timeline time at which the clock last stopped (valid while stopped).
+    /// </summary>
+    private double stoppedAt;
+
     private int frames;
     private double fpsAccumulator;
 
     public double CurrentTime { get; private set; }
     public double ElapsedFrameTime { get; private set; }
     public double FramesPerSecond { get; private set; }
-    public bool IsRunning => stopwatch.IsRunning;
+    public double Rate => 1.0;
+    public bool IsRunning { get; private set; }
 
     public Clock(bool start = false)
     {
+        stoppedAt = TimeSource.CurrentTime;
         if (start)
             Start();
     }
 
     public void Start()
     {
-        stopwatch.Start();
-        lastTime = stopwatch.Elapsed.TotalMilliseconds;
+        if (IsRunning) return;
+
+        pausedTotal += TimeSource.CurrentTime - stoppedAt;
+        // Anchor so the first frame after starting doesn't report a huge elapsed time.
+        CurrentTime = TimeSource.CurrentTime - pausedTotal;
+        IsRunning = true;
     }
 
-    public void Stop() => stopwatch.Stop();
-
-    public void Update()
+    public void Stop()
     {
-        double currentTimeMs = stopwatch.Elapsed.TotalMilliseconds;
-        ElapsedFrameTime = currentTimeMs - lastTime;
-        CurrentTime = currentTimeMs;
-        lastTime = currentTimeMs;
+        if (!IsRunning) return;
+
+        stoppedAt = TimeSource.CurrentTime;
+        IsRunning = false;
+    }
+
+    /// <summary>
+    /// Takes this frame's time snapshot. Call once per frame.
+    /// </summary>
+    public void ProcessFrame()
+    {
+        if (!IsRunning)
+        {
+            ElapsedFrameTime = 0;
+            return;
+        }
+
+        double newTime = TimeSource.CurrentTime - pausedTotal;
+        ElapsedFrameTime = newTime - CurrentTime;
+        CurrentTime = newTime;
 
         frames++;
         fpsAccumulator += ElapsedFrameTime;
@@ -50,6 +79,11 @@ public class Clock : IClock
             fpsAccumulator -= 1000;
         }
     }
+
+    /// <summary>
+    /// Alias of <see cref="ProcessFrame"/>, kept for existing call sites.
+    /// </summary>
+    public void Update() => ProcessFrame();
 
     public override string ToString()
     {

--- a/Sakura.Framework/Timing/DecouplingFramedClock.cs
+++ b/Sakura.Framework/Timing/DecouplingFramedClock.cs
@@ -1,0 +1,157 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using Sakura.Framework.Utilities;
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// A framed clock that can keep running when its adjustable source cannot.
+/// While the source is playing, this clock reports the source's time. While the source is
+/// stopped (or the time is outside the source's valid range, e.g. negative lead-in time
+/// before an audio track starts), the clock continues running from an internal real-time
+/// reference. When the decoupled time re-enters the source's valid range, the source is
+/// sought to the current time and started automatically.
+/// </summary>
+public class DecouplingFramedClock : IFrameBasedClock, IAdjustableClock, ISourceChangeableClock
+{
+    private IAdjustableClock source;
+    private readonly IClock reference;
+    private double lastReferenceTime;
+    private bool isRunning;
+    private double rate = 1.0;
+
+    public IClock Source => source;
+
+    public double CurrentTime { get; private set; }
+    public double ElapsedFrameTime { get; private set; }
+    public double FramesPerSecond => 0;
+    public bool IsRunning => isRunning;
+
+    /// <summary>
+    /// Whether time is currently being driven by the internal reference rather than the source.
+    /// </summary>
+    public bool IsDecoupled { get; private set; }
+
+    public double Rate
+    {
+        get => rate;
+        set
+        {
+            rate = value;
+            source.Rate = value;
+        }
+    }
+
+    /// <param name="source">The adjustable source (typically a track clock).</param>
+    /// <param name="referenceClock">
+    /// Real-time reference for decoupled operation. Defaults to the shared
+    /// <see cref="TimeSource"/> timeline; tests can pass a <see cref="ManualClock"/>.
+    /// </param>
+    public DecouplingFramedClock(IAdjustableClock source, IClock? referenceClock = null)
+    {
+        this.source = source;
+        reference = referenceClock ?? new TimeSourceClock();
+        lastReferenceTime = reference.CurrentTime;
+        CurrentTime = source.CurrentTime;
+    }
+
+    public void ChangeSource(IClock newSource)
+    {
+        if (newSource is not IAdjustableClock adjustable)
+            throw new ArgumentException($"Source of a {nameof(DecouplingFramedClock)} must be an {nameof(IAdjustableClock)}.", nameof(newSource));
+
+        source = adjustable;
+        CurrentTime = adjustable.CurrentTime;
+        // Reset the reference baseline so no stale elapsed from the old source
+        // leaks into the first ProcessFrame with the new source.
+        lastReferenceTime = reference.CurrentTime;
+    }
+
+    public void Start()
+    {
+        if (isRunning) return;
+
+        isRunning = true;
+
+        if (CurrentTime >= 0)
+        {
+            source.Seek(CurrentTime);
+            source.Start();
+        }
+        // If we're in negative (lead-in) time, ProcessFrame runs decoupled and will
+        // start the source automatically when time crosses zero.
+    }
+
+    public void Stop()
+    {
+        if (!isRunning) return;
+
+        isRunning = false;
+        source.Stop();
+    }
+
+    public bool Seek(double position)
+    {
+        CurrentTime = position;
+
+        if (position >= 0)
+        {
+            source.Seek(position);
+            if (isRunning && !source.IsRunning)
+                source.Start();
+        }
+        else
+        {
+            source.Stop();
+            source.Seek(0);
+        }
+
+        return true;
+    }
+
+    public void Reset()
+    {
+        Stop();
+        Seek(0);
+    }
+
+    public void ProcessFrame()
+    {
+        double lastTime = CurrentTime;
+        double referenceTime = reference.CurrentTime;
+        double referenceElapsed = referenceTime - lastReferenceTime;
+        lastReferenceTime = referenceTime;
+
+        if (!isRunning)
+        {
+            ElapsedFrameTime = 0;
+            return;
+        }
+
+        if (source.IsRunning)
+        {
+            // Source-driven: report the source's time directly.
+            CurrentTime = source.CurrentTime;
+            IsDecoupled = false;
+        }
+        else
+        {
+            // Decoupled: advance from the real-time reference at our rate.
+            CurrentTime += referenceElapsed * rate;
+            IsDecoupled = true;
+
+            // Crossed into the source's valid range — hand over to the source.
+            if (Precision.AlmostBigger(CurrentTime, 0))
+            {
+                source.Seek(Math.Max(0, CurrentTime));
+                source.Start();
+            }
+        }
+
+        ElapsedFrameTime = CurrentTime - lastTime;
+    }
+
+    public override string ToString() => $"DecouplingFramedClock: {CurrentTime:F2}ms (decoupled: {IsDecoupled}, running: {isRunning})";
+}

--- a/Sakura.Framework/Timing/FramedClock.cs
+++ b/Sakura.Framework/Timing/FramedClock.cs
@@ -5,9 +5,10 @@ namespace Sakura.Framework.Timing;
 
 /// <summary>
 /// A clock that is "framed" to a source clock.
-/// It processes time from its source, allow for local time manipulations like rate changes and pauses.
+/// It processes time from its source once per frame, allowing local time manipulations
+/// like rate changes and pauses. All times are in milliseconds.
 /// </summary>
-public class FramedClock : IClock
+public class FramedClock : IFrameBasedClock, ISourceChangeableClock
 {
     private IClock source;
     private double lastSourceTime;
@@ -22,12 +23,14 @@ public class FramedClock : IClock
         }
     }
 
-    public double CurrentTime { get; set; }
+    public void ChangeSource(IClock newSource) => Source = newSource;
+
+    public double CurrentTime { get; private set; }
     public double ElapsedFrameTime { get; private set; }
     public double Rate { get; set; } = 1.0;
     public bool IsRunning { get; private set; } = true;
 
-    public double FramesPerSecond => source.FramesPerSecond;
+    public double FramesPerSecond => (source as IFrameBasedClock)?.FramesPerSecond ?? 0;
 
     public FramedClock(IClock source, bool startFromZero = false)
     {
@@ -43,7 +46,7 @@ public class FramedClock : IClock
     /// Updates the clock's current time based on the source clock.
     /// This should be called once per frame.
     /// </summary>
-    public void Update()
+    public void ProcessFrame()
     {
         if (IsRunning)
         {
@@ -58,7 +61,10 @@ public class FramedClock : IClock
         lastSourceTime = source.CurrentTime;
     }
 
-    public void ProcessFrame() => Update();
+    /// <summary>
+    /// Alias of <see cref="ProcessFrame"/>, kept for existing call sites.
+    /// </summary>
+    public void Update() => ProcessFrame();
 
     public override string ToString() => $"FramedClock: {CurrentTime:F2}ms (Rate: {Rate}, Running: {IsRunning})";
 }

--- a/Sakura.Framework/Timing/GameplayClock.cs
+++ b/Sakura.Framework/Timing/GameplayClock.cs
@@ -1,0 +1,92 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// The recommended master clock for rhythm gameplay.
+/// <para>
+/// Composes the full precision chain over an audio source:
+/// source → <see cref="DecouplingFramedClock"/> (lead-in/pause/seek support) →
+/// <see cref="InterpolatingFramedClock"/> (smooths the coarse audio position) →
+/// a per-frame snapshot with a user <see cref="Offset"/> applied.
+/// </para>
+/// <para>
+/// Call <see cref="ProcessFrame"/> once per update frame (e.g. in your gameplay screen's
+/// <c>Update</c>), then read <see cref="CurrentTime"/> everywhere. To judge an input event,
+/// use <see cref="GetTimeAt"/> with the event's shared-timeline timestamp, this removes
+/// the latency between the physical press and the frame that processes it.
+/// </para>
+/// </summary>
+public class GameplayClock : IFrameBasedClock, IAdjustableClock
+{
+    private readonly DecouplingFramedClock decoupled;
+    private readonly InterpolatingFramedClock interpolated;
+    private double lastReferenceTime;
+    private readonly IClock reference;
+
+    /// <summary>
+    /// A constant offset in milliseconds added to the reported time, used for user audio
+    /// calibration (positive values make events register as earlier relative to the music).
+    /// </summary>
+    public double Offset { get; set; }
+
+    /// <summary>
+    /// The decoupling stage, exposed for diagnostics.
+    /// </summary>
+    public DecouplingFramedClock DecoupledClock => decoupled;
+
+    /// <summary>
+    /// The interpolation stage, exposed for diagnostics and error tuning
+    /// (<see cref="InterpolatingFramedClock.AllowableErrorMilliseconds"/>).
+    /// </summary>
+    public InterpolatingFramedClock InterpolatedClock => interpolated;
+
+    public double CurrentTime => interpolated.CurrentTime + Offset;
+    public double ElapsedFrameTime => interpolated.ElapsedFrameTime;
+    public double FramesPerSecond => 0;
+    public bool IsRunning => decoupled.IsRunning;
+
+    public double Rate
+    {
+        get => decoupled.Rate;
+        set => decoupled.Rate = value;
+    }
+
+    /// <param name="source">The adjustable audio source clock (e.g. a <see cref="Sakura.Framework.Audio.TrackClock"/>).</param>
+    /// <param name="referenceClock">
+    /// Real-time reference for both stages. Defaults to the shared <see cref="TimeSource"/>
+    /// timeline; tests can pass a <see cref="ManualClock"/> for determinism.
+    /// </param>
+    public GameplayClock(IAdjustableClock source, IClock? referenceClock = null)
+    {
+        reference = referenceClock ?? new TimeSourceClock();
+        decoupled = new DecouplingFramedClock(source, reference);
+        interpolated = new InterpolatingFramedClock(decoupled, reference);
+        lastReferenceTime = reference.CurrentTime;
+    }
+
+    public void ProcessFrame()
+    {
+        lastReferenceTime = reference.CurrentTime;
+        decoupled.ProcessFrame();
+        interpolated.ProcessFrame();
+    }
+
+    /// <summary>
+    /// Translates a timestamp on the shared <see cref="TimeSource"/> timeline (e.g. an input
+    /// event's <c>Timestamp</c>) into this clock's gameplay time, compensating for the delay
+    /// between when the event physically happened and the current frame.
+    /// </summary>
+    /// <param name="sharedTimelineTime">A time on the shared timeline, in milliseconds.</param>
+    /// <returns>The gameplay time at which the event occurred.</returns>
+    public double GetTimeAt(double sharedTimelineTime)
+        => CurrentTime - (lastReferenceTime - sharedTimelineTime) * Rate;
+
+    public void Start() => decoupled.Start();
+    public void Stop() => decoupled.Stop();
+    public bool Seek(double position) => decoupled.Seek(position);
+    public void Reset() => decoupled.Reset();
+
+    public override string ToString() => $"GameplayClock: {CurrentTime:F2}ms (offset: {Offset}, rate: {Rate}, running: {IsRunning})";
+}

--- a/Sakura.Framework/Timing/IAdjustableClock.cs
+++ b/Sakura.Framework/Timing/IAdjustableClock.cs
@@ -1,0 +1,37 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// A clock whose playback can be controlled: started, stopped, sought, and rate-adjusted.
+/// </summary>
+public interface IAdjustableClock : IClock
+{
+    /// <summary>
+    /// Starts (or resumes) the clock.
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// Stops (pauses) the clock at its current time.
+    /// </summary>
+    void Stop();
+
+    /// <summary>
+    /// Seeks the clock to the given time in milliseconds.
+    /// </summary>
+    /// <param name="position">The target time in milliseconds.</param>
+    /// <returns>Whether the seek was successful.</returns>
+    bool Seek(double position);
+
+    /// <summary>
+    /// Stops the clock and resets its time to zero.
+    /// </summary>
+    void Reset();
+
+    /// <summary>
+    /// The rate this clock runs at, relative to real time. Settable.
+    /// </summary>
+    new double Rate { get; set; }
+}

--- a/Sakura.Framework/Timing/IClock.cs
+++ b/Sakura.Framework/Timing/IClock.cs
@@ -4,42 +4,23 @@
 namespace Sakura.Framework.Timing;
 
 /// <summary>
-/// Interface for a clock that provides high-precision timing.
+/// The minimal read-only contract for a clock.
+/// All times in the framework are expressed in <b>milliseconds</b>.
 /// </summary>
 public interface IClock
 {
     /// <summary>
-    /// The current time in seconds since the clock was started.
+    /// The current time of this clock in milliseconds.
     /// </summary>
     double CurrentTime { get; }
 
     /// <summary>
-    /// The time in seconds that has elapsed since the last frame.
+    /// The rate this clock is running at, relative to real time. 1.0 is real time.
     /// </summary>
-    double ElapsedFrameTime { get; }
-
-    /// <summary>
-    /// The number of frames that have been processed since the clock was started.
-    /// </summary>
-    double FramesPerSecond { get; }
+    double Rate { get; }
 
     /// <summary>
     /// Whether the clock is currently running.
     /// </summary>
     bool IsRunning { get; }
-
-    /// <summary>
-    /// Start the clock.
-    /// </summary>
-    void Start();
-
-    /// <summary>
-    /// Stop the clock.
-    /// </summary>
-    void Stop();
-
-    /// <summary>
-    /// Update the clock's state. This should be called once per frame.
-    /// </summary>
-    void Update();
 }

--- a/Sakura.Framework/Timing/IFrameBasedClock.cs
+++ b/Sakura.Framework/Timing/IFrameBasedClock.cs
@@ -1,0 +1,31 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// A clock that takes a consistent snapshot of time once per frame.
+/// <para>
+/// Between calls to <see cref="ProcessFrame"/>, <see cref="IClock.CurrentTime"/> does not change.
+/// This guarantees every consumer within a single frame observes the same time, which is
+/// essential for coherent layout, animation and judgement logic.
+/// </para>
+/// </summary>
+public interface IFrameBasedClock : IClock
+{
+    /// <summary>
+    /// The time in milliseconds that elapsed between the last two <see cref="ProcessFrame"/> calls.
+    /// </summary>
+    double ElapsedFrameTime { get; }
+
+    /// <summary>
+    /// The number of frames processed per second, averaged over a recent window.
+    /// </summary>
+    double FramesPerSecond { get; }
+
+    /// <summary>
+    /// Advances the clock to the current time of its underlying source.
+    /// Call exactly once per frame, before any consumer reads the clock.
+    /// </summary>
+    void ProcessFrame();
+}

--- a/Sakura.Framework/Timing/ISourceChangeableClock.cs
+++ b/Sakura.Framework/Timing/ISourceChangeableClock.cs
@@ -1,0 +1,22 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// A clock that derives its time from another <see cref="IClock"/> and allows
+/// that source to be exchanged at runtime.
+/// </summary>
+public interface ISourceChangeableClock : IClock
+{
+    /// <summary>
+    /// The source this clock derives its time from.
+    /// </summary>
+    IClock Source { get; }
+
+    /// <summary>
+    /// Exchanges the source of this clock.
+    /// </summary>
+    /// <param name="source">The new source.</param>
+    void ChangeSource(IClock source);
+}

--- a/Sakura.Framework/Timing/InterpolatingFramedClock.cs
+++ b/Sakura.Framework/Timing/InterpolatingFramedClock.cs
@@ -1,0 +1,126 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using Sakura.Framework.Utilities;
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// A framed clock that smooths a source whose time advances in coarse steps
+/// (typically an audio track position, which only updates per audio buffer).
+/// <para>
+/// Between source updates, time advances continuously using a real-time reference at the
+/// source's rate. The interpolated time is guaranteed to never drift more than
+/// <see cref="AllowableErrorMilliseconds"/> from the source, and to never run backwards
+/// while the source is playing forwards — small corrections are absorbed smoothly, large
+/// discontinuities (seeks) snap.
+/// </para>
+/// </summary>
+public class InterpolatingFramedClock : IFrameBasedClock, ISourceChangeableClock
+{
+    /// <summary>
+    /// The maximum amount the interpolated time may deviate from the source before snapping
+    /// back to it. Should be at least the source's update granularity
+    /// (one audio buffer, typically 5–10 ms).
+    /// </summary>
+    public double AllowableErrorMilliseconds { get; set; } = 10;
+
+    /// <summary>
+    /// Whether the last frame was produced by smooth interpolation (true) or by snapping
+    /// directly to the source (false). Diagnostic.
+    /// </summary>
+    public bool IsInterpolating { get; private set; }
+
+    private IClock source;
+    private readonly IClock reference;
+    private double lastReferenceTime;
+    private bool hasProcessed;
+
+    public IClock Source => source;
+
+    public double CurrentTime { get; private set; }
+    public double ElapsedFrameTime { get; private set; }
+    public double FramesPerSecond => (source as IFrameBasedClock)?.FramesPerSecond ?? 0;
+    public double Rate => source.Rate;
+    public bool IsRunning => source.IsRunning;
+
+    /// <param name="source">The coarse clock to smooth.</param>
+    /// <param name="referenceClock">
+    /// The real-time reference used to advance between source updates.
+    /// Defaults to the shared <see cref="TimeSource"/> timeline; tests can pass a
+    /// <see cref="ManualClock"/> for full determinism.
+    /// </param>
+    public InterpolatingFramedClock(IClock source, IClock? referenceClock = null)
+    {
+        this.source = source;
+        reference = referenceClock ?? new TimeSourceClock();
+        CurrentTime = source.CurrentTime;
+        lastReferenceTime = reference.CurrentTime;
+    }
+
+    public void ChangeSource(IClock newSource)
+    {
+        source = newSource;
+        CurrentTime = newSource.CurrentTime;
+        lastReferenceTime = reference.CurrentTime;
+        hasProcessed = false;
+    }
+
+    public void ProcessFrame()
+    {
+        double lastTime = CurrentTime;
+        double sourceTime = source.CurrentTime;
+        double referenceTime = reference.CurrentTime;
+        double referenceElapsed = referenceTime - lastReferenceTime;
+        lastReferenceTime = referenceTime;
+
+        if (!source.IsRunning)
+        {
+            // A stopped source is exact by definition — report it directly.
+            CurrentTime = sourceTime;
+            IsInterpolating = false;
+        }
+        else if (!hasProcessed)
+        {
+            // First frame: no interpolation history yet.
+            CurrentTime = sourceTime;
+            IsInterpolating = false;
+            hasProcessed = true;
+        }
+        else
+        {
+            double candidate = lastTime + referenceElapsed * source.Rate;
+
+            if (Math.Abs(candidate - sourceTime) > AllowableErrorMilliseconds)
+            {
+                // Too far from the source to be a buffer-granularity artifact —
+                // treat as a discontinuity (seek / stall) and snap.
+                CurrentTime = sourceTime;
+                IsInterpolating = false;
+            }
+            else
+            {
+                // Smooth advance, but never run backwards relative to the last frame
+                // while playing forwards, and never lead the source by more than the
+                // allowable error.
+                if (source.Rate >= 0)
+                    candidate = Math.Clamp(candidate, lastTime, sourceTime + AllowableErrorMilliseconds);
+                else
+                    candidate = Math.Clamp(candidate, sourceTime - AllowableErrorMilliseconds, lastTime);
+
+                CurrentTime = candidate;
+                IsInterpolating = true;
+            }
+        }
+
+        ElapsedFrameTime = CurrentTime - lastTime;
+    }
+
+    /// <summary>
+    /// Whether this clock currently reports (almost) exactly the source time.
+    /// </summary>
+    public bool IsAtSourceTime => Precision.AlmostEquals(CurrentTime, source.CurrentTime, AllowableErrorMilliseconds);
+
+    public override string ToString() => $"InterpolatingFramedClock: {CurrentTime:F2}ms (source: {source.CurrentTime:F2}ms, interpolating: {IsInterpolating})";
+}

--- a/Sakura.Framework/Timing/ManualClock.cs
+++ b/Sakura.Framework/Timing/ManualClock.cs
@@ -1,0 +1,20 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// A clock whose time is set manually by hand.
+/// Useful for deterministic tests, replays and fixed-step simulation: drive any clock chain
+/// (or an entire scene) by assigning <see cref="CurrentTime"/> exact values per step.
+/// </summary>
+public class ManualClock : IClock
+{
+    public double CurrentTime { get; set; }
+
+    public double Rate { get; set; } = 1.0;
+
+    public bool IsRunning { get; set; } = true;
+
+    public override string ToString() => $"ManualClock: {CurrentTime:F2}ms (Rate: {Rate}, Running: {IsRunning})";
+}

--- a/Sakura.Framework/Timing/StopwatchClock.cs
+++ b/Sakura.Framework/Timing/StopwatchClock.cs
@@ -1,0 +1,73 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// An adjustable clock running off the shared <see cref="TimeSource"/>.
+/// Supports start/stop, seeking and rate adjustment with no accumulation error:
+/// the current time is always derived directly from the time source.
+/// </summary>
+public class StopwatchClock : IAdjustableClock
+{
+    private double accumulated;
+    private double lastReferenceTime;
+    private double rate = 1.0;
+
+    public bool IsRunning { get; private set; }
+
+    public double CurrentTime => IsRunning
+        ? accumulated + (TimeSource.CurrentTime - lastReferenceTime) * rate
+        : accumulated;
+
+    public double Rate
+    {
+        get => rate;
+        set
+        {
+            if (rate == value) return;
+
+            // Bank the time elapsed at the old rate before switching.
+            accumulated = CurrentTime;
+            lastReferenceTime = TimeSource.CurrentTime;
+            rate = value;
+        }
+    }
+
+    public StopwatchClock(bool start = false)
+    {
+        if (start)
+            Start();
+    }
+
+    public void Start()
+    {
+        if (IsRunning) return;
+
+        lastReferenceTime = TimeSource.CurrentTime;
+        IsRunning = true;
+    }
+
+    public void Stop()
+    {
+        if (!IsRunning) return;
+
+        accumulated = CurrentTime;
+        IsRunning = false;
+    }
+
+    public bool Seek(double position)
+    {
+        accumulated = position;
+        lastReferenceTime = TimeSource.CurrentTime;
+        return true;
+    }
+
+    public void Reset()
+    {
+        Stop();
+        accumulated = 0;
+    }
+
+    public override string ToString() => $"StopwatchClock: {CurrentTime:F2}ms (Rate: {Rate}, Running: {IsRunning})";
+}

--- a/Sakura.Framework/Timing/TimeSource.cs
+++ b/Sakura.Framework/Timing/TimeSource.cs
@@ -1,0 +1,33 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Diagnostics;
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// The process-wide monotonic time source that all framework clocks derive from.
+/// Every clock in the framework reports time on this single shared timeline (in milliseconds
+/// since process start). This makes timestamps taken on different threads — input, audio,
+/// update, draw — directly comparable, which is the foundation for things like
+/// accurate hit judgement in rhythm games: <c>inputTime - audioTime</c>
+/// is only meaningful when both sides share an epoch.
+/// </summary>
+public static class TimeSource
+{
+    private static readonly long epoch = Stopwatch.GetTimestamp();
+    private static readonly double ms_per_tick = 1000.0 / Stopwatch.Frequency;
+
+    /// <summary>
+    /// The current time in milliseconds on the shared timeline.
+    /// Monotonic, unaffected by system clock changes, safe to read from any thread.
+    /// </summary>
+    public static double CurrentTime => (Stopwatch.GetTimestamp() - epoch) * ms_per_tick;
+
+    /// <summary>
+    /// Converts a raw <see cref="Stopwatch.GetTimestamp"/> value onto the shared timeline.
+    /// </summary>
+    /// <param name="stopwatchTimestamp">A timestamp obtained from <see cref="Stopwatch.GetTimestamp"/>.</param>
+    /// <returns>The equivalent time in milliseconds on the shared timeline.</returns>
+    public static double FromStopwatchTimestamp(long stopwatchTimestamp) => (stopwatchTimestamp - epoch) * ms_per_tick;
+}

--- a/Sakura.Framework/Timing/TimeSourceClock.cs
+++ b/Sakura.Framework/Timing/TimeSourceClock.cs
@@ -1,0 +1,18 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Timing;
+
+/// <summary>
+/// A live, always-running view of the shared <see cref="TimeSource"/> timeline.
+/// Used as the default real-time reference for interpolating and decoupling clocks;
+/// tests can substitute a <see cref="ManualClock"/> to make those clocks fully deterministic.
+/// </summary>
+public class TimeSourceClock : IClock
+{
+    public double CurrentTime => TimeSource.CurrentTime;
+
+    public double Rate => 1.0;
+
+    public bool IsRunning => true;
+}


### PR DESCRIPTION
Since #104 I think our "clock" system now really inconsistent and it's really hard to do the clock syncing to do things like rhythm game and even precise time rendering really hard. That's why this PR add and improve a lot of clock system, with the class that will use in my rhythm game too. The documentation will be coming soon since it's really hard to understand at first.

That's why every developer "love" the "CLOCK" system 😔

Also added a test!