### PR TITLE
Fix clock start before renderer lead to missing startup animation

### DIFF
--- a/Sakura.Framework.Tests/Timing/ClockTest.cs
+++ b/Sakura.Framework.Tests/Timing/ClockTest.cs
@@ -1,0 +1,72 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Timing;
+
+[TestFixture]
+public class ClockTest
+{
+    [Test]
+    public void TestAdvancesWhenRunning()
+    {
+        var clock = new Clock(true);
+        Thread.Sleep(50);
+        clock.ProcessFrame();
+        Assert.That(clock.CurrentTime, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void TestDoesNotAdvanceWhenStopped()
+    {
+        var clock = new Clock(true);
+        Thread.Sleep(30);
+        clock.ProcessFrame();
+        clock.Stop();
+        double stoppedTime = clock.CurrentTime;
+        Thread.Sleep(30);
+        clock.ProcessFrame();
+        Assert.That(clock.CurrentTime, Is.EqualTo(stoppedTime).Within(1));
+    }
+
+    [Test]
+    public void TestResetReturnsToZero()
+    {
+        var clock = new Clock(start: true);
+        Thread.Sleep(50);
+        clock.ProcessFrame();
+        Assert.That(clock.CurrentTime, Is.GreaterThan(0));
+        clock.Reset();
+        Assert.That(clock.CurrentTime, Is.EqualTo(0).Within(1));
+        Assert.That(clock.ElapsedFrameTime, Is.EqualTo(0).Within(1));
+    }
+
+    [Test]
+    public void TestFirstFrameAfterResetHasSmallElapsed()
+    {
+        var clock = new Clock(start: true);
+        Thread.Sleep(50);
+        clock.ProcessFrame();
+        clock.Reset();
+        clock.ProcessFrame();
+        Assert.That(clock.CurrentTime, Is.LessThan(20));
+        Assert.That(clock.CurrentTime, Is.GreaterThanOrEqualTo(0));
+    }
+
+    [Test]
+    public void TestContinuesRunningAfterReset()
+    {
+        var clock = new Clock(start: true);
+        Thread.Sleep(30);
+        clock.ProcessFrame();
+        clock.Reset();
+        Thread.Sleep(50);
+        clock.ProcessFrame();
+        Assert.That(clock.IsRunning, Is.True);
+        Assert.That(clock.CurrentTime, Is.GreaterThan(0));
+        Assert.That(clock.CurrentTime, Is.LessThan(100));
+    }
+}

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -67,6 +67,34 @@ public partial class App : Container, IFocusManager, IDisposable
 
     public void SetHost(AppHost host) => Host = host;
 
+    /// <summary>
+    /// Invoked after the application is fully initialized (loaded, renderer ready)
+    /// </summary>
+    public virtual void OnReady()
+    {
+    }
+
+    internal void InvokeReady()
+    {
+        OnReady();
+        Ready?.Invoke();
+    }
+
+    /// <summary>
+    /// Re-baselines the app's clock to zero to make every clock start from zero.
+    /// </summary>
+    internal void ResetClock()
+    {
+        if (Clock is FramedClock framed)
+            framed.Reset();
+    }
+
+    /// <summary>
+    /// Raised after <see cref="OnReady"/>, at the moment the application is fully initialized
+    /// and about to become visible. See <see cref="OnReady"/> for timing guarantees.
+    /// </summary>
+    public event Action Ready;
+
     private DrawVisualiser drawVisualiser;
     private GlobalStatisticsDisplay globalStatisticsDisplay;
     private TextureViewerDisplay textureViewerDisplay;

--- a/Sakura.Framework/Graphics/Screens/Screen.cs
+++ b/Sakura.Framework/Graphics/Screens/Screen.cs
@@ -28,7 +28,7 @@ public partial class Screen : Container
         get => state;
         private set
         {
-            Logger.Verbose($"Screen {this} state changed from {state} to {value}");
+            Logger.Verbose($"📺 Screen {this} state changed from {state} to {value}");
             state = value;
         }
     }

--- a/Sakura.Framework/Graphics/Screens/ScreenStack.cs
+++ b/Sakura.Framework/Graphics/Screens/ScreenStack.cs
@@ -65,7 +65,7 @@ public partial class ScreenStack : Container
         // and for removing itself from the Parent (this ScreenStack).
         exitingScreen.InternalExit(nextScreen);
 
-        Logger.Verbose($"Screen stack {this} exited screen {exitingScreen} (depth: {screenStack.Count}).");
+        Logger.Verbose($"📺 Screen stack {this} exited screen {exitingScreen} (depth: {screenStack.Count}).");
 
         // Tell the next screen (if any) that it's resuming.
         nextScreen?.InternalResume(exitingScreen);

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -47,10 +47,10 @@ public abstract class AppHost : IDisposable
 
     public Reactive<FrameSync> FrameLimiter { get; set; }
     public Reactive<ExecutionMode> ExecutionMode { get; set; }
-    protected internal IFrameBasedClock UpdateClock { get; private set; }
-    protected internal IFrameBasedClock DrawClock { get; private set; }
-    protected internal IFrameBasedClock AudioClock { get; private set; }
-    public IFrameBasedClock InputClock { get; private set; }
+    protected internal Clock UpdateClock { get; private set; }
+    protected internal Clock DrawClock { get; private set; }
+    protected internal Clock AudioClock { get; private set; }
+    public Clock InputClock { get; private set; }
     private readonly ThrottledFrameClock soundClock = new ThrottledFrameClock(1000);
     private readonly Stopwatch appLoopStopwatch = new Stopwatch();
     private readonly ConcurrentQueue<PendingInput> inputQueue = new ConcurrentQueue<PendingInput>();
@@ -509,6 +509,18 @@ public abstract class AppHost : IDisposable
             this.app.Load();
             this.app.LoadComplete();
 
+            UpdateClock.Reset();
+            DrawClock.Reset();
+            AudioClock.Reset();
+            InputClock.Reset();
+
+            this.app.ResetClock();
+            this.app.InvokeReady();
+
+            renderPrimingFrame();
+
+            Window.Show();
+
             if (ExecutionMode.Value == Threading.ExecutionMode.MultiThread)
             {
                 Window.ClearCurrent();
@@ -742,6 +754,24 @@ public abstract class AppHost : IDisposable
     /// This method is called at a fixed 1000Hz for precise audio processing.
     /// </summary>
     protected virtual void PerformSoundUpdate() { }
+
+    /// <summary>
+    /// Runs a single synchronous update + draw + present pass on the calling (main) thread.
+    /// Used once at startup to put a real frame on screen before the window is shown, so the
+    /// user never sees a blank window. Must be called while the graphics context is current on
+    /// the calling thread before switching to multi-threaded execution.
+    /// </summary>
+    private void renderPrimingFrame()
+    {
+        if (IsHeadless || Renderer == null)
+            return;
+        
+        UpdateClock.ProcessFrame();
+        PerformUpdate();
+
+        DrawClock.ProcessFrame();
+        PerformDraw();
+    }
 
     /// <summary>
     /// This method runs the main game logic updates. It uses a fixed-step approach

--- a/Sakura.Framework/Platform/HeadlessWindow.cs
+++ b/Sakura.Framework/Platform/HeadlessWindow.cs
@@ -40,6 +40,11 @@ public class HeadlessWindow : IWindow
 
     }
 
+    public void Show()
+    {
+
+    }
+
     public void PollEvents()
     {
         Update?.Invoke();

--- a/Sakura.Framework/Platform/IWindow.cs
+++ b/Sakura.Framework/Platform/IWindow.cs
@@ -136,8 +136,22 @@ public interface IWindow : IDisposable
 
     /// <summary>
     /// Create the window.
+    /// <remarks>
+    /// The window is created hidden so nothing is shown to the user until the application is
+    /// fully initialized and the first frame has been rendered. Call <see cref="Show"/> once
+    /// everything is ready.
+    /// </remarks>
     /// </summary>
     void Create();
+
+    /// <summary>
+    /// Makes the window visible to the user.
+    /// <remarks>
+    /// this should be called once the application is fully initialized and the first frame has been
+    /// rendered, to avoid showing a blank/black window during startup.
+    /// </remarks>
+    /// </summary>
+    void Show();
 
     void PollEvents();
 

--- a/Sakura.Framework/Platform/SDLWindow.cs
+++ b/Sakura.Framework/Platform/SDLWindow.cs
@@ -365,6 +365,8 @@ public class SDLWindow : IWindow
 
     public unsafe void Create()
     {
+        windowFlags |= SDL_WindowFlags.SDL_WINDOW_HIDDEN;
+
         if (Resizable)
         {
             windowFlags |= SDL_WindowFlags.SDL_WINDOW_RESIZABLE;
@@ -1095,6 +1097,12 @@ public class SDLWindow : IWindow
 
         // normal OS message processing
         handleSdlEvents();
+    }
+
+    public unsafe void Show()
+    {
+        if (window != null)
+            SDL_ShowWindow(window);
     }
 
     public unsafe void SwapBuffers()

--- a/Sakura.Framework/Timing/Clock.cs
+++ b/Sakura.Framework/Timing/Clock.cs
@@ -56,6 +56,21 @@ public class Clock : IFrameBasedClock
     }
 
     /// <summary>
+    /// Rebases the clock so that <see cref="CurrentTime"/> becomes 0 at the current moment.
+    /// The next <see cref="ProcessFrame"/> reports an <see cref="ElapsedFrameTime"/> measured
+    /// from this point.
+    /// </summary>
+    public void Reset()
+    {
+        pausedTotal = TimeSource.CurrentTime;
+        stoppedAt = TimeSource.CurrentTime;
+        CurrentTime = 0;
+        ElapsedFrameTime = 0;
+        frames = 0;
+        fpsAccumulator = 0;
+    }
+
+    /// <summary>
     /// Takes this frame's time snapshot. Call once per frame.
     /// </summary>
     public void ProcessFrame()

--- a/Sakura.Framework/Timing/FramedClock.cs
+++ b/Sakura.Framework/Timing/FramedClock.cs
@@ -43,6 +43,18 @@ public class FramedClock : IFrameBasedClock, ISourceChangeableClock
     public void Stop() => IsRunning = false;
 
     /// <summary>
+    /// Rebases this clock so <see cref="CurrentTime"/> becomes 0, set based line onto the source's
+    /// current time. The next <see cref="ProcessFrame"/> reports elapsed time measured from this
+    /// point rather than producing a large jump
+    /// </summary>
+    public void Reset()
+    {
+        CurrentTime = 0;
+        ElapsedFrameTime = 0;
+        lastSourceTime = source.CurrentTime;
+    }
+
+    /// <summary>
     /// Updates the clock's current time based on the source clock.
     /// This should be called once per frame.
     /// </summary>


### PR DESCRIPTION
Before this PR the app startup flow be like: create window (and show) -> start thread with clock started -> load everything -> `LoadComplete` -> everything run

So based on the flow when animation or some drawable scheduler should start when `LoadComplete` right? But since the clock got start even from load everything so if you schedule the transform like 500ms you will got only partial animation played or even not at all since clock pass the 500ms point. So this PR change this flow.

New flow : create window (with hidden) -> start thread and load everything -> reset clock -> render frame manually 1 time (prevent blank frame) -> show window -> everything run