### PR TITLE
Fix fallback font chain not persistence when specified weight

### DIFF
--- a/Sakura.Framework.Tests/Extensions/IconUsageExtensionsTest.cs
+++ b/Sakura.Framework.Tests/Extensions/IconUsageExtensionsTest.cs
@@ -1,0 +1,37 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Extensions.IconUsageExtensions;
+using Sakura.Framework.Graphics.Drawables;
+
+namespace Sakura.Framework.Tests.Extensions;
+
+public class IconUsageExtensionsTest
+{
+    [Test]
+    public void TestToGlyphMatchesCodepoint()
+    {
+        string glyph = IconUsage.PlayArrow.ToGlyph();
+
+        Assert.That(glyph, Is.EqualTo(char.ConvertFromUtf32((int)IconUsage.PlayArrow)));
+    }
+
+    [Test]
+    public void TestToGlyphRoundTrips()
+    {
+        string glyph = IconUsage.Alarm.ToGlyph();
+
+        // the produced string should decode back to the same codepoint.
+        Assert.That(char.ConvertToUtf32(glyph, 0), Is.EqualTo((int)IconUsage.Alarm));
+    }
+
+    [Test]
+    public void TestToGlyphComposesWithText()
+    {
+        string composed = $"Play {IconUsage.PlayArrow.ToGlyph()}";
+
+        Assert.That(composed, Does.StartWith("Play "));
+        Assert.That(composed, Does.EndWith(IconUsage.PlayArrow.ToGlyph()));
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestIconSprite.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestIconSprite.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NUnit.Framework;
 using Sakura.Framework.Allocation;
 using Sakura.Framework.Extensions.DrawableExtensions;
+using Sakura.Framework.Extensions.IconUsageExtensions;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
@@ -96,7 +97,7 @@ public partial class TestIconSprite : TestScene
                 Origin = Anchor.Centre,
                 Color = Color.White,
                 Font = FontUsage.Default.With(size: 40, weight: nameof(DefaultFontWeights.Bold)),
-                Text = "Bold alarm " + char.ConvertFromUtf32((int)IconUsage.Alarm)
+                Text = $"Bold alarm {IconUsage.Alarm.ToGlyph()}"
             };
             Add(text);
         });

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestIconSprite.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestIconSprite.cs
@@ -1,11 +1,14 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System.Linq;
 using NUnit.Framework;
+using Sakura.Framework.Allocation;
 using Sakura.Framework.Extensions.DrawableExtensions;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Text;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Testing;
 
@@ -13,6 +16,9 @@ namespace Sakura.Framework.Tests.Visuals.Drawables;
 
 public partial class TestIconSprite : TestScene
 {
+    [Resolved]
+    private IFontStore fontStore { get; set; } = null!;
+
     private IconSprite icon;
 
     [SetUp]
@@ -77,5 +83,41 @@ public partial class TestIconSprite : TestScene
             };
             Add(text);
         });
+    }
+
+    [Test]
+    public void TestIconInBoldSpriteText()
+    {
+        AddStep("Add a Bold SpriteText with an icon", () =>
+        {
+            var text = new SpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Color = Color.White,
+                Font = FontUsage.Default.With(size: 40, weight: nameof(DefaultFontWeights.Bold)),
+                Text = "Bold alarm " + char.ConvertFromUtf32((int)IconUsage.Alarm)
+            };
+            Add(text);
+        });
+    }
+
+    [Test]
+    public void TestIconFallbackSurvivesWeightOverride()
+    {
+        AddAssert("Material font is a fallback for Regular", () => iconFontIsFallbackFor(FontUsage.Default));
+        AddAssert("Material font is a fallback for Bold", () => iconFontIsFallbackFor(FontUsage.Default.With(weight: nameof(DefaultFontWeights.Bold))));
+        AddAssert("Material font is a fallback for Bold Italic", () => iconFontIsFallbackFor(FontUsage.Default.With(weight: nameof(DefaultFontWeights.Bold), italics: true)));
+    }
+
+    private bool iconFontIsFallbackFor(FontUsage usage)
+    {
+        var materialFont = fontStore.Get("MaterialSymbolsOutlined");
+
+        // headless font stores return null and have no fallbacks, this work only on real renderer
+        if (materialFont == null)
+            return true;
+
+        return fontStore.GetFallbacks(usage).Contains(materialFont);
     }
 }

--- a/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
+++ b/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Maths;
 
@@ -362,13 +363,4 @@ public static class TransformExtensions
         drawable.Scheduler.AddDelayed(action, delay);
         return drawable;
     }
-}
-
-/// <summary>
-/// Direction of rotation for <see cref="TransformExtensions.Spin"/>.
-/// </summary>
-public enum RotationDirection
-{
-    Clockwise,
-    CounterClockwise
 }

--- a/Sakura.Framework/Extensions/IconUsageExtensions/IconUsageExtensions.cs
+++ b/Sakura.Framework/Extensions/IconUsageExtensions/IconUsageExtensions.cs
@@ -1,0 +1,27 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Graphics.Drawables;
+
+namespace Sakura.Framework.Extensions.IconUsageExtensions;
+
+/// <summary>
+/// Extensions for working with <see cref="IconUsage"/> icons in text.
+/// </summary>
+public static class IconUsageExtensions
+{
+    /// <summary>
+    /// Converts an <see cref="IconUsage"/> into the string it represents, so it can be placed directly
+    /// in a <see cref="SpriteText.Text"/> or interpolated alongside other text. The icon font is
+    /// resolved automatically via the font fallback chain, so this works even when the surrounding
+    /// text uses a different (e.g. bold or custom) font.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// new SpriteText { Text = $"Play {IconUsage.PlayArrow.ToGlyph()}" };
+    /// </code>
+    /// </example>
+    /// <param name="icon">The icon to convert.</param>
+    /// <returns>The string (which may be a surrogate pair) representing the icon glyph.</returns>
+    public static string ToGlyph(this IconUsage icon) => char.ConvertFromUtf32((int)icon);
+}

--- a/Sakura.Framework/Extensions/TransformSequenceExtensions/TransformSequenceExtensions.cs
+++ b/Sakura.Framework/Extensions/TransformSequenceExtensions/TransformSequenceExtensions.cs
@@ -4,6 +4,7 @@
 using Sakura.Framework.Extensions.DrawableExtensions;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Maths;
 

--- a/Sakura.Framework/Graphics/Drawables/IconSprite.cs
+++ b/Sakura.Framework/Graphics/Drawables/IconSprite.cs
@@ -1,6 +1,8 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using Sakura.Framework.Extensions.IconUsageExtensions;
+
 namespace Sakura.Framework.Graphics.Drawables;
 
 /// <summary>
@@ -25,7 +27,7 @@ public partial class IconSprite : SpriteText
         {
             if (icon == value) return;
             icon = value;
-            Text = char.ConvertFromUtf32((int)icon);
+            Text = icon.ToGlyph();
         }
     }
 

--- a/Sakura.Framework/Graphics/Primitives/RotationDirection.cs
+++ b/Sakura.Framework/Graphics/Primitives/RotationDirection.cs
@@ -1,0 +1,15 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Extensions.DrawableExtensions;
+
+namespace Sakura.Framework.Graphics.Primitives;
+
+/// <summary>
+/// Direction of rotation for <see cref="TransformExtensions.Spin"/>.
+/// </summary>
+public enum RotationDirection
+{
+    Clockwise,
+    CounterClockwise
+}

--- a/Sakura.Framework/Graphics/Text/RendererFontStore.cs
+++ b/Sakura.Framework/Graphics/Text/RendererFontStore.cs
@@ -74,9 +74,13 @@ public class RendererFontStore : IFontStore
 
         // Material Symbols for IconSprite
         // TODO: The material symbols font support variable font with different weights and italics, should add support in future.
+        // These are single-weight fonts, also add fallback with non-weight
         AddFont(resourceStorage, "MaterialSymbolsOutlined-Regular.ttf", alias: "MaterialSymbolsOutlined-Regular");
+        addFontAlias("MaterialSymbolsOutlined-Regular", "MaterialSymbolsOutlined");
         AddFont(resourceStorage, "MaterialSymbolsRounded-Regular.ttf", alias: "MaterialSymbolsRounded-Regular");
+        addFontAlias("MaterialSymbolsRounded-Regular", "MaterialSymbolsRounded");
         AddFont(resourceStorage, "MaterialSymbolsSharp-Regular.ttf", alias: "MaterialSymbolsSharp-Regular");
+        addFontAlias("MaterialSymbolsSharp-Regular", "MaterialSymbolsSharp");
         AddFallbackFamily("MaterialSymbolsOutlined");
     }
 
@@ -91,6 +95,10 @@ public class RendererFontStore : IFontStore
             // AddFont already has a try-catch and checks if the stream is null,
             // so it will safely skip weights that don't exist in the storage.
             AddFont(storage, normalFileName, alias: $"{family}-{weight}");
+
+            // Add regular font as normal fallback too
+            if (weight == nameof(DefaultFontWeights.Regular))
+                addFontAlias($"{family}-{weight}", family);
 
             if (hasItalics)
             {
@@ -133,6 +141,22 @@ public class RendererFontStore : IFontStore
                 return null!;
             }
         });
+    }
+
+    /// <summary>
+    /// Registers an additional cache key that points at an already-registered font, sharing the same
+    /// underlying <see cref="Font"/> instance. Use this instead of calling <see cref="AddFont"/> again
+    /// for the same file, so the font is loaded once and lookups by either key return the same object
+    /// (important for reference-identity comparisons in fallback resolution).
+    /// </summary>
+    private void addFontAlias(string existingKey, string alias)
+    {
+        if (existingKey == alias) return;
+
+        if (fontCache.TryGetValue(existingKey, out var existing))
+            fontCache[alias] = existing;
+        else
+            Logger.Warning($"Cannot alias font '{alias}' to missing key '{existingKey}'.");
     }
 
     private Font loadFontFromStream(string name, Stream stream)
@@ -195,14 +219,13 @@ public class RendererFontStore : IFontStore
 
         foreach (string family in fallbackFamilies)
         {
-            var fallbackUsage = usage.With(family: family);
-            var fallbackFont = Get(fallbackUsage);
+            var fallbackFont = Get(usage.With(family: family));
 
-            if (fallbackFont != null && fallbackFont != defaultFont && !returnedFonts.Contains(fallbackFont))
-            {
-                returnedFonts.Add(fallbackFont);
+            if (fallbackFont == defaultFont || fallbackFont == null)
+                fallbackFont = Get(family);
+
+            if (fallbackFont != null && fallbackFont != defaultFont && returnedFonts.Add(fallbackFont))
                 yield return fallbackFont;
-            }
         }
     }
 


### PR DESCRIPTION
Now if the requested font with that weight is not available it will start looking in fallback chain. This also applied in the icon usage too since our icon usage built on top of font renderer. So if you render mix of normal text and icon (using `char.ConvertFromUtf32`) with "bold" weight, in the icon part it will finding the "MaterialIcon-Bold" that we don't have since we only have regular, this PR make the fallback more weight-tolerant by make it look for regular weight instead too.

Also since I use mix of icon and text in `SpriteText` so I add a new extension for `IconUsage` for make my sanity better in `char.ConvertFromUtf32` everywhere.

```csharp
// before
Text = $"Play {char.ConvertFromUtf32((int)IconUsage.PlayArrow))}
// new
Text = $"Play {IconUsage.PlayArrow.ToGlyph()}
```