### PR TITLE
Bump GLSL shader to version 450 with switch to fully using SPIRV

### DIFF
--- a/Sakura.Framework.Tests/IO/DiskCacheTest.cs
+++ b/Sakura.Framework.Tests/IO/DiskCacheTest.cs
@@ -1,0 +1,158 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using Sakura.Framework.IO;
+using Sakura.Framework.Platform;
+
+namespace Sakura.Framework.Tests.IO;
+
+[TestFixture]
+public class DiskCacheTest
+{
+    private string tempDir = null!;
+    private NativeStorage storage = null!;
+    private DiskCache cache = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "sakura-diskcache-test", Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        storage = new NativeStorage(tempDir);
+        cache = new DiskCache(storage);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, true);
+    }
+
+    [Test]
+    public void TryRead_MissingKey_ReturnsFalse()
+    {
+        Assert.That(cache.TryRead("does-not-exist", out byte[] data), Is.False);
+        Assert.That(data, Is.Null);
+    }
+
+    [Test]
+    public void WriteThenRead_RoundTripsBytes()
+    {
+        byte[] payload = { 1, 2, 3, 4, 250, 0, 99 };
+
+        cache.Write("key1", payload);
+
+        Assert.That(cache.TryRead("key1", out byte[] read), Is.True);
+        Assert.That(read, Is.EqualTo(payload));
+    }
+
+    [Test]
+    public void Write_OverwritesExistingEntryAtomically()
+    {
+        cache.Write("key1", new byte[] { 1, 2, 3 });
+        cache.Write("key1", new byte[] { 9, 8 });
+
+        Assert.That(cache.TryRead("key1", out byte[] read), Is.True);
+        Assert.That(read, Is.EqualTo(new byte[] { 9, 8 }));
+    }
+
+    [Test]
+    public void WriteThenRead_EmptyPayload_RoundTrips()
+    {
+        cache.Write("empty", System.Array.Empty<byte>());
+
+        Assert.That(cache.TryRead("empty", out byte[] read), Is.True);
+        Assert.That(read, Is.Empty);
+    }
+
+    [Test]
+    public void CorruptedPayload_IsTreatedAsMiss()
+    {
+        cache.Write("key1", new byte[] { 1, 2, 3, 4 });
+
+        // Corrupt the stored file so the payload no longer matches its checksum.
+        string full = storage.GetFullPath("key1");
+        byte[] bytes = File.ReadAllBytes(full);
+        bytes[^1] ^= 0xFF;
+        File.WriteAllBytes(full, bytes);
+
+        Assert.That(cache.TryRead("key1", out byte[] read), Is.False);
+        Assert.That(read, Is.Null);
+    }
+
+    [Test]
+    public void TruncatedFile_IsTreatedAsMiss()
+    {
+        cache.Write("key1", new byte[] { 1, 2, 3, 4, 5, 6 });
+
+        string full = storage.GetFullPath("key1");
+        byte[] bytes = File.ReadAllBytes(full);
+        File.WriteAllBytes(full, bytes[..(bytes.Length / 2)]);
+
+        Assert.That(cache.TryRead("key1", out _), Is.False);
+    }
+
+    [Test]
+    public void StringPair_RoundTrips()
+    {
+        cache.WriteStrings("pair", "hello", "world");
+
+        Assert.That(cache.TryReadStrings("pair", out string a, out string b), Is.True);
+        Assert.That(a, Is.EqualTo("hello"));
+        Assert.That(b, Is.EqualTo("world"));
+    }
+
+    [Test]
+    public void StringPair_HandlesUnicodeAndEmpty()
+    {
+        cache.WriteStrings("pair", "main0 → MSL", string.Empty);
+
+        Assert.That(cache.TryReadStrings("pair", out string a, out string b), Is.True);
+        Assert.That(a, Is.EqualTo("main0 → MSL"));
+        Assert.That(b, Is.Empty);
+    }
+
+    [Test]
+    public void TryReadStrings_MissingKey_ReturnsFalse()
+    {
+        Assert.That(cache.TryReadStrings("nope", out string a, out string b), Is.False);
+        Assert.That(a, Is.Null);
+        Assert.That(b, Is.Null);
+    }
+
+    [Test]
+    public void HashString_IsStableAndContentSensitive()
+    {
+        string h1 = DiskCache.HashString("abc");
+        string h2 = DiskCache.HashString("abc");
+        string h3 = DiskCache.HashString("abd");
+
+        Assert.That(h1, Is.EqualTo(h2));
+        Assert.That(h1, Is.Not.EqualTo(h3));
+        Assert.That(h1, Has.Length.EqualTo(32)); // 16-byte MD5 as hex
+    }
+
+    [Test]
+    public void HashBytes_MatchesEquivalentStringContent()
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("payload");
+        Assert.That(DiskCache.HashBytes(bytes), Is.EqualTo(DiskCache.HashString("payload")));
+    }
+
+    [Test]
+    public void DifferentKeys_DoNotCollide()
+    {
+        cache.Write("a", new byte[] { 1 });
+        cache.Write("b", new byte[] { 2 });
+
+        cache.TryRead("a", out byte[] ra);
+        cache.TryRead("b", out byte[] rb);
+
+        Assert.That(ra, Is.EqualTo(new byte[] { 1 }));
+        Assert.That(rb, Is.EqualTo(new byte[] { 2 }));
+    }
+}

--- a/Sakura.Framework.Tests/Rendering/ShaderCompilerTest.cs
+++ b/Sakura.Framework.Tests/Rendering/ShaderCompilerTest.cs
@@ -1,0 +1,169 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.IO;
+using Sakura.Framework.Platform;
+using Sakura.Framework.SPIRV;
+
+namespace Sakura.Framework.Tests.Rendering;
+
+[TestFixture]
+public class ShaderCompilerTest
+{
+    private string tempDir = null!;
+    private NativeStorage sourceStorage = null!;
+    private DiskCache cache = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "sakura-shadercompiler-test", Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        sourceStorage = new NativeStorage(tempDir);
+        cache = new DiskCache(new NativeStorage(Path.Combine(tempDir, "cache")));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, true);
+    }
+
+    private void writeSource(string name, string content) => File.WriteAllText(Path.Combine(tempDir, name), content);
+
+    #region #include resolution (no GPU / compiler needed)
+
+    [Test]
+    public void ReadWithIncludes_InlinesIncludedFile()
+    {
+        writeSource("util.glsl", "float helper() { return 1.0; }");
+        writeSource("main.frag", "#include \"util.glsl\"\nvoid main() { }");
+
+        string resolved = ShaderCompiler.ReadWithIncludes(sourceStorage, "main.frag");
+
+        Assert.That(resolved, Does.Contain("float helper()"));
+        Assert.That(resolved, Does.Contain("void main()"));
+        Assert.That(resolved, Does.Not.Contain("#include"));
+    }
+
+    [Test]
+    public void ReadWithIncludes_ResolvesNestedIncludes()
+    {
+        writeSource("a.glsl", "// a");
+        writeSource("b.glsl", "#include \"a.glsl\"\n// b");
+        writeSource("main.frag", "#include \"b.glsl\"\n// main");
+
+        string resolved = ShaderCompiler.ReadWithIncludes(sourceStorage, "main.frag");
+
+        Assert.That(resolved, Does.Contain("// a"));
+        Assert.That(resolved, Does.Contain("// b"));
+        Assert.That(resolved, Does.Contain("// main"));
+    }
+
+    [Test]
+    public void ReadWithIncludes_MissingInclude_Throws()
+    {
+        writeSource("main.frag", "#include \"nope.glsl\"\nvoid main() { }");
+
+        Assert.That(() => ShaderCompiler.ReadWithIncludes(sourceStorage, "main.frag"),
+            Throws.TypeOf<FileNotFoundException>());
+    }
+
+    #endregion
+
+    #region Compilation + caching
+
+    private const string minimal_vert_450 =
+        "#version 450\n" +
+        "layout(location = 0) in vec2 aPosition;\n" +
+        "layout(set = 0, binding = 0) uniform ProjBlock { mat4 u_Projection; };\n" +
+        "void main() { gl_Position = u_Projection * vec4(aPosition, 0.0, 1.0); }\n";
+
+    private const string minimal_frag_450 =
+        "#version 450\n" +
+        "layout(location = 0) out vec4 FragColor;\n" +
+        "void main() { FragColor = vec4(1.0); }\n";
+
+    private static bool tryCompile(out Exception error)
+    {
+        try
+        {
+            ShaderCompiler.GetOrCompileSource(minimal_vert_450, minimal_frag_450, CrossCompileTarget.GLSL);
+            error = null!;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex;
+            return false;
+        }
+    }
+
+    [Test]
+    public void CompilesMinimalShader_ToGLSL()
+    {
+        if (!tryCompile(out Exception err))
+            Assert.Ignore($"SPIR-V native compiler unavailable on this platform: {err.Message}");
+
+        var (vert, frag) = ShaderCompiler.GetOrCompileSource(
+            minimal_vert_450, minimal_frag_450, CrossCompileTarget.GLSL);
+
+        Assert.That(vert, Does.Contain("void main"));
+        Assert.That(frag, Does.Contain("void main"));
+    }
+
+    [Test]
+    public void CompilesMinimalShader_ToMSL()
+    {
+        if (!tryCompile(out Exception err))
+            Assert.Ignore($"SPIR-V native compiler unavailable on this platform: {err.Message}");
+
+        var (vert, frag) = ShaderCompiler.GetOrCompileSource(
+            minimal_vert_450, minimal_frag_450, CrossCompileTarget.MSL);
+
+        Assert.That(vert, Does.Contain("#include <metal_stdlib>"));
+        Assert.That(frag, Does.Contain("#include <metal_stdlib>"));
+    }
+
+    [Test]
+    public void SecondCall_HitsCache_AndReturnsSameOutput()
+    {
+        if (!tryCompile(out Exception err))
+            Assert.Ignore($"SPIR-V native compiler unavailable on this platform: {err.Message}");
+
+        var first = ShaderCompiler.GetOrCompileSource(
+            minimal_vert_450, minimal_frag_450, CrossCompileTarget.GLSL, cache);
+
+        // The cache directory should now contain exactly one entry.
+        string cacheDir = Path.Combine(tempDir, "cache");
+        Assert.That(Directory.GetFiles(cacheDir), Has.Length.EqualTo(1));
+
+        var second = ShaderCompiler.GetOrCompileSource(
+            minimal_vert_450, minimal_frag_450, CrossCompileTarget.GLSL, cache);
+
+        Assert.That(second.vert, Is.EqualTo(first.vert));
+        Assert.That(second.frag, Is.EqualTo(first.frag));
+        // Still only one entry, the second call read it rather than writing a new one.
+        Assert.That(Directory.GetFiles(cacheDir), Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void DifferentTarget_ProducesSeparateCacheEntry()
+    {
+        if (!tryCompile(out Exception err))
+            Assert.Ignore($"SPIR-V native compiler unavailable on this platform: {err.Message}");
+
+        ShaderCompiler.GetOrCompileSource(minimal_vert_450, minimal_frag_450, CrossCompileTarget.GLSL, cache);
+        ShaderCompiler.GetOrCompileSource(minimal_vert_450, minimal_frag_450, CrossCompileTarget.MSL, cache);
+
+        string cacheDir = Path.Combine(tempDir, "cache");
+        Assert.That(Directory.GetFiles(cacheDir), Has.Length.EqualTo(2));
+    }
+
+    #endregion
+}

--- a/Sakura.Framework/Graphics/Rendering/BufferedContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/BufferedContainerDrawNode.cs
@@ -200,17 +200,23 @@ public class BufferedContainerDrawNode : ContainerDrawNode
 
         runShaderPass(renderer, source, target, rect, blur_shader!, shader =>
         {
-            shader.SetUniform("u_TexelSize", new Vector2(1f / source.Width, 1f / source.Height));
-            shader.SetUniform("u_Direction", direction);
-            shader.SetUniform("u_Sigma", sigmaTexels);
-            shader.SetUniform("u_Radius", radius);
+            shader.SetUniformBlock("BlurBlock", new Uniforms.BlurBlock
+            {
+                TexelSize = new Vector2(1f / source.Width, 1f / source.Height),
+                Direction = new Vector2(direction.X, direction.Y),
+                Sigma = sigmaTexels,
+                Radius = radius,
+            });
         });
     }
 
     private void grayscalePass(IGLRenderer renderer, IFrameBuffer source, IFrameBuffer target, RectangleF rect)
     {
         runShaderPass(renderer, source, target, rect, grayscale_shader!, shader =>
-            shader.SetUniform("u_Strength", grayscaleStrength));
+            shader.SetUniformBlock("GrayscaleBlock", new Uniforms.GrayscaleBlock
+            {
+                Strength = grayscaleStrength
+            }));
     }
 
     /// <summary>
@@ -224,7 +230,10 @@ public class BufferedContainerDrawNode : ContainerDrawNode
         renderer.FlushBatch();
 
         shader.Use();
-        shader.SetUniform("u_Projection", renderer.ProjectionMatrix);
+        shader.SetUniformBlock("ProjectionBlock", new Uniforms.ProjectionBlock
+        {
+            Projection = renderer.ProjectionMatrix
+        });
         shader.SetUniform("u_Texture", 0);
         setUniforms(shader);
 

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -78,6 +78,20 @@ public class GLRenderer : IGLRenderer
 
     private GLShader shader;
 
+    private Uniforms.GLUniformBuffer<Uniforms.ProjectionBlock> projectionBuffer;
+    private Uniforms.GLUniformBuffer<Uniforms.MaskBlock> maskBuffer;
+    private Uniforms.MaskBlock maskState;
+
+    private const uint projection_binding = 0;
+    private const uint mask_binding = 1;
+
+    private void uploadProjection()
+    {
+        projectionBuffer.Update(new Uniforms.ProjectionBlock { Projection = projectionMatrix });
+    }
+
+    private void uploadMaskState() => maskBuffer.Update(maskState);
+
     private Matrix4x4 projectionMatrix;
 
     private TriangleBatch triangleBatch;
@@ -173,7 +187,19 @@ public class GLRenderer : IGLRenderer
         prefillTextureSlots();
         resetTextureSlots();
 
-        shader = new GLShader(gl, ShaderStorage, "shader.vert", "shader.frag");
+        var (mainVert, mainFrag) = ShaderCompiler.GetOrCompile(
+            ShaderStorage, "shader.vert", "shader.frag", SPIRV.CrossCompileTarget.GLSL, ShaderCache);
+        shader = new GLShader(gl, mainVert, mainFrag);
+
+        projectionBuffer = new Uniforms.GLUniformBuffer<Uniforms.ProjectionBlock>(gl, projection_binding);
+        maskBuffer = new Uniforms.GLUniformBuffer<Uniforms.MaskBlock>(gl, mask_binding);
+
+        if (!shader.BindUniformBlock("ProjectionBlock", projection_binding))
+            Logger.Error("GLRenderer: main shader is missing expected uniform block 'ProjectionBlock'.");
+        if (!shader.BindUniformBlock("MaskBlock", mask_binding))
+            Logger.Error("GLRenderer: main shader is missing expected uniform block 'MaskBlock'.");
+
+        maskState = default;
 
         triangleBatch = new TriangleBatch(gl, 1000 * 12);
 
@@ -229,16 +255,26 @@ public class GLRenderer : IGLRenderer
     public void RestoreMainShader()
     {
         shader.Use();
-        shader.SetUniform("u_Projection", projectionMatrix);
         shader.SetUniformIntArray("u_Textures", texture_samplers);
-        shader.SetUniform("u_IsMasking", false);
-        shader.SetUniform("u_IsBorder", false);
+
+        uploadProjection();
+        projectionBuffer.Bind();
+
+        maskState.IsMasking = 0;
+        maskState.IsBorder = 0;
+        uploadMaskState();
+        maskBuffer.Bind();
     }
 
     public void DisableSrgb() => gl.Disable(EnableCap.FramebufferSrgb);
     public void RestoreSrgb() => gl.Enable(EnableCap.FramebufferSrgb);
 
-    public IShader CreateShader(Storage storage, string vertexPath, string fragmentPath) => new GLShader(gl, storage, vertexPath, fragmentPath);
+    public IShader CreateShader(Storage storage, string vertexPath, string fragmentPath)
+    {
+        (string vert, string frag) = ShaderCompiler.GetOrCompile(
+            storage, vertexPath, fragmentPath, SPIRV.CrossCompileTarget.GLSL, ShaderCache);
+        return new GLShader(gl, vert, frag);
+    }
 
     public INativeVideoTexture CreateVideoTexture(int width, int height) => new VideoGLTexture(gl, width, height);
 
@@ -280,8 +316,10 @@ public class GLRenderer : IGLRenderer
         stat_drawables_drawn.Value = 0;
 
         shader.Use();
-        shader.SetUniform("u_Projection", projectionMatrix);
         shader.SetUniformIntArray("u_Textures", texture_samplers);
+
+        uploadProjection();
+        projectionBuffer.Bind();
 
         stencilLevel = 0;
         scissorStack.Clear();
@@ -292,8 +330,10 @@ public class GLRenderer : IGLRenderer
             ShearX = 0,
             Radius = 0
         };
-        shader.SetUniform("u_IsMasking", false);
-        shader.SetUniform("u_IsBorder", false);
+        maskState.IsMasking = 0;
+        maskState.IsBorder = 0;
+        uploadMaskState();
+        maskBuffer.Bind();
 
         lastBoundTextureHandle = uint.MaxValue;
         SetBlendMode(BlendingMode.Alpha);
@@ -350,7 +390,7 @@ public class GLRenderer : IGLRenderer
             sourceRect.X, sourceRect.X + sourceRect.Width,
             sourceRect.Y + sourceRect.Height, sourceRect.Y,
             -1, 1);
-        shader.SetUniform("u_Projection", projectionMatrix);
+        uploadProjection();
 
         // Content inside the buffer starts from a clean clip state; the outer clip applies
         // to the final composited quad instead.
@@ -384,7 +424,7 @@ public class GLRenderer : IGLRenderer
         currentViewportHeight = state.ViewportHeight;
 
         projectionMatrix = state.Projection;
-        shader.SetUniform("u_Projection", projectionMatrix);
+        uploadProjection();
 
         currentClip = state.Clip;
     }
@@ -457,15 +497,15 @@ public class GLRenderer : IGLRenderer
 
         triangleBatch.Draw();
 
-        shader.SetUniform("u_IsBorder", true);
-
-        shader.SetUniform("u_MaskCenter", maskCenter);
-        shader.SetUniform("u_MaskHalfSize", maskHalfSize);
-        shader.SetUniform("u_ShearX", shearX);
-        shader.SetUniform("u_CornerRadius", cornerRadius);
-
-        shader.SetUniform("u_BorderThickness", borderThickness);
-        shader.SetUniform("u_BorderColor", borderColor);
+        maskState.IsBorder = 1;
+        maskState.MaskCenter = new System.Numerics.Vector2(maskCenter.X, maskCenter.Y);
+        maskState.MaskHalfSize = new System.Numerics.Vector2(maskHalfSize.X, maskHalfSize.Y);
+        maskState.ShearX = shearX;
+        maskState.CornerRadius = cornerRadius;
+        maskState.BorderThickness = borderThickness;
+        maskState.BorderColor = new System.Numerics.Vector4(
+            borderColor.R / 255f, borderColor.G / 255f, borderColor.B / 255f, borderColor.A / 255f);
+        uploadMaskState();
 
         if (boundTextureCount == 0 || whiteGLTexture.GLHandle != boundTextureHandles[0])
         {
@@ -481,7 +521,8 @@ public class GLRenderer : IGLRenderer
 
         triangleBatch.Draw();
 
-        shader.SetUniform("u_IsBorder", false);
+        maskState.IsBorder = 0;
+        uploadMaskState();
         lastBoundTextureHandle = uint.MaxValue;
     }
 

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Sakura.Framework.Graphics.Rendering.Batches;
 using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.IO;
 using Silk.NET.OpenGL;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
@@ -71,6 +72,7 @@ public class GLRenderer : IGLRenderer
     public Texture WhitePixel { get; private set; }
     public Matrix4x4 ProjectionMatrix => projectionMatrix;
     public Storage ShaderStorage { get; set; }
+    public DiskCache ShaderCache { get; set; }
 
     private GLTexture whiteGLTexture => (GLTexture)WhitePixel.BackendTexture!;
 

--- a/Sakura.Framework/Graphics/Rendering/GLShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLShader.cs
@@ -218,7 +218,7 @@ public partial class GLShader : IShader
     {
         using Stream stream = storage.GetStream(path, FileAccess.Read, FileMode.Open);
         string src = readStream(stream);
-        return resolveIncludes(src, name =>
+        return ShaderCompiler.ResolveIncludes(src, name =>
         {
             try
             {
@@ -233,43 +233,6 @@ public partial class GLShader : IShader
         });
     }
 
-    /// <summary>
-    /// Resolves <c>#include</c> directives by passing each include name to <paramref name="loadInclude"/>.
-    /// Uses a compiled regex instead of manual string parsing — handles both <c>"file"</c> and
-    /// <c>&lt;file&gt;</c> syntax, and tolerates whitespace between <c>#</c> and <c>include</c>.
-    /// </summary>
-    private static string resolveIncludes(string src, Func<string, string> loadInclude)
-    {
-        src = src.Replace("\r\n", "\n").Replace("\r", "\n");
-
-        var result = new StringBuilder();
-
-        foreach (string line in src.Split('\n'))
-        {
-            Match match = IncludePattern.Match(line);
-
-            if (match.Success)
-            {
-                string includeName = match.Groups[1].Value.Trim();
-                string includeSource = loadInclude(includeName);
-
-                // Recurse so included files can themselves contain #include.
-                includeSource = resolveIncludes(includeSource, loadInclude);
-                includeSource = includeSource.TrimEnd('\n', '\r');
-
-                result.Append("// ---- begin include: ").Append(includeName).Append(" ----\n");
-                result.Append(includeSource).Append('\n');
-                result.Append("// ---- end include: ").Append(includeName).Append(" ----\n");
-            }
-            else
-            {
-                result.Append(line).Append('\n');
-            }
-        }
-
-        return result.ToString();
-    }
-
     private uint loadFromAssembly(ShaderType type, string resourcePath, Assembly assembly)
     {
         string directory = resourcePath.Contains('/')
@@ -277,7 +240,7 @@ public partial class GLShader : IShader
             : string.Empty;
 
         string src = readEmbeddedResource(resourcePath, assembly);
-        src = resolveIncludes(src, includeName => readEmbeddedResource(directory + includeName, assembly));
+        src = ShaderCompiler.ResolveIncludes(src, includeName => readEmbeddedResource(directory + includeName, assembly));
 
         return compileShader(type, src, resourcePath);
     }

--- a/Sakura.Framework/Graphics/Rendering/GLShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLShader.cs
@@ -34,6 +34,19 @@ public partial class GLShader : IShader
     // per-frame SetUniform calls (projection, masking state, ...) cheap.
     private readonly Dictionary<string, int> uniformLocations = new Dictionary<string, int>();
 
+    // Lazily-created UBOs for std140 blocks set via SetUniformBlock. Each distinct block name gets a
+    // dedicated buffer and a sequential binding point linked into the program on first use.
+    private readonly Dictionary<string, GLBlockBinding> uniformBlocks = new Dictionary<string, GLBlockBinding>();
+    private uint nextBlockBinding;
+
+    private sealed class GLBlockBinding
+    {
+        public uint Buffer;
+        public uint BindingPoint;
+        public int Size;
+        public bool Allocated;
+    }
+
     private int getUniformLocation(string name)
     {
         if (!uniformLocations.TryGetValue(name, out int location))
@@ -106,6 +119,73 @@ public partial class GLShader : IShader
     {
         gl.UseProgram(handle);
         stat_shader_binds.Value++;
+    }
+
+    /// <summary>
+    /// Links a named std140 uniform block in this program to a GL uniform-buffer binding point,
+    /// so a <see cref="Uniforms.GLUniformBuffer{T}"/> bound to the same point feeds the block.
+    /// Call once after construction for each block the shader declares.
+    /// </summary>
+    /// <param name="blockName">The block name as it appears in the cross-compiled GLSL (e.g. "ProjectionBlock").</param>
+    /// <param name="bindingPoint">The binding point to associate the block with.</param>
+    /// <returns>True if the block exists in the program and was linked; false if not found.</returns>
+    public bool BindUniformBlock(string blockName, uint bindingPoint)
+    {
+        uint index = gl.GetUniformBlockIndex(handle, blockName);
+
+        // GL_INVALID_INDEX (0xFFFFFFFF) means the block was optimised out or not present.
+        if (index == uint.MaxValue)
+            return false;
+
+        gl.UniformBlockBinding(handle, index, bindingPoint);
+        return true;
+    }
+
+    public unsafe void SetUniformBlock<T>(string blockName, in T data) where T : unmanaged
+    {
+        if (!uniformBlocks.TryGetValue(blockName, out GLBlockBinding block))
+        {
+            uint index = gl.GetUniformBlockIndex(handle, blockName);
+            if (index == uint.MaxValue)
+            {
+                // Block not present in this program (e.g. optimised out), nothing to upload.
+                uniformBlocks[blockName] = new GLBlockBinding
+                {
+                    Buffer = 0,
+                    BindingPoint = uint.MaxValue
+                };
+                return;
+            }
+
+            block = new GLBlockBinding
+            {
+                Buffer = gl.GenBuffer(),
+                BindingPoint = nextBlockBinding++,
+                Size = sizeof(T),
+            };
+            gl.UniformBlockBinding(handle, index, block.BindingPoint);
+            uniformBlocks[blockName] = block;
+        }
+
+        if (block.BindingPoint == uint.MaxValue)
+            return;
+
+        gl.BindBuffer(BufferTargetARB.UniformBuffer, block.Buffer);
+        fixed (T* ptr = &data)
+        {
+            if (!block.Allocated)
+            {
+                gl.BufferData(BufferTargetARB.UniformBuffer, (nuint)block.Size, ptr, BufferUsageARB.DynamicDraw);
+                block.Allocated = true;
+            }
+            else
+            {
+                gl.BufferSubData(BufferTargetARB.UniformBuffer, 0, (nuint)block.Size, ptr);
+            }
+        }
+
+        gl.BindBufferBase(BufferTargetARB.UniformBuffer, block.BindingPoint, block.Buffer);
+        gl.BindBuffer(BufferTargetARB.UniformBuffer, 0);
     }
 
     public void SetUniform(string name, int value)
@@ -195,6 +275,15 @@ public partial class GLShader : IShader
     {
         if (disposed) return;
         gl.DeleteProgram(handle);
+
+        foreach (GLBlockBinding block in uniformBlocks.Values)
+        {
+            if (block.Buffer != 0)
+                gl.DeleteBuffer(block.Buffer);
+        }
+
+        uniformBlocks.Clear();
+
         GlobalStatistics.Get<int>("Graphics", "Loaded Shaders").Value--;
         disposed = true;
         GC.SuppressFinalize(this);

--- a/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
@@ -4,6 +4,7 @@
 using System;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.IO;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Timing;
@@ -15,6 +16,7 @@ public class HeadlessRenderer : IRenderer
     public Texture WhitePixel { get; }
     public Matrix4x4 ProjectionMatrix => default;
     public Storage ShaderStorage { get; set; }
+    public DiskCache ShaderCache { get; set; }
     private readonly HeadlessTextureManager textureManager;
 
     public HeadlessRenderer(HeadlessTextureManager textureManager)

--- a/Sakura.Framework/Graphics/Rendering/HeadlessShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/HeadlessShader.cs
@@ -20,5 +20,6 @@ public sealed class HeadlessShader : IShader
     public void SetUniform(string name, Color value) { }
     public void SetUniformIntArray(string name, int[] values) { }
     public void SetUniform(string name, float[] mat3X3) { }
+    public void SetUniformBlock<T>(string blockName, in T data) where T : unmanaged { }
     public void Dispose() { }
 }

--- a/Sakura.Framework/Graphics/Rendering/IRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/IRenderer.cs
@@ -4,6 +4,7 @@
 using System;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.IO;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Timing;
@@ -81,6 +82,11 @@ public interface IRenderer
     /// Set by <see cref="Platform.AppHost"/> after <see cref="Initialize"/> completes.
     /// </summary>
     Storage ShaderStorage { get; set; }
+
+    /// <summary>
+    /// Content-addressed disk cache for cross-compiled shader output
+    /// </summary>
+    DiskCache ShaderCache { get; set; }
 
     /// <summary>
     /// Creates a backend-specific shader by loading source from a <see cref="Platform.Storage"/>.

--- a/Sakura.Framework/Graphics/Rendering/IShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/IShader.cs
@@ -33,6 +33,14 @@ public interface IShader : IDisposable
     void SetUniform(string name, float[] mat3X3);
 
     /// <summary>
+    /// Uploads a std140-laid-out uniform block by name. <typeparamref name="T"/> must match the
+    /// block's GLSL layout exactly (see <c>Uniforms</c> structs). The backend owns the underlying
+    /// buffer and binds it to the block's binding point. Replaces per-name <see cref="SetUniform(string,float)"/>
+    /// calls for shaders authored in GLSL 450 with uniform blocks.
+    /// </summary>
+    void SetUniformBlock<T>(string blockName, in T data) where T : unmanaged;
+
+    /// <summary>
     /// The native program handle. Used by backend-specific code that needs raw access.
     /// </summary>
     nint Handle { get; }

--- a/Sakura.Framework/Graphics/Rendering/ShaderCompiler.cs
+++ b/Sakura.Framework/Graphics/Rendering/ShaderCompiler.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Sakura.Framework.IO;
+using Sakura.Framework.Logging;
 using Sakura.Framework.Platform;
 using Sakura.Framework.SPIRV;
 
@@ -47,7 +48,8 @@ public static partial class ShaderCompiler
         string vertSrc = ReadWithIncludes(sourceStorage, vertexPath);
         string fragSrc = ReadWithIncludes(sourceStorage, fragmentPath);
 
-        return GetOrCompileSource(vertSrc, fragSrc, target, cache);
+        // readable name for logs, e.g. "shader.vert+shader.frag".
+        return GetOrCompileSource(vertSrc, fragSrc, target, cache, $"{vertexPath}+{fragmentPath}");
     }
 
     /// <summary>
@@ -59,14 +61,22 @@ public static partial class ShaderCompiler
         string vertexSource,
         string fragmentSource,
         CrossCompileTarget target,
-        DiskCache cache = null)
+        DiskCache cache = null,
+        string name = null)
     {
         string key = $"{DiskCache.HashString(vertexSource)}" +
                      $"#{DiskCache.HashString(fragmentSource)}" +
                      $"#{(int)target}#{cache_version}";
 
+        string label = !string.IsNullOrEmpty(name) ? name : (key.Length > 12 ? key[..12] : key);
+
         if (cache != null && cache.TryReadStrings(key, out string cachedVert, out string cachedFrag))
+        {
+            Logger.Verbose($"☀️ Shader cache hit for {label} → {target}, loaded from cache");
             return (cachedVert, cachedFrag);
+        }
+
+        Logger.Verbose($"☀️ Shader cache miss for {label} → {target}, compiling");
 
         var options = new CrossCompileOptions(
             fixClipSpaceZ: false,
@@ -79,7 +89,12 @@ public static partial class ShaderCompiler
             target,
             options);
 
-        cache?.WriteStrings(key, result.VertexShader, result.FragmentShader);
+        if (cache != null)
+        {
+            cache.WriteStrings(key, result.VertexShader, result.FragmentShader);
+            Logger.Verbose($"☀️ Shader compiled for {label} -> {target}!");
+        }
+
         return (result.VertexShader, result.FragmentShader);
     }
 

--- a/Sakura.Framework/Graphics/Rendering/ShaderCompiler.cs
+++ b/Sakura.Framework/Graphics/Rendering/ShaderCompiler.cs
@@ -1,0 +1,153 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Sakura.Framework.IO;
+using Sakura.Framework.Platform;
+using Sakura.Framework.SPIRV;
+
+namespace Sakura.Framework.Graphics.Rendering;
+
+/// <summary>
+/// Shared utility that compile shader to target shader language
+/// </summary>
+public static partial class ShaderCompiler
+{
+    /// <summary>
+    /// Bump this when the compiler output format or options change to invalidate all existing
+    /// cache entries without having to clear the cache directory by hand.
+    /// </summary>
+    private const int cache_version = 1;
+
+    [GeneratedRegex(@"^\s*#\s*include\s+[""<](.*)["">]", RegexOptions.Compiled)]
+    private static partial Regex includePatternRegex();
+
+    private static readonly Regex include_pattern = includePatternRegex();
+
+    /// <summary>
+    /// Reads a vertex + fragment shader pair from <paramref name="sourceStorage"/> (resolving
+    /// <c>#include</c> directives), cross-compiles them to <paramref name="target"/>, and returns
+    /// the resulting source. The result is cached in <paramref name="cache"/> when one is supplied.
+    /// </summary>
+    /// <param name="sourceStorage">Storage containing the GLSL 450 source files.</param>
+    /// <param name="vertexPath">Path within the storage to the vertex shader (e.g. "shader.vert").</param>
+    /// <param name="fragmentPath">Path within the storage to the fragment shader (e.g. "shader.frag").</param>
+    /// <param name="target">The shading language to produce.</param>
+    /// <param name="cache">Optional disk cache. When null, compilation always runs.</param>
+    public static (string vert, string frag) GetOrCompile(
+        Storage sourceStorage,
+        string vertexPath,
+        string fragmentPath,
+        CrossCompileTarget target,
+        DiskCache cache = null)
+    {
+        string vertSrc = ReadWithIncludes(sourceStorage, vertexPath);
+        string fragSrc = ReadWithIncludes(sourceStorage, fragmentPath);
+
+        return GetOrCompileSource(vertSrc, fragSrc, target, cache);
+    }
+
+    /// <summary>
+    /// Cross-compiles already-resolved GLSL 450 source strings to <paramref name="target"/>,
+    /// using <paramref name="cache"/> when supplied. Useful when the source is generated at runtime
+    /// rather than loaded from storage.
+    /// </summary>
+    public static (string vert, string frag) GetOrCompileSource(
+        string vertexSource,
+        string fragmentSource,
+        CrossCompileTarget target,
+        DiskCache cache = null)
+    {
+        string key = $"{DiskCache.HashString(vertexSource)}" +
+                     $"#{DiskCache.HashString(fragmentSource)}" +
+                     $"#{(int)target}#{cache_version}";
+
+        if (cache != null && cache.TryReadStrings(key, out string cachedVert, out string cachedFrag))
+            return (cachedVert, cachedFrag);
+
+        var options = new CrossCompileOptions(
+            fixClipSpaceZ: false,
+            // Metal's framebuffer origin is top-left vs OpenGL's bottom-left, so flip Y for MSL only.
+            invertVertexOutputY: target == CrossCompileTarget.MSL);
+
+        VertexFragmentCompilationResult result = SpirvCompilation.CompileVertexFragment(
+            Encoding.UTF8.GetBytes(vertexSource),
+            Encoding.UTF8.GetBytes(fragmentSource),
+            target,
+            options);
+
+        cache?.WriteStrings(key, result.VertexShader, result.FragmentShader);
+        return (result.VertexShader, result.FragmentShader);
+    }
+
+    /// <summary>
+    /// Reads shader source from a <see cref="Storage"/>, recursively resolving <c>#include</c>
+    /// directives relative to the same storage. Mirrors the include handling in <c>GLShader</c>
+    /// so a shader compiles identically whether loaded directly or through this compiler.
+    /// </summary>
+    public static string ReadWithIncludes(Storage storage, string path)
+    {
+        using Stream stream = storage.GetStream(path, FileAccess.Read, FileMode.Open);
+        string src = readStream(stream);
+
+        return ResolveIncludes(src, name =>
+        {
+            try
+            {
+                using Stream s = storage.GetStream(name, FileAccess.Read, FileMode.Open);
+                return readStream(s);
+            }
+            catch (Exception ex)
+            {
+                throw new FileNotFoundException(
+                    $"Shader #include '{name}' not found in storage '{storage.GetFullPath(string.Empty)}'.", ex);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Resolves <c>#include</c> directives by passing each include name to <paramref name="loadInclude"/>.
+    /// Uses a compiled regex instead of manual string parsing — handles both <c>"file"</c> and
+    /// <c>&lt;file&gt;</c> syntax, and tolerates whitespace between <c>#</c> and <c>include</c>.
+    /// </summary>
+    public static string ResolveIncludes(string src, Func<string, string> loadInclude)
+    {
+        src = src.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        var result = new StringBuilder();
+
+        foreach (string line in src.Split('\n'))
+        {
+            Match match = include_pattern.Match(line);
+
+            if (match.Success)
+            {
+                string includeName = match.Groups[1].Value.Trim();
+                string includeSource = loadInclude(includeName);
+
+                // Recurse so included files can themselves contain #include.
+                includeSource = ResolveIncludes(includeSource, loadInclude);
+                includeSource = includeSource.TrimEnd('\n', '\r');
+
+                result.Append("// ---- begin include: ").Append(includeName).Append(" ----\n");
+                result.Append(includeSource).Append('\n');
+                result.Append("// ---- end include: ").Append(includeName).Append(" ----\n");
+            }
+            else
+            {
+                result.Append(line).Append('\n');
+            }
+        }
+
+        return result.ToString();
+    }
+
+    private static string readStream(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/Sakura.Framework/Graphics/Rendering/Uniforms/GLUniformBuffer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Uniforms/GLUniformBuffer.cs
@@ -1,0 +1,72 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using Silk.NET.OpenGL;
+
+namespace Sakura.Framework.Graphics.Rendering.Uniforms;
+
+/// <summary>
+/// A GL uniform buffer object holding a single std140-laid-out block of type
+/// <typeparamref name="T"/>, bound to a fixed binding point.
+/// </summary>
+public sealed class GLUniformBuffer<T> : IDisposable
+    where T : unmanaged
+{
+    /// <summary>The binding point this buffer is bound to (matches the shader's <c>binding=</c>).</summary>
+    public uint BindingPoint { get; }
+
+    private readonly GL gl;
+    private readonly uint handle;
+    private readonly int size;
+    private bool allocated;
+    private bool disposed;
+
+    public GLUniformBuffer(GL gl, uint bindingPoint)
+    {
+        this.gl = gl;
+        BindingPoint = bindingPoint;
+        unsafe { size = sizeof(T); }
+        handle = gl.GenBuffer();
+    }
+
+    /// <summary>
+    /// Uploads <paramref name="data"/> to the GPU. The first call allocates storage with
+    /// <c>glBufferData</c>, subsequent calls reuse it with <c>glBufferSubData</c>.
+    /// </summary>
+    public unsafe void Update(in T data)
+    {
+        gl.BindBuffer(BufferTargetARB.UniformBuffer, handle);
+
+        fixed (T* ptr = &data)
+        {
+            if (!allocated)
+            {
+                gl.BufferData(BufferTargetARB.UniformBuffer, (nuint)size, ptr, BufferUsageARB.DynamicDraw);
+                allocated = true;
+            }
+            else
+            {
+                gl.BufferSubData(BufferTargetARB.UniformBuffer, 0, (nuint)size, ptr);
+            }
+        }
+
+        gl.BindBuffer(BufferTargetARB.UniformBuffer, 0);
+    }
+
+    /// <summary>
+    /// Binds this buffer to its binding point so shaders whose matching block is linked to the
+    /// same point read from it. Safe to call every frame.
+    /// </summary>
+    public void Bind()
+    {
+        gl.BindBufferBase(BufferTargetARB.UniformBuffer, BindingPoint, handle);
+    }
+
+    public void Dispose()
+    {
+        if (disposed) return;
+        gl.DeleteBuffer(handle);
+        disposed = true;
+    }
+}

--- a/Sakura.Framework/Graphics/Rendering/Uniforms/UniformBlocks.cs
+++ b/Sakura.Framework/Graphics/Rendering/Uniforms/UniformBlocks.cs
@@ -1,0 +1,172 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Runtime.InteropServices;
+using Sakura.Framework.Maths;
+
+namespace Sakura.Framework.Graphics.Rendering.Uniforms;
+
+/// <summary>
+/// std140 layout of the framework's built-in uniform blocks.
+/// </summary>
+/// <remarks>
+/// These structs are uploaded verbatim into GL uniform buffer objects (and, later, Metal argument
+/// buffers), so their field order, sizes and padding MUST match the <c>std140</c> block declared in
+/// the corresponding GLSL 450 shader exactly. std140 rules in play here:
+/// <list type="bullet">
+/// <item><description><c>float</c>/<c>int</c> align to 4 bytes.</description></item>
+/// <item><description><c>vec2</c> aligns to 8 bytes.</description></item>
+/// <item><description><c>vec4</c> and <c>mat4</c> align to 16 bytes; a <c>mat4</c> is 64 bytes.</description></item>
+/// <item><description>GLSL <c>bool</c> in a std140 block occupies 4 bytes — represented here as <c>int</c> (0/1).</description></item>
+/// <item><description>The whole block is rounded up to a multiple of 16 bytes.</description></item>
+/// </list>
+/// <see cref="StructLayout"/> with explicit <see cref="FieldOffsetAttribute"/> is used so the layout
+/// is pinned and self-documenting rather than left to the C# compiler.
+/// </remarks>
+[StructLayout(LayoutKind.Explicit, Size = 64)]
+public struct ProjectionBlock
+{
+    /// <summary>The orthographic projection matrix. Maps to <c>mat4 u_Projection</c>.</summary>
+    [FieldOffset(0)] public Matrix4x4 Projection;
+}
+
+/// <summary>
+/// Masking + border state for the main shader. Matches <c>MaskBlock</c> in shader.frag.
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 64)]
+public struct MaskBlock
+{
+    /// <summary>
+    /// Border colour (premultiplied as elsewhere). Maps to <c>vec4 u_BorderColor</c>.
+    /// </summary>
+    [FieldOffset(0)]
+    public Vector4 BorderColor;
+
+    /// <summary>
+    /// True element centre in screen space. Maps to <c>vec2 u_MaskCenter</c>.
+    /// </summary>
+    [FieldOffset(16)]
+    public Vector2 MaskCenter;
+
+    /// <summary>
+    /// Un-sheared half size. Maps to <c>vec2 u_MaskHalfSize</c>.
+    /// </summary>
+    [FieldOffset(24)]
+    public Vector2 MaskHalfSize;
+
+    /// <summary>
+    /// Horizontal shear. Maps to <c>float u_ShearX</c>.
+    /// </summary>
+    [FieldOffset(32)]
+    public float ShearX;
+
+    /// <summary>
+    /// Corner radius. Maps to <c>float u_CornerRadius</c>.
+    /// </summary>
+    [FieldOffset(36)]
+    public float CornerRadius;
+
+    /// <summary>
+    /// Border thickness. Maps to <c>float u_BorderThickness</c>.
+    /// </summary>
+    [FieldOffset(40)]
+    public float BorderThickness;
+
+    /// <summary>
+    /// Masking enabled (0/1). Maps to <c>int u_IsMasking</c> (GLSL bool).
+    /// </summary>
+    [FieldOffset(44)]
+    public int IsMasking;
+
+    /// <summary>
+    /// Border pass enabled (0/1). Maps to <c>int u_IsBorder</c> (GLSL bool).
+    /// </summary>
+    [FieldOffset(48)]
+    public int IsBorder;
+}
+
+/// <summary>
+/// Grayscale-pass strength for <c>BufferedContainer</c>. Matches <c>GrayscaleBlock</c> in grayscale.frag.
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 16)]
+public struct GrayscaleBlock
+{
+    /// <summary>
+    /// 0 = original colours, 1 = fully grayscale. Maps to <c>float u_Strength</c>.
+    /// </summary>
+    [FieldOffset(0)]
+    public float Strength;
+}
+
+/// <summary>
+/// One separable Gaussian blur direction for <c>BufferedContainer</c>. Matches <c>BlurBlock</c> in blur.frag.
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 32)]
+public struct BlurBlock
+{
+    /// <summary>
+    /// 1.0 / texture size in pixels. Maps to <c>vec2 u_TexelSize</c>.
+    /// </summary>
+    [FieldOffset(0)]
+    public Vector2 TexelSize;
+
+    /// <summary>
+    /// (1,0) horizontal pass, (0,1) vertical pass. Maps to <c>vec2 u_Direction</c>.
+    /// </summary>
+    [FieldOffset(8)]
+    public Vector2 Direction;
+
+    /// <summary>
+    /// Gaussian sigma in texels. Maps to <c>float u_Sigma</c>.
+    /// </summary>
+    [FieldOffset(16)]
+    public float Sigma;
+
+    /// <summary>
+    /// Sampling radius (taps each side, max 64). Maps to <c>int u_Radius</c>.
+    /// </summary>
+    [FieldOffset(20)]
+    public int Radius;
+}
+
+/// <summary>
+/// YUV→RGB conversion coefficients for the video shader. Matches <c>VideoBlock</c> in video.frag.
+/// </summary>
+/// <remarks>
+/// The shader declares the coefficients as a <c>mat4</c> (using only the upper-left 3×3) because a
+/// std140 <c>mat3</c> pads each column to 16 bytes anyway; a <c>mat4</c> is the same 64 bytes with a
+/// far simpler, less error-prone layout. Use <see cref="FromMat3"/> to build it from a row-major
+/// float[9].
+/// </remarks>
+[StructLayout(LayoutKind.Explicit, Size = 64)]
+public struct VideoBlock
+{
+    /// <summary>
+    /// YUV→RGB matrix; upper-left 3×3 is used. Maps to <c>mat4 u_YuvCoeff</c>.
+    /// </summary>
+    [FieldOffset(0)]
+    public Matrix4x4 YuvCoeff;
+
+    /// <summary>
+    /// Builds a <see cref="VideoBlock"/> from a 3×3 matrix supplied as a row-major float[9],
+    /// placing it in the upper-left of a 4×4 (identity elsewhere). The GLSL side reads it as
+    /// <c>mat3(u_YuvCoeff)</c>, which takes the upper-left 3 columns × 3 rows.
+    /// </summary>
+    public static VideoBlock FromMat3(float[] m)
+    {
+        var sm = Matrix4x4.Identity;
+
+        // The GLSL source treated u_YuvCoeff as a mat3 multiplied as `coeff * yuv` with the array
+        // uploaded column-major (UniformMatrix3 convention). Matrix4x4 is row-major,
+        // and mat3(mat4) in GLSL reads columns; place the 9 values so the resulting mat3 columns
+        // match the original mat3 columns 1:1.
+        sm.M11 = m[0]; sm.M12 = m[1]; sm.M13 = m[2];
+        sm.M21 = m[3]; sm.M22 = m[4]; sm.M23 = m[5];
+        sm.M31 = m[6]; sm.M32 = m[7]; sm.M33 = m[8];
+
+        return new VideoBlock
+        {
+            YuvCoeff = sm
+        };
+    }
+}

--- a/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file for full license text.
 
 using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Rendering.Uniforms;
 
 namespace Sakura.Framework.Graphics.Video;
 
@@ -43,7 +44,10 @@ internal class VideoDrawNode : DrawNode
         renderer.FlushBatch();
 
         videoShader.Use();
-        videoShader.SetUniform("u_Projection", renderer.ProjectionMatrix);
+        videoShader.SetUniformBlock("ProjectionBlock", new ProjectionBlock
+            {
+                Projection = renderer.ProjectionMatrix
+            });
 
         // Bind Y/U/V planes to texture units 0/1/2 — GL stays inside VideoTexture.
         videoTexture.BindPlanes();
@@ -53,7 +57,7 @@ internal class VideoDrawNode : DrawNode
         videoShader.SetUniform("u_TextureV", 2);
 
         if (yuvMatrix != null)
-            videoShader.SetUniform("u_YuvCoeff", yuvMatrix);
+            videoShader.SetUniformBlock("VideoBlock", VideoBlock.FromMat3(yuvMatrix));
 
         glRenderer.DrawVerticesRaw(Vertices);
         renderer.RestoreMainShader();

--- a/Sakura.Framework/IO/DiskCache.cs
+++ b/Sakura.Framework/IO/DiskCache.cs
@@ -1,0 +1,144 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using Sakura.Framework.Platform;
+
+namespace Sakura.Framework.IO;
+
+/// <summary>
+/// A generic content-addressed disk cache backed by a <see cref="Storage"/>.
+/// </summary>
+public class DiskCache
+{
+    private readonly Storage storage;
+    private static readonly Lock write_lock = new Lock();
+
+    public DiskCache(Storage storage)
+    {
+        this.storage = storage ?? throw new ArgumentNullException(nameof(storage));
+    }
+
+    /// <summary>
+    /// Computes a hex MD5 hash of a UTF-8 string, used to build cache keys.
+    /// MD5 is used purely for content addressing (not security), matching the
+    /// framework's existing glyph-store hashing.
+    /// </summary>
+    public static string HashString(string input)
+    {
+        byte[] bytes = MD5.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Computes a hex MD5 hash of a byte array,used to build cache keys and payload checksums.
+    /// </summary>
+    public static string HashBytes(byte[] input)
+    {
+        byte[] bytes = MD5.HashData(input);
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Tries to read a previously cached entry.
+    /// </summary>
+    /// <param name="key">The cache key (a filename within the backing storage).</param>
+    /// <param name="data">The cached payload on success; <c>null</c> on miss.</param>
+    /// <returns>true on a verified hit, false on miss, corruption, or any I/O error.</returns>
+    public bool TryRead(string key, out byte[] data)
+    {
+        try
+        {
+            if (!storage.Exists(key))
+            {
+                data = null;
+                return false;
+            }
+
+            using Stream stream = storage.GetStream(key, FileAccess.Read, FileMode.Open);
+            using var reader = new BinaryReader(stream);
+
+            string storedChecksum = reader.ReadString();
+            byte[] payload = reader.ReadBytes((int)(stream.Length - stream.Position));
+
+            // Verify integrity — a truncated or tampered file fails here and is treated as a miss.
+            if (storedChecksum != HashBytes(payload))
+            {
+                data = null;
+                return false;
+            }
+
+            data = payload;
+            return true;
+        }
+        catch
+        {
+            data = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Writes data to the cache under the given key. Atomically replaces any existing entry
+    /// (via <see cref="Storage.CreateFileSafely"/>) and is safe to call from multiple threads.
+    /// </summary>
+    public void Write(string key, byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        lock (write_lock)
+        {
+            string checksum = HashBytes(data);
+
+            using Stream stream = storage.CreateFileSafely(key);
+            using var writer = new BinaryWriter(stream);
+            writer.Write(checksum);
+            writer.Write(data);
+        }
+    }
+
+    /// <summary>
+    /// Reads a cached UTF-8 string pair (e.g. a vertex + fragment shader pair).
+    /// </summary>
+    public bool TryReadStrings(string key, out string a, out string b)
+    {
+        if (!TryRead(key, out byte[] data))
+        {
+            a = b = null;
+            return false;
+        }
+
+        try
+        {
+            using var ms = new MemoryStream(data);
+            using var reader = new BinaryReader(ms);
+            a = reader.ReadString();
+            b = reader.ReadString();
+            return true;
+        }
+        catch
+        {
+            a = b = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Writes a UTF-8 string pair to the cache.
+    /// </summary>
+    public void WriteStrings(string key, string a, string b)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(a);
+            writer.Write(b);
+        }
+
+        Write(key, ms.ToArray());
+    }
+}

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -20,6 +20,7 @@ using Sakura.Framework.Extensions.ExceptionExtensions;
 using Sakura.Framework.Extensions.IEnumerableExtensions;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Input;
+using Sakura.Framework.IO;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Reactive;
@@ -714,6 +715,10 @@ public abstract class AppHost : IDisposable
     {
         Renderer = CreateRenderer();
         Renderer.ShaderStorage = FrameworkStorage.GetStorageForDirectory("Shaders");
+
+        if (Storage != null)
+            Renderer.ShaderCache = new DiskCache(Storage.GetStorageForDirectory("cache/shader"));
+
         InitializeGraphicsContext(Window, Renderer);
         Renderer.Initialize(Window.GraphicsSurface);
     }
@@ -765,7 +770,7 @@ public abstract class AppHost : IDisposable
     {
         if (IsHeadless || Renderer == null)
             return;
-        
+
         UpdateClock.ProcessFrame();
         PerformUpdate();
 

--- a/Sakura.Framework/Resources/Shaders/blur.frag
+++ b/Sakura.Framework/Resources/Shaders/blur.frag
@@ -1,24 +1,24 @@
-#version 330 core
+#version 450
 
-// One direction of a two-pass separable Gaussian blur, used by BufferedContainer.
-// Pairs with the standard shader.vert; unused varyings are simply not declared.
+layout(location = 0) in vec4 v_Color;
+layout(location = 1) in vec2 v_TexCoords;
 
-in vec4 v_Color;
-in vec2 v_TexCoords;
+layout(location = 0) out vec4 FragColor;
 
-out vec4 FragColor;
+layout(set = 1, binding = 0) uniform sampler2D u_Texture;
 
-uniform sampler2D u_Texture;
-
-// 1.0 / texture size in pixels.
-uniform vec2 u_TexelSize;
-
-// (1,0) for the horizontal pass, (0,1) for the vertical pass.
-uniform vec2 u_Direction;
-
-// Gaussian sigma in texels, and the sampling radius (taps each side, max 64).
-uniform float u_Sigma;
-uniform int u_Radius;
+// Field order matches the std140 layout in BlurBlock (C#):
+//   vec2  u_TexelSize  (offset 0)   // 1.0 / texture size in pixels
+//   vec2  u_Direction  (offset 8)   // (1,0) horizontal pass, (0,1) vertical pass
+//   float u_Sigma      (offset 16)  // Gaussian sigma in texels
+//   int   u_Radius     (offset 20)  // sampling radius (taps each side, max 64)
+layout(set = 0, binding = 3, std140) uniform BlurBlock
+{
+    vec2 u_TexelSize;
+    vec2 u_Direction;
+    float u_Sigma;
+    int u_Radius;
+};
 
 void main()
 {

--- a/Sakura.Framework/Resources/Shaders/grayscale.frag
+++ b/Sakura.Framework/Resources/Shaders/grayscale.frag
@@ -1,16 +1,19 @@
-#version 330 core
+#version 450
 
 // Grayscale pass for BufferedContainer. Pairs with the standard shader.vert.
 
-in vec4 v_Color;
-in vec2 v_TexCoords;
+layout(location = 0) in vec4 v_Color;
+layout(location = 1) in vec2 v_TexCoords;
 
-out vec4 FragColor;
+layout(location = 0) out vec4 FragColor;
 
-uniform sampler2D u_Texture;
+layout(set = 1, binding = 0) uniform sampler2D u_Texture;
 
-// 0.0 = original colors, 1.0 = fully grayscale.
-uniform float u_Strength;
+layout(set = 0, binding = 2, std140) uniform GrayscaleBlock
+{
+    // 0.0 = original colors, 1.0 = fully grayscale.
+    float u_Strength;
+};
 
 void main()
 {

--- a/Sakura.Framework/Resources/Shaders/shader.frag
+++ b/Sakura.Framework/Resources/Shaders/shader.frag
@@ -1,38 +1,47 @@
-#version 330 core
+#version 450
 
 #include "sh_Utils.glsl"
 
-in vec4 v_Color;
-in vec2 v_TexCoords;
-in vec2 v_FragPos;
-in float v_TexIndex;
-in vec4 v_ClipData;
-in float v_ClipShearX;
-in float v_ClipRadius;
+layout(location = 0) in vec4 v_Color;
+layout(location = 1) in vec2 v_TexCoords;
+layout(location = 2) in vec2 v_FragPos;
+layout(location = 3) in float v_TexIndex;
+layout(location = 4) in vec4 v_ClipData;
+layout(location = 5) in float v_ClipShearX;
+layout(location = 6) in float v_ClipRadius;
 
-out vec4 FragColor;
+layout(location = 0) out vec4 FragColor;
 
-uniform sampler2D u_Textures[8];
+layout(set = 1, binding = 0) uniform sampler2D u_Textures[8];
 
-// Masking uniforms
-uniform bool u_IsMasking;
-uniform vec2 u_MaskCenter;     // True center of the element in screen space
-uniform vec2 u_MaskHalfSize;   // Un-sheared half size (Width/2, Height/2)
-uniform float u_ShearX;        // Container.Shear.X
-uniform float u_CornerRadius;
-
-// Border uniforms
-uniform bool u_IsBorder;
-uniform float u_BorderThickness;
-uniform vec4 u_BorderColor;
+// Masking + border state. Field order matches the std140 layout in MaskBlock in C#
+//   vec4 u_BorderColor (offset 0)
+//   vec2 u_MaskCenter (offset 16)
+//   vec2 u_MaskHalfSize (offset 24)
+//   float u_ShearX (offset 32)
+//   float u_CornerRadius (offset 36)
+//   float u_BorderThickness(offset 40)
+//   int u_IsMasking (offset 44)
+//   int u_IsBorder (offset 48)
+layout(set = 0, binding = 1, std140) uniform MaskBlock
+{
+    vec4 u_BorderColor;
+    vec2 u_MaskCenter;
+    vec2 u_MaskHalfSize;
+    float u_ShearX;
+    float u_CornerRadius;
+    float u_BorderThickness;
+    int u_IsMasking;
+    int u_IsBorder;
+};
 
 void main()
 {
-    if (u_IsBorder)
+    if (u_IsBorder != 0)
     {
         vec2 posInRect = v_FragPos - u_MaskCenter;
         float sk = u_ShearX * u_MaskHalfSize.y;
-        
+
         float dist = sdRoundParallelogram(posInRect, u_MaskHalfSize, sk, u_CornerRadius);
 
         float outerAlpha = 1.0 - smoothstep(-0.5, 0.5, dist);
@@ -61,7 +70,7 @@ void main()
 
     texColor *= v_Color;
 
-    if (u_IsMasking && u_CornerRadius > 0.0)
+    if (u_IsMasking != 0 && u_CornerRadius > 0.0)
     {
         vec2 posInRect = v_FragPos - u_MaskCenter;
         float sk = u_ShearX * u_MaskHalfSize.y;

--- a/Sakura.Framework/Resources/Shaders/shader.vert
+++ b/Sakura.Framework/Resources/Shaders/shader.vert
@@ -1,22 +1,25 @@
-#version 330 core
+#version 450
 
-layout (location = 0) in vec2 aPosition;
-layout (location = 1) in vec2 aTexCoords;
-layout (location = 2) in vec4 aColor;
-layout (location = 3) in float aTexIndex;
-layout (location = 4) in vec4 aClipData;
-layout (location = 5) in float aClipShearX;
-layout (location = 6) in float aClipRadius;
+layout(location = 0) in vec2 aPosition;
+layout(location = 1) in vec2 aTexCoords;
+layout(location = 2) in vec4 aColor;
+layout(location = 3) in float aTexIndex;
+layout(location = 4) in vec4 aClipData;
+layout(location = 5) in float aClipShearX;
+layout(location = 6) in float aClipRadius;
 
-out vec4 v_Color;
-out vec2 v_TexCoords;
-out vec2 v_FragPos;
-out float v_TexIndex;
-out vec4 v_ClipData;
-out float v_ClipShearX;
-out float v_ClipRadius;
+layout(location = 0) out vec4 v_Color;
+layout(location = 1) out vec2 v_TexCoords;
+layout(location = 2) out vec2 v_FragPos;
+layout(location = 3) out float v_TexIndex;
+layout(location = 4) out vec4 v_ClipData;
+layout(location = 5) out float v_ClipShearX;
+layout(location = 6) out float v_ClipRadius;
 
-uniform mat4 u_Projection;
+layout(set = 0, binding = 0, std140) uniform ProjectionBlock
+{
+    mat4 u_Projection;
+};
 
 void main()
 {

--- a/Sakura.Framework/Resources/Shaders/video.frag
+++ b/Sakura.Framework/Resources/Shaders/video.frag
@@ -1,33 +1,36 @@
-#version 330 core
+#version 450
 
 #include "sh_Utils.glsl"
 
-in vec4 v_Color;
-in vec2 v_TexCoords;
-in vec2 v_FragPos;
-in vec4 v_ClipData;
-in float v_ClipShearX;
-in float v_ClipRadius;
+layout(location = 0) in vec4 v_Color;
+layout(location = 1) in vec2 v_TexCoords;
+layout(location = 2) in vec2 v_FragPos;
+layout(location = 3) in vec4 v_ClipData;
+layout(location = 4) in float v_ClipShearX;
+layout(location = 5) in float v_ClipRadius;
 
-out vec4 FragColor;
+layout(location = 0) out vec4 FragColor;
 
 // Y, U (Cb), V (Cr) planes -- each is a single-channel R8 texture
-uniform sampler2D u_TextureY;
-uniform sampler2D u_TextureU;
-uniform sampler2D u_TextureV;
+layout(set = 1, binding = 0) uniform sampler2D u_TextureY;
+layout(set = 1, binding = 1) uniform sampler2D u_TextureU;
+layout(set = 1, binding = 2) uniform sampler2D u_TextureV;
 
-// YUV -> RGB conversion matrix (column-major).
-// Supports both Rec.601 (SD) and Rec.709 (HD) colour spaces.
-uniform mat3 u_YuvCoeff;
+// YUV -> RGB conversion. Carried as a mat4 for a clean std140 layout (a mat3 would pad each
+// column to 16 bytes anyway); only the upper-left 3x3 is used. Matches VideoBlock in C#.
+layout(set = 0, binding = 4, std140) uniform VideoBlock
+{
+    mat4 u_YuvCoeff;
+};
 
 void main()
 {
     float y  = texture(u_TextureY, v_TexCoords).r;
     float cb = texture(u_TextureU, v_TexCoords).r;
     float cr = texture(u_TextureV, v_TexCoords).r;
-    
+
     vec3 yuv = vec3(y - 0.0625, cb - 0.5, cr - 0.5);
-    vec3 rgb = clamp(u_YuvCoeff * yuv, 0.0, 1.0);
+    vec3 rgb = clamp(mat3(u_YuvCoeff) * yuv, 0.0, 1.0);
 
     // The YUV matrix produces gamma-encoded (non-linear) RGB values matching the
     // video stream's transfer function (approx. BT.709 gamma ~2.2).

--- a/Sakura.Framework/Resources/Shaders/video.vert
+++ b/Sakura.Framework/Resources/Shaders/video.vert
@@ -1,21 +1,24 @@
-#version 330 core
+#version 450
 
-layout (location = 0) in vec2 aPosition;
-layout (location = 1) in vec2 aTexCoords;
-layout (location = 2) in vec4 aColor;
-layout (location = 3) in float aTexIndex;
-layout (location = 4) in vec4 aClipData;
-layout (location = 5) in float aClipShearX;
-layout (location = 6) in float aClipRadius;
+layout(location = 0) in vec2 aPosition;
+layout(location = 1) in vec2 aTexCoords;
+layout(location = 2) in vec4 aColor;
+layout(location = 3) in float aTexIndex;
+layout(location = 4) in vec4 aClipData;
+layout(location = 5) in float aClipShearX;
+layout(location = 6) in float aClipRadius;
 
-out vec4 v_Color;
-out vec2 v_TexCoords;
-out vec2 v_FragPos;
-out vec4 v_ClipData;
-out float v_ClipShearX;
-out float v_ClipRadius;
+layout(location = 0) out vec4 v_Color;
+layout(location = 1) out vec2 v_TexCoords;
+layout(location = 2) out vec2 v_FragPos;
+layout(location = 3) out vec4 v_ClipData;
+layout(location = 4) out float v_ClipShearX;
+layout(location = 5) out float v_ClipRadius;
 
-uniform mat4 u_Projection;
+layout(set = 0, binding = 0, std140) uniform ProjectionBlock
+{
+    mat4 u_Projection;
+};
 
 void main()
 {

--- a/Sakura.Framework/Sakura.Framework.csproj
+++ b/Sakura.Framework/Sakura.Framework.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sakura.Framework.SPIRV" Version="2026.608.1" />
+    <PackageReference Include="Sakura.Framework.SPIRV" Version="2026.617.0" />
     <PackageReference Include="ppy.SDL3-CS" Version="2026.520.0" />
     <PackageReference Include="Silk.NET.OpenGL" Version="2.22.0" />
     <PackageReference Include="Silk.NET.Maths" Version="2.22.0" />


### PR DESCRIPTION
To further support new renderer, I just add SPIRV support but it's still not used anywhere so the GLSL that's still using version 330 need to bump to version 450 for cross-compile to other shader language (e.g. MSL etc.). Also add caching support since it's take sometime on SPIRV to run so it's not worth to run everytime on start the app. The caching utility I tried to make it usable not just shader so it can be used in other application factor too.

So now the flow be like

- OpenGL -> Use SPIRV to compile shader to version 330
- Other renderer -> Use SPIRV to compile to its shader language

Also added test!