### PR TITLE
Add a way to add multiple resource and add app to test scene

### DIFF
--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Sakura.Framework.Audio;
 using Sakura.Framework.Audio.BassEngine;
@@ -55,7 +56,16 @@ public partial class App : Container, IFocusManager, IDisposable
     /// </summary>
     protected virtual string ResourceRootNamespace => $"{GetType().Namespace}.Resources";
 
-    internal void SetHost(AppHost host) => Host = host;
+    /// <summary>
+    /// Additional resource assemblies to merge with the primary <see cref="ResourceAssembly"/>.
+    /// Each entry is an (Assembly, rootNamespace) pair. Resources from all assemblies are
+    /// searched in order. Mainly for override your test app to include both game resources
+    /// and test-specific resources.
+    /// </summary>
+    protected virtual IEnumerable<(Assembly Assembly, string RootNamespace)> AdditionalResourceAssemblies
+        => Array.Empty<(Assembly, string)>();
+
+    public void SetHost(AppHost host) => Host = host;
 
     private DrawVisualiser drawVisualiser;
     private GlobalStatisticsDisplay globalStatisticsDisplay;
@@ -83,7 +93,13 @@ public partial class App : Container, IFocusManager, IDisposable
 
         Cache(AudioManager);
 
-        var embeddedResourceStorage = new EmbeddedResourceStorage(ResourceAssembly, ResourceRootNamespace);
+        var primaryStorage = new EmbeddedResourceStorage(ResourceAssembly, ResourceRootNamespace);
+        var additionalStorages = AdditionalResourceAssemblies
+            .Select(e => (Storage)new EmbeddedResourceStorage(e.Assembly, e.RootNamespace))
+            .ToList();
+        Storage embeddedResourceStorage = additionalStorages.Count == 0
+            ? primaryStorage
+            : new CompositeStorage([primaryStorage, ..additionalStorages]);
 
         TrackStore = new TrackStore(embeddedResourceStorage.GetStorageForDirectory("Tracks"), AudioManager);
         SampleStore = new SampleStore(embeddedResourceStorage.GetStorageForDirectory("Samples"), AudioManager);

--- a/Sakura.Framework/Testing/TestScene.cs
+++ b/Sakura.Framework/Testing/TestScene.cs
@@ -27,10 +27,10 @@ public abstract partial class TestScene : Container
     /// <summary>
     /// Adds an <see cref="App"/> to this test scene
     /// </summary>
-    protected void AddApp(App game)
+    protected void AddApp(App app)
     {
-        game.SetHost(host);
-        Add(game);
+        app.SetHost(host);
+        Add(app);
     }
 
     /// <summary>

--- a/Sakura.Framework/Testing/TestScene.cs
+++ b/Sakura.Framework/Testing/TestScene.cs
@@ -8,6 +8,7 @@ using System.Numerics;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using NUnit.Framework;
+using Sakura.Framework.Allocation;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Logging;
@@ -20,6 +21,18 @@ namespace Sakura.Framework.Testing;
 [TestFixture]
 public abstract partial class TestScene : Container
 {
+    [Resolved]
+    private AppHost host { get; set; }
+
+    /// <summary>
+    /// Adds an <see cref="App"/> to this test scene
+    /// </summary>
+    protected void AddApp(App game)
+    {
+        game.SetHost(host);
+        Add(game);
+    }
+
     /// <summary>
     /// Tells the TestScene to bypass spinning up a headless host because the visual is running it.
     /// </summary>


### PR DESCRIPTION
For example we have a multiple resource esp. in the external visual test so it use
- Game resource
- Test resource

but now in current structure we can only "point" the `App` to only one specific `Storage` so I add an ability to add a list of storage assembly to the app. Also add a way to run the "app" in the test scene.