### PR TITLE
Add support for safe nullable in DI

### DIFF
--- a/Sakura.Framework.SourceGenerators.Tests/DependencyInjectionAnalyzerTests.cs
+++ b/Sakura.Framework.SourceGenerators.Tests/DependencyInjectionAnalyzerTests.cs
@@ -1,6 +1,7 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Sakura.Framework.CodeFixes.Analyzers;
@@ -21,16 +22,25 @@ public class DependencyInjectionAnalyzerTests
         namespace Sakura.Framework.Allocation
         {
             public interface IDependencyInjectionCandidate { }
-            public interface IReadOnlyDependencyContainer { T Get<T>() where T : class; }
+            public interface IReadOnlyDependencyContainer { T Get<T>() where T : class; T? TryGet<T>() where T : class; }
             public class DependencyContainer : IReadOnlyDependencyContainer
             {
                 public DependencyContainer(IReadOnlyDependencyContainer? parent = null) { }
                 public T Get<T>() where T : class => default!;
+                public T? TryGet<T>() where T : class => default;
                 public void CacheAs<T>(object instance) where T : class { }
             }
 
             [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
-            public class ResolvedAttribute : System.Attribute { }
+            public class ResolvedAttribute : System.Attribute
+            {
+                public bool CanBeNull { get; init; }
+                public ResolvedAttribute() { }
+                public ResolvedAttribute(bool canBeNull) { CanBeNull = canBeNull; }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Parameter)]
+            public sealed class CanBeNullAttribute : System.Attribute { }
 
             [System.AttributeUsage(System.AttributeTargets.Method)]
             public class BackgroundDependencyLoaderAttribute : System.Attribute { }
@@ -508,5 +518,77 @@ public class DependencyInjectionAnalyzerTests
             """;
 
         AnalyzerTestHelper.AssertNoDiagnostics<DependencyInjectionAnalyzer>(stubs, source);
+    }
+
+    [Test]
+    public void SFDI0007_reported_when_canBeNull_member_is_non_nullable()
+    {
+        const string source = """
+            #nullable enable
+            using Sakura.Framework.Allocation;
+            namespace WaguriGame
+            {
+                public abstract partial class Drawable : IDependencyInjectionCandidate { }
+
+                public partial class SpriteText : Drawable
+                {
+                    // Non-nullable type but marked optional — should trigger SFDI0007.
+                    [Resolved(canBeNull: true)]
+                    private IFont font { get; set; } = null!;
+                }
+
+                public interface IFont { }
+            }
+            """;
+
+        AnalyzerTestHelper.AssertSingleDiagnostic<DependencyInjectionAnalyzer>("SFDI0007", stubs, source);
+    }
+
+    [Test]
+    public void SFDI0007_not_reported_when_canBeNull_member_is_nullable()
+    {
+        const string source = """
+            #nullable enable
+            using Sakura.Framework.Allocation;
+            namespace WaguriGame
+            {
+                public abstract partial class Drawable : IDependencyInjectionCandidate { }
+
+                public partial class SpriteText : Drawable
+                {
+                    [Resolved(canBeNull: true)]
+                    private IFont? font { get; set; }
+                }
+
+                public interface IFont { }
+            }
+            """;
+
+        var diagnostics = AnalyzerTestHelper.GetDiagnostics<DependencyInjectionAnalyzer>(stubs, source);
+        Assert.That(diagnostics.Any(d => d.Id == "SFDI0007"), Is.False);
+    }
+
+    [Test]
+    public void SFDI0007_not_reported_for_required_resolved_member()
+    {
+        const string source = """
+            #nullable enable
+            using Sakura.Framework.Allocation;
+            namespace WaguriGame
+            {
+                public abstract partial class Drawable : IDependencyInjectionCandidate { }
+
+                public partial class SpriteText : Drawable
+                {
+                    [Resolved]
+                    private IFont font { get; set; } = null!;
+                }
+
+                public interface IFont { }
+            }
+            """;
+
+        var diagnostics = AnalyzerTestHelper.GetDiagnostics<DependencyInjectionAnalyzer>(stubs, source);
+        Assert.That(diagnostics.Any(d => d.Id == "SFDI0007"), Is.False);
     }
 }

--- a/Sakura.Framework.SourceGenerators.Tests/DependencyInjectionGeneratorTests.cs
+++ b/Sakura.Framework.SourceGenerators.Tests/DependencyInjectionGeneratorTests.cs
@@ -34,17 +34,26 @@ public class DependencyInjectionGeneratorTests
             }
             public delegate void InjectDependenciesDelegate(object target, IReadOnlyDependencyContainer dependencies);
             public delegate IReadOnlyDependencyContainer CacheDependenciesDelegate(object target, IReadOnlyDependencyContainer? parent);
-            public interface IReadOnlyDependencyContainer { T Get<T>() where T : class; void Inject<T>(T instance) where T : class; }
+            public interface IReadOnlyDependencyContainer { T Get<T>() where T : class; T? TryGet<T>() where T : class; void Inject<T>(T instance) where T : class; }
             public class DependencyContainer : IReadOnlyDependencyContainer
             {
                 public DependencyContainer(IReadOnlyDependencyContainer? parent = null) { }
                 public T Get<T>() where T : class => default!;
+                public T? TryGet<T>() where T : class => default;
                 public void Inject<T>(T instance) where T : class { }
                 public void CacheAs<T>(object instance) where T : class { }
             }
 
             [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
-            public class ResolvedAttribute : System.Attribute { }
+            public class ResolvedAttribute : System.Attribute
+            {
+                public bool CanBeNull { get; init; }
+                public ResolvedAttribute() { }
+                public ResolvedAttribute(bool canBeNull) { CanBeNull = canBeNull; }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Parameter)]
+            public sealed class CanBeNullAttribute : System.Attribute { }
 
             [System.AttributeUsage(System.AttributeTargets.Method)]
             public class BackgroundDependencyLoaderAttribute : System.Attribute { }
@@ -118,6 +127,92 @@ public class DependencyInjectionGeneratorTests
             // No [Cached] — cache delegate should be null
             Assert.That(generated, Does.Contain("null"));
         });
+    }
+
+    // [Resolved(canBeNull: true)] — positional ctor form should emit TryGet<T>()
+
+    [Test]
+    public void Resolved_canBeNull_positional_generates_TryGet()
+    {
+        const string source = """
+            using Sakura.Framework.Allocation;
+            namespace WaguriApp
+            {
+                public abstract partial class Drawable : IDependencyInjectionCandidate { }
+
+                public partial class SpriteText : Drawable
+                {
+                    [Resolved(canBeNull: true)]
+                    private IFontStore? fontStore { get; set; }
+                }
+
+                public interface IFontStore { }
+            }
+            """;
+
+        var result = GeneratorTestHelper.RunGenerator<DependencyInjectionGenerator>(stubs, source);
+        string generated = GeneratorTestHelper.GetGeneratedSource(result, "WaguriApp_SpriteText.DI.g.cs");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(generated, Does.Contain("self.fontStore = deps.TryGet<global::WaguriApp.IFontStore>()"));
+            Assert.That(generated, Does.Not.Contain("deps.Get<global::WaguriApp.IFontStore>()"));
+        });
+    }
+
+    // [Resolved(CanBeNull = true)] — named property form should also emit TryGet<T>()
+
+    [Test]
+    public void Resolved_canBeNull_named_generates_TryGet()
+    {
+        const string source = """
+            using Sakura.Framework.Allocation;
+            namespace WaguriApp
+            {
+                public abstract partial class Drawable : IDependencyInjectionCandidate { }
+
+                public partial class SpriteText : Drawable
+                {
+                    [Resolved(CanBeNull = true)]
+                    private IFontStore? fontStore { get; set; }
+                }
+
+                public interface IFontStore { }
+            }
+            """;
+
+        var result = GeneratorTestHelper.RunGenerator<DependencyInjectionGenerator>(stubs, source);
+        string generated = GeneratorTestHelper.GetGeneratedSource(result, "WaguriApp_SpriteText.DI.g.cs");
+
+        Assert.That(generated, Does.Contain("self.fontStore = deps.TryGet<global::WaguriApp.IFontStore>()"));
+    }
+
+    // [BackgroundDependencyLoader] with a [CanBeNull] parameter should resolve via TryGet<T>()
+
+    [Test]
+    public void BackgroundDependencyLoader_canBeNull_param_generates_TryGet()
+    {
+        const string source = """
+            using Sakura.Framework.Allocation;
+            namespace WaguriApp
+            {
+                public abstract partial class Drawable : IDependencyInjectionCandidate { }
+
+                public partial class VideoSprite : Drawable
+                {
+                    [BackgroundDependencyLoader]
+                    private void load(IRenderer renderer, [CanBeNull] ITextureManager textures) { }
+                }
+
+                public interface IRenderer { }
+                public interface ITextureManager { }
+            }
+            """;
+
+        var result = GeneratorTestHelper.RunGenerator<DependencyInjectionGenerator>(stubs, source);
+        string generated = GeneratorTestHelper.GetGeneratedSource(result, "WaguriApp_VideoSprite.DI.g.cs");
+
+        Assert.That(generated, Does.Contain("self.load(deps.Get<global::WaguriApp.IRenderer>(), deps.TryGet<global::WaguriApp.ITextureManager>())"));
     }
 
     // [Resolved] field (not property)

--- a/Sakura.Framework.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/Sakura.Framework.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -13,3 +13,4 @@ SFDI0003 | Sakura.DI | Error   | [Resolved] property must have a setter
 SFDI0004 | Sakura.DI | Warning | Only one [BackgroundDependencyLoader] method is allowed per class
 SFDI0005 | Sakura.DI | Error   | [Resolved] cannot be applied to a static member
 SFDI0006 | Sakura.DI | Error   | [Cached] property must have a getter
+SFDI0007 | Sakura.DI | Warning | [Resolved(canBeNull: true)] member should be a nullable type

--- a/Sakura.Framework.SourceGenerators/Analyzers/DependencyInjectionAnalyzer.cs
+++ b/Sakura.Framework.SourceGenerators/Analyzers/DependencyInjectionAnalyzer.cs
@@ -78,6 +78,16 @@ public sealed class DependencyInjectionAnalyzer : DiagnosticAnalyzer
         description: "The DI system caches [Cached] property values by reading through the getter. A write-only property cannot be cached.",
         helpLinkUri: "https://github.com/HelloYeew/sakura/wiki");
 
+    public static readonly DiagnosticDescriptor NULLABLE_RESOLVED_ON_NON_NULLABLE_TYPE = new DiagnosticDescriptor(
+        id: "SFDI0007",
+        title: "[Resolved(canBeNull: true)] member should be a nullable type",
+        messageFormat: "'{0}' is marked [Resolved(canBeNull: true)] but its type is not nullable; declare it as a nullable reference type (e.g. 'T?').",
+        category: "Sakura.DI",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "An optional [Resolved] member resolves to null when the dependency is missing. Declaring it as a nullable reference type makes the possible null visible at use sites and avoids false non-null assumptions.",
+        helpLinkUri: "https://github.com/HelloYeew/sakura/wiki");
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         => ImmutableArray.Create(
             MISSING_PARTIAL_ON_DI_CLASS,
@@ -85,7 +95,8 @@ public sealed class DependencyInjectionAnalyzer : DiagnosticAnalyzer
             RESOLVED_PROPERTY_HAS_NO_SETTER,
             MULTIPLE_BACKGROUND_LOADERS,
             RESOLVED_ON_STATIC_MEMBER,
-            CACHED_PROPERTY_HAS_NO_GETTER);
+            CACHED_PROPERTY_HAS_NO_GETTER,
+            NULLABLE_RESOLVED_ON_NON_NULLABLE_TYPE);
 
     private const string resolved_fqn = "Sakura.Framework.Allocation.ResolvedAttribute";
     private const string cached_fqn = "Sakura.Framework.Allocation.CachedAttribute";
@@ -163,8 +174,9 @@ public sealed class DependencyInjectionAnalyzer : DiagnosticAnalyzer
                 }
             }
 
-            // SFDI0003, SFDI0005 — [Resolved] checks
-            if (hasAttribute(member, resolved_fqn))
+            // SFDI0003, SFDI0005, SFDI0007 — [Resolved] checks
+            var resolvedAttr = getAttribute(member, resolved_fqn);
+            if (resolvedAttr != null)
             {
                 var loc = getFirstLocation(member, context);
 
@@ -177,11 +189,20 @@ public sealed class DependencyInjectionAnalyzer : DiagnosticAnalyzer
                     // SFDI0003 — no setter
                     if (resolvedProp.SetMethod == null)
                         context.ReportDiagnostic(Diagnostic.Create(RESOLVED_PROPERTY_HAS_NO_SETTER, loc, member.Name));
+
+                    // SFDI0007 — canBeNull on a non-nullable type
+                    if (isNullableResolvedOnNonNullable(resolvedAttr, resolvedProp.Type))
+                        context.ReportDiagnostic(Diagnostic.Create(NULLABLE_RESOLVED_ON_NON_NULLABLE_TYPE, loc, member.Name));
                 }
-                else if (member is IFieldSymbol resolvedField && resolvedField.IsStatic)
+                else if (member is IFieldSymbol resolvedField)
                 {
                     // SFDI0005 — static field
-                    context.ReportDiagnostic(Diagnostic.Create(RESOLVED_ON_STATIC_MEMBER, loc, member.Name));
+                    if (resolvedField.IsStatic)
+                        context.ReportDiagnostic(Diagnostic.Create(RESOLVED_ON_STATIC_MEMBER, loc, member.Name));
+
+                    // SFDI0007 — canBeNull on a non-nullable type
+                    if (isNullableResolvedOnNonNullable(resolvedAttr, resolvedField.Type))
+                        context.ReportDiagnostic(Diagnostic.Create(NULLABLE_RESOLVED_ON_NON_NULLABLE_TYPE, loc, member.Name));
                 }
             }
 
@@ -224,6 +245,42 @@ public sealed class DependencyInjectionAnalyzer : DiagnosticAnalyzer
         => symbol.GetAttributes().Any(a =>
             a.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
              .Replace("global::", string.Empty) == fqn);
+
+    private static AttributeData? getAttribute(ISymbol symbol, string fqn)
+        => symbol.GetAttributes().FirstOrDefault(a =>
+            a.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+             .Replace("global::", string.Empty) == fqn);
+
+    /// <summary>
+    /// True when a [Resolved] attribute opts into canBeNull (via ctor arg or named property) but the
+    /// member's type is a non-nullable reference type, which SFDI0007 flags.
+    /// </summary>
+    private static bool isNullableResolvedOnNonNullable(AttributeData resolvedAttr, ITypeSymbol memberType)
+    {
+        if (!getResolvedCanBeNull(resolvedAttr))
+            return false;
+
+        // Value types are out of scope (TryGet/Get require a reference type anyway).
+        if (!memberType.IsReferenceType)
+            return false;
+
+        // Already nullable (e.g. `Foo?`) — nothing to flag.
+        return memberType.NullableAnnotation != NullableAnnotation.Annotated;
+    }
+
+    private static bool getResolvedCanBeNull(AttributeData attr)
+    {
+        if (attr.ConstructorArguments.Length > 0 && attr.ConstructorArguments[0].Value is bool ctorValue)
+            return ctorValue;
+
+        foreach (var named in attr.NamedArguments)
+        {
+            if (named.Key == "CanBeNull" && named.Value.Value is bool namedValue)
+                return namedValue;
+        }
+
+        return false;
+    }
 
     private static Location getFirstLocation(ISymbol symbol, SymbolAnalysisContext context)
     {

--- a/Sakura.Framework.SourceGenerators/Generators/Dependencies/DependenciesClassCandidate.cs
+++ b/Sakura.Framework.SourceGenerators/Generators/Dependencies/DependenciesClassCandidate.cs
@@ -95,6 +95,12 @@ internal sealed class ResolvedMemberData
     /// True if this is a field; false if it is a property.
     /// </summary>
     public bool IsField { get; set; }
+
+    /// <summary>
+    /// True when the member is marked <c>[Resolved(canBeNull: true)]</c>, meaning it should be
+    /// resolved via <c>TryGet&lt;T&gt;</c> (null when missing) rather than <c>Get&lt;T&gt;</c>.
+    /// </summary>
+    public bool CanBeNull { get; set; }
 }
 
 /// <summary>
@@ -122,6 +128,12 @@ internal sealed class BackgroundLoaderParameterData
     /// Fully qualified type, e.g. "global::Sakura.Framework.AppHost"
     /// </summary>
     public string FullyQualifiedTypeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when the parameter is marked <c>[CanBeNull]</c> or declared as a nullable reference
+    /// type, meaning it should be resolved via <c>TryGet&lt;T&gt;</c> rather than <c>Get&lt;T&gt;</c>.
+    /// </summary>
+    public bool CanBeNull { get; set; }
 }
 
 /// <summary>

--- a/Sakura.Framework.SourceGenerators/Generators/Dependencies/DependencyInjectionGenerator.cs
+++ b/Sakura.Framework.SourceGenerators/Generators/Dependencies/DependencyInjectionGenerator.cs
@@ -28,6 +28,7 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
 {
     // Fully qualified attribute names used to recognize DI members.
     private const string resolved_attribute = "Sakura.Framework.Allocation.ResolvedAttribute";
+    private const string can_be_null_attribute = "Sakura.Framework.Allocation.CanBeNullAttribute";
     private const string cached_attribute = "Sakura.Framework.Allocation.CachedAttribute";
     private const string background_loader_attribute = "Sakura.Framework.Allocation.BackgroundDependencyLoaderAttribute";
     private const string candidate_interface = "Sakura.Framework.Allocation.IDependencyInjectionCandidate";
@@ -45,10 +46,6 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
 
         context.RegisterSourceOutput(candidates, emit);
     }
-
-    // -------------------------------------------------------------------------
-    // Pipeline: predicate
-    // -------------------------------------------------------------------------
 
     /// <summary>
     /// Syntax-only check that does this class declaration look like a DI candidate?
@@ -153,7 +150,10 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
         var resolvedMembers = new List<ResolvedMemberData>();
         foreach (var member in symbol.GetMembers())
         {
-            if (!hasAttribute(member, resolved_attribute)) continue;
+            var resolvedAttr = getAttribute(member, resolved_attribute);
+            if (resolvedAttr == null) continue;
+
+            bool canBeNull = getResolvedCanBeNull(resolvedAttr);
 
             switch (member)
             {
@@ -163,6 +163,7 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
                         MemberName = prop.Name,
                         FullyQualifiedTypeName = toGlobalName(prop.Type),
                         IsField = false,
+                        CanBeNull = canBeNull,
                     });
                     break;
 
@@ -172,6 +173,7 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
                         MemberName = field.Name,
                         FullyQualifiedTypeName = toGlobalName(field.Type),
                         IsField = true,
+                        CanBeNull = canBeNull,
                     });
                     break;
             }
@@ -190,6 +192,7 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
                     .Select(p => new BackgroundLoaderParameterData
                     {
                         FullyQualifiedTypeName = toGlobalName(p.Type),
+                        CanBeNull = loaderParameterCanBeNull(p),
                     })
                     .ToList(),
             };
@@ -361,7 +364,10 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
             sb.AppendLine($"{bodyIndent}        var self = ({candidate.FullyQualifiedName})target;");
 
             foreach (var resolved in candidate.ResolvedMembers)
-                sb.AppendLine($"{bodyIndent}        self.{resolved.MemberName} = deps.Get<{resolved.FullyQualifiedTypeName}>();");
+            {
+                string resolveCall = resolved.CanBeNull ? "TryGet" : "Get";
+                sb.AppendLine($"{bodyIndent}        self.{resolved.MemberName} = deps.{resolveCall}<{resolved.FullyQualifiedTypeName}>();");
+            }
 
             if (candidate.BackgroundLoader != null)
             {
@@ -372,7 +378,7 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
                 }
                 else
                 {
-                    string args = string.Join(", ", loader.Parameters.Select(p => $"deps.Get<{p.FullyQualifiedTypeName}>()"));
+                    string args = string.Join(", ", loader.Parameters.Select(p => $"deps.{(p.CanBeNull ? "TryGet" : "Get")}<{p.FullyQualifiedTypeName}>()"));
                     sb.AppendLine($"{bodyIndent}        self.{loader.MethodName}({args});");
                 }
             }
@@ -448,6 +454,47 @@ public sealed class DependencyInjectionGenerator : IIncrementalGenerator
         return symbol.GetAttributes().Any(a =>
             a.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
              .Replace("global::", string.Empty) == attributeFqn);
+    }
+
+    private static AttributeData? getAttribute(ISymbol symbol, string attributeFqn)
+    {
+        return symbol.GetAttributes().FirstOrDefault(a =>
+            a.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+             .Replace("global::", string.Empty) == attributeFqn);
+    }
+
+    /// <summary>
+    /// Reads the CanBeNull state from a [Resolved] attribute, honoring both the positional
+    /// constructor argument (<c>[Resolved(true)]</c>) and the named property (<c>[Resolved(CanBeNull = true)]</c>).
+    /// </summary>
+    private static bool getResolvedCanBeNull(AttributeData attr)
+    {
+        // Positional constructor argument: ResolvedAttribute(bool canBeNull).
+        if (attr.ConstructorArguments.Length > 0 &&
+            attr.ConstructorArguments[0].Value is bool ctorValue)
+            return ctorValue;
+
+        // Named argument: CanBeNull = true.
+        foreach (var named in attr.NamedArguments)
+        {
+            if (named.Key == "CanBeNull" && named.Value.Value is bool namedValue)
+                return namedValue;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// A loader parameter resolves optionally when it carries [CanBeNull] or is declared as a
+    /// nullable reference type (e.g. <c>Foo?</c>).
+    /// </summary>
+    private static bool loaderParameterCanBeNull(IParameterSymbol parameter)
+    {
+        if (hasAttribute(parameter, can_be_null_attribute))
+            return true;
+
+        return parameter.Type.IsReferenceType &&
+               parameter.NullableAnnotation == NullableAnnotation.Annotated;
     }
 
     private static bool isCachedAttribute(AttributeData attr)

--- a/Sakura.Framework.Tests/Allocation/NullableDependencyResolutionTest.cs
+++ b/Sakura.Framework.Tests/Allocation/NullableDependencyResolutionTest.cs
@@ -1,0 +1,113 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using NUnit.Framework;
+using Sakura.Framework.Allocation;
+
+namespace Sakura.Framework.Tests.Allocation;
+
+/// <summary>
+/// Verifies that <c>[Resolved(canBeNull: true)]</c> and <c>[CanBeNull]</c> loader parameters
+/// resolve missing dependencies to <c>null</c> instead of throwing
+/// </summary>
+[TestFixture]
+public partial class NullableDependencyResolutionTest
+{
+    private static IReadOnlyDependencyContainer emptyContainer() => new DependencyContainer();
+
+    private static IReadOnlyDependencyContainer containerWith(IService service)
+    {
+        var c = new DependencyContainer();
+        c.Cache(service);
+        return c;
+    }
+
+    [Test]
+    public void Optional_resolved_member_is_null_when_missing()
+    {
+        var target = new GeneratedConsumer();
+        DependencyActivator.Inject(target, emptyContainer());
+
+        Assert.That(target.OptionalService, Is.Null);
+    }
+
+    [Test]
+    public void Optional_resolved_member_is_populated_when_present()
+    {
+        var service = new ServiceImpl();
+        var target = new GeneratedConsumer();
+        DependencyActivator.Inject(target, containerWith(service));
+
+        Assert.That(target.OptionalService, Is.SameAs(service));
+    }
+
+    [Test]
+    public void Required_resolved_member_throws_when_missing()
+    {
+        var target = new RequiredConsumer();
+        Assert.Throws<InvalidOperationException>(() => DependencyActivator.Inject(target, emptyContainer()));
+    }
+
+    [Test]
+    public void Optional_loader_parameter_is_null_when_missing()
+    {
+        var target = new GeneratedLoaderConsumer();
+        DependencyActivator.Inject(target, emptyContainer());
+
+        Assert.That(target.LoaderSawNull, Is.True);
+    }
+
+    [Test]
+    public void Reflection_fallback_optional_member_is_null_when_missing()
+    {
+        var target = new ReflectionConsumer();
+        DependencyActivator.Inject(target, emptyContainer());
+
+        Assert.That(target.OptionalService, Is.Null);
+    }
+
+    [Test]
+    public void Reflection_fallback_optional_member_is_populated_when_present()
+    {
+        var service = new ServiceImpl();
+        var target = new ReflectionConsumer();
+        DependencyActivator.Inject(target, containerWith(service));
+
+        Assert.That(target.OptionalService, Is.SameAs(service));
+    }
+
+    public interface IService { }
+
+    private class ServiceImpl : IService { }
+
+    public partial class GeneratedConsumer : IDependencyInjectionCandidate
+    {
+        [Resolved(canBeNull: true)]
+        public IService? OptionalService { get; set; }
+    }
+
+    public partial class RequiredConsumer : IDependencyInjectionCandidate
+    {
+        [Resolved]
+        public IService Service { get; set; } = null!;
+    }
+
+    public partial class GeneratedLoaderConsumer : IDependencyInjectionCandidate
+    {
+        public bool LoaderSawNull { get; private set; }
+
+        [BackgroundDependencyLoader]
+        private void load([CanBeNull] IService service)
+        {
+            LoaderSawNull = service == null;
+        }
+    }
+
+    // forces the reflection fallback in ReflectionDependencyActivator.
+    public class ReflectionConsumer : IDependencyInjectionCandidate
+    {
+        [Resolved(canBeNull: true)]
+        public IService? OptionalService { get; set; }
+    }
+}

--- a/Sakura.Framework/Allocation/CanBeNullAttribute.cs
+++ b/Sakura.Framework/Allocation/CanBeNullAttribute.cs
@@ -1,0 +1,29 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.Allocation;
+
+/// <summary>
+/// Marks a <see cref="BackgroundDependencyLoaderAttribute"/> method parameter as optional.
+/// <para>
+/// When applied, the parameter is resolved via <see cref="IReadOnlyDependencyContainer.TryGet{T}"/>
+/// and is passed <c>null</c> if the dependency is not cached anywhere in the hierarchy, rather than
+/// throwing. A parameter declared as a nullable reference type (e.g. <c>Foo?</c>) is treated as
+/// optional as well, even without this attribute.
+/// </para>
+/// <example>
+/// <code>
+/// [BackgroundDependencyLoader]
+/// private void load([CanBeNull] AudioManager audio)
+/// {
+///     audio?.DoSomething();
+/// }
+/// </code>
+/// </example>
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class CanBeNullAttribute : Attribute
+{
+}

--- a/Sakura.Framework/Allocation/ReflectionDependencyActivator.cs
+++ b/Sakura.Framework/Allocation/ReflectionDependencyActivator.cs
@@ -28,6 +28,10 @@ internal static class ReflectionDependencyActivator
         typeof(IReadOnlyDependencyContainer).GetMethod(nameof(IReadOnlyDependencyContainer.Get), BindingFlags.Public | BindingFlags.Instance)
         ?? throw new InvalidOperationException($"Could not find '{nameof(IReadOnlyDependencyContainer.Get)}' on {nameof(IReadOnlyDependencyContainer)}.");
 
+    private static readonly MethodInfo try_get_method =
+        typeof(IReadOnlyDependencyContainer).GetMethod(nameof(IReadOnlyDependencyContainer.TryGet), BindingFlags.Public | BindingFlags.Instance)
+        ?? throw new InvalidOperationException($"Could not find '{nameof(IReadOnlyDependencyContainer.TryGet)}' on {nameof(IReadOnlyDependencyContainer)}.");
+
     private static readonly MethodInfo cache_as_method =
         typeof(DependencyContainer).GetMethod(nameof(DependencyContainer.CacheAs), BindingFlags.Public | BindingFlags.Instance)
         ?? throw new InvalidOperationException($"Could not find '{nameof(DependencyContainer.CacheAs)}' on {nameof(DependencyContainer)}.");
@@ -82,9 +86,28 @@ internal static class ReflectionDependencyActivator
 
     /// <summary>
     /// Builds an expression that resolves <paramref name="dependencyType"/> from the container parameter.
+    /// When <paramref name="canBeNull"/> is true the non-throwing <c>TryGet&lt;T&gt;</c> is used so a missing
+    /// dependency resolves to <c>null</c> instead of throwing.
     /// </summary>
-    private static Expression resolveExpression(ParameterExpression depsParam, Type dependencyType)
-        => Expression.Call(depsParam, get_method.MakeGenericMethod(dependencyType));
+    private static MethodCallExpression resolveExpression(ParameterExpression depsParam, Type dependencyType, bool canBeNull)
+    {
+        var method = canBeNull ? try_get_method : get_method;
+        return Expression.Call(depsParam, method.MakeGenericMethod(dependencyType));
+    }
+
+    /// <summary>
+    /// Determines whether a loader parameter should be resolved optionally either it carries
+    /// <see cref="CanBeNullAttribute"/> or it is declared as a nullable reference type.
+    /// </summary>
+    private static bool loaderParameterCanBeNull(ParameterInfo parameter)
+    {
+        if (parameter.GetCustomAttribute<CanBeNullAttribute>() != null)
+            return true;
+
+        // Nullable reference type annotation, e.g. `Foo?`.
+        var nullabilityInfo = new NullabilityInfoContext().Create(parameter);
+        return nullabilityInfo.WriteState == NullabilityState.Nullable;
+    }
 
     /// <summary>
     /// Builds an inject delegate that handles only members <b>declared directly on <paramref name="type"/></b>
@@ -105,7 +128,8 @@ internal static class ReflectionDependencyActivator
                      BindingFlags.Public | BindingFlags.NonPublic |
                      BindingFlags.Instance | BindingFlags.DeclaredOnly))
         {
-            if (member.GetCustomAttribute<ResolvedAttribute>() == null)
+            var resolved = member.GetCustomAttribute<ResolvedAttribute>();
+            if (resolved == null)
                 continue;
 
             if (member is PropertyInfo property)
@@ -115,13 +139,13 @@ internal static class ReflectionDependencyActivator
                     throw new InvalidOperationException(
                         $"Member {type.Name}.{property.Name} is marked [Resolved] but has no setter.");
 
-                body.Add(Expression.Call(typedInstance, setter, resolveExpression(depsParam, property.PropertyType)));
+                body.Add(Expression.Call(typedInstance, setter, resolveExpression(depsParam, property.PropertyType, resolved.CanBeNull)));
             }
             else if (member is FieldInfo field)
             {
                 body.Add(Expression.Assign(
                     Expression.Field(typedInstance, field),
-                    resolveExpression(depsParam, field.FieldType)));
+                    resolveExpression(depsParam, field.FieldType, resolved.CanBeNull)));
             }
         }
 
@@ -134,7 +158,7 @@ internal static class ReflectionDependencyActivator
         if (loaderMethod != null)
         {
             var args = loaderMethod.GetParameters()
-                .Select(p => resolveExpression(depsParam, p.ParameterType))
+                .Select(p => resolveExpression(depsParam, p.ParameterType, loaderParameterCanBeNull(p)))
                 .ToArray();
 
             body.Add(Expression.Call(typedInstance, loaderMethod, args));

--- a/Sakura.Framework/Allocation/ResolvedAttribute.cs
+++ b/Sakura.Framework/Allocation/ResolvedAttribute.cs
@@ -9,7 +9,43 @@ namespace Sakura.Framework.Allocation;
 /// Marks a field or property to be automatically populated with a dependency
 /// from the nearest <see cref="IReadOnlyDependencyContainer"/>.
 /// </summary>
+/// <example>
+/// Required dependency (throws if not cached anywhere in the hierarchy):
+/// <code>
+/// [Resolved]
+/// private AudioManager audio { get; set; } = null!;
+/// </code>
+/// Optional dependency (resolves to <c>null</c> instead of throwing when missing):
+/// <code>
+/// [Resolved(canBeNull: true)]
+/// private AudioManager? audio { get; set; }
+/// </code>
+/// The named form <c>[Resolved(CanBeNull = true)]</c> is also supported.
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public class ResolvedAttribute : Attribute
 {
+    /// <summary>
+    /// When <c>true</c>, the dependency is resolved via
+    /// <see cref="IReadOnlyDependencyContainer.TryGet{T}"/> and is set to <c>null</c>
+    /// if it is not cached anywhere in the hierarchy, rather than throwing.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool CanBeNull { get; init; }
+
+    /// <summary>
+    /// Creates a <see cref="ResolvedAttribute"/> for a required dependency.
+    /// </summary>
+    public ResolvedAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ResolvedAttribute"/>, optionally marking the dependency as optional.
+    /// </summary>
+    /// <param name="canBeNull">When <c>true</c>, a missing dependency resolves to <c>null</c> instead of throwing.</param>
+    public ResolvedAttribute(bool canBeNull)
+    {
+        CanBeNull = canBeNull;
+    }
 }


### PR DESCRIPTION
Before this, we don't have a "nullable DI" support like in `[Resolved]` attribute, if null it will be error. This PR add support for using `CanBeNull` in both `Resolved` attribute and `BackgroundDependencyLoader` (with test...). Just use JetBrain for helping writing docstring.