### PR TITLE
Fix caret position is incorrect if set the text programatically

### DIFF
--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicTextBox.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicTextBox.cs
@@ -382,4 +382,66 @@ public partial class TestBasicTextBox : ManualInputManagerTestScene
 
         AddAssert("Clipboard kept earlier copy", () => textBox.Text.Value == "keepme");
     }
+
+    [Test]
+    public void TestSetTextOnInit()
+    {
+        const string initial = "Initial   blablabla";
+
+        AddStep("Set initial text", () => textBox.Text.Value = initial);
+
+        AddAssert("Reactive value updated", () => textBox.Text.Value == initial);
+        AddAssert("Caret moved to end of text", () => textBox.CaretIndex == initial.Length);
+        AddAssert("No selection after setting text", () => textBox.SelectionStart == textBox.CaretIndex);
+
+        // Setting the text again should still leave the caret at the end of the new value.
+        AddStep("Set shorter text", () => textBox.Text.Value = "short");
+        AddAssert("Caret moved to end of new text", () => textBox.CaretIndex == "short".Length);
+        AddAssert("Caret stays within bounds", () => textBox.CaretIndex <= textBox.Text.Value.Length);
+    }
+
+    [Test]
+    public void TestSetTextDoesNotDisruptTyping()
+    {
+        AddStep("Set initial text", () => textBox.Text.Value = "abc");
+
+        AddStep("Focus textbox", () =>
+        {
+            InputManager.MoveMouseTo(textBox);
+            InputManager.Click(MouseButton.Left);
+        });
+
+        // Clicking to focus repositions the caret to the mouse, so move it to the end first.
+        AddStep("Move caret to end", () => InputManager.PressKey(Key.End));
+        AddStep("Type more text", () => InputManager.TypeText("def"));
+        AddAssert("Typed text appended at end", () => textBox.Text.Value == "abcdef");
+        AddAssert("Caret at end after typing", () => textBox.CaretIndex == "abcdef".Length);
+    }
+
+    [Test]
+    public void TestSetTextWithSpace()
+    {
+        // Spaces (including consecutive, leading, and trailing ones) must be counted so the caret
+        // lands at the true end of the string rather than collapsing whitespace.
+        const string spaced = "  hello   world  ";
+
+        AddStep("Set text with spaces", () => textBox.Text.Value = spaced);
+
+        AddAssert("Reactive value preserves spaces", () => textBox.Text.Value == spaced);
+        AddAssert("Caret at end including trailing spaces", () => textBox.CaretIndex == spaced.Length);
+        AddAssert("No selection after setting text", () => textBox.SelectionStart == textBox.CaretIndex);
+
+        // Typing into a space-containing string should append, keeping every space intact.
+        // Clicking to focus repositions the caret to the mouse, so move it to the end first.
+        AddStep("Focus textbox", () =>
+        {
+            InputManager.MoveMouseTo(textBox);
+            InputManager.Click(MouseButton.Left);
+        });
+        AddStep("Move caret to end", () => InputManager.PressKey(Key.End));
+
+        AddStep("Type trailing word", () => InputManager.TypeText("!"));
+        AddAssert("Appended after trailing spaces", () => textBox.Text.Value == spaced + "!");
+        AddAssert("Caret at new end", () => textBox.CaretIndex == (spaced + "!").Length);
+    }
 }

--- a/Sakura.Framework/Graphics/UserInterface/TextBox.cs
+++ b/Sakura.Framework/Graphics/UserInterface/TextBox.cs
@@ -59,6 +59,24 @@ public abstract partial class TextBox : Container
     private bool shiftHeld;
 
     /// <summary>
+    /// The current caret index within <see cref="Text"/>.
+    /// </summary>
+    public int CaretIndex => caretIndex;
+
+    /// <summary>
+    /// The current selection anchor index within <see cref="Text"/>. Equal to <see cref="CaretIndex"/>
+    /// when there is no selection.
+    /// </summary>
+    public int SelectionStart => selectionStart;
+
+    /// <summary>
+    /// Set internally while the text value is being changed programmatically (i.e. not via a user
+    /// edit such as typing, pasting, or deleting). Used to decide whether the caret should jump to
+    /// the end of the new text.
+    /// </summary>
+    private bool isEditingText;
+
+    /// <summary>
     /// True while an IME composition is in progress (SDL_TEXTEDITING received with non-empty text).
     /// Enter/Escape are suppressed during composition so they don't accidentally commit or close the text box.
     /// </summary>
@@ -159,10 +177,24 @@ public abstract partial class TextBox : Container
         {
             string newText = e.NewValue ?? "";
             SpriteText.Text = newText;
-            caretIndex = Math.Clamp(caretIndex, 0, newText.Length);
-            selectionStart = Math.Clamp(selectionStart, 0, newText.Length);
+
+            if (isEditingText)
+            {
+                // A user edit (typing, pasting, deleting) already positioned the caret itself,
+                // so we only clamp to keep it within the new bounds.
+                caretIndex = Math.Clamp(caretIndex, 0, newText.Length);
+                selectionStart = Math.Clamp(selectionStart, 0, newText.Length);
+            }
+            else
+            {
+                // The value was assigned programmatically (e.g. setting initial text). Place the
+                // caret at the end of the new text, matching standard text box behaviour.
+                caretIndex = newText.Length;
+                selectionStart = newText.Length;
+            }
+
             UpdatePlaceholderVisibility();
-            Invalidate(InvalidationFlags.DrawInfo);
+            caretMoved();
         };
     }
 
@@ -331,6 +363,25 @@ public abstract partial class TextBox : Container
         return true;
     }
 
+    /// <summary>
+    /// Assigns <see cref="Text"/> as part of a user edit (typing, pasting, deleting). The caller is
+    /// responsible for having already positioned <see cref="caretIndex"/>; this flag tells the
+    /// <see cref="Text"/> change handler not to reset the caret to the end of the text.
+    /// </summary>
+    private void setTextFromUserEdit(string value)
+    {
+        isEditingText = true;
+
+        try
+        {
+            Text.Value = value;
+        }
+        finally
+        {
+            isEditingText = false;
+        }
+    }
+
     private void deleteSelection()
     {
         if (selectionStart == caretIndex) return;
@@ -340,7 +391,7 @@ public abstract partial class TextBox : Container
 
         caretIndex = start;
         selectionStart = start;
-        Text.Value = Text.Value.Remove(start, length);
+        setTextFromUserEdit(Text.Value.Remove(start, length));
     }
 
     private void insertTextAtCaret(string text)
@@ -362,7 +413,7 @@ public abstract partial class TextBox : Container
         int insertIndex = caretIndex;
         caretIndex += text.Length;
         selectionStart = caretIndex;
-        Text.Value = Text.Value.Insert(insertIndex, text);
+        setTextFromUserEdit(Text.Value.Insert(insertIndex, text));
         caretMoved();
     }
 
@@ -449,9 +500,10 @@ public abstract partial class TextBox : Container
                 else if (caretIndex > 0)
                 {
                     int boundary = findPreviousWordBoundary(caretIndex);
-                    Text.Value = Text.Value.Remove(boundary, caretIndex - boundary);
+                    string updated = Text.Value.Remove(boundary, caretIndex - boundary);
                     caretIndex = boundary;
                     selectionStart = boundary;
+                    setTextFromUserEdit(updated);
                 }
                 caretMoved();
                 return true;
@@ -464,7 +516,7 @@ public abstract partial class TextBox : Container
                 else if (caretIndex < Text.Value.Length)
                 {
                     int boundary = findNextWordBoundary(caretIndex);
-                    Text.Value = Text.Value.Remove(caretIndex, boundary - caretIndex);
+                    setTextFromUserEdit(Text.Value.Remove(caretIndex, boundary - caretIndex));
                 }
                 caretMoved();
                 return true;
@@ -518,7 +570,7 @@ public abstract partial class TextBox : Container
             {
                 caretIndex--;
                 selectionStart = caretIndex;
-                Text.Value = Text.Value.Remove(caretIndex, 1);
+                setTextFromUserEdit(Text.Value.Remove(caretIndex, 1));
                 caretMoved();
                 return true;
             }
@@ -529,7 +581,7 @@ public abstract partial class TextBox : Container
             if (hasSelection) { deleteSelection(); caretMoved(); return true; }
             if (caretIndex < Text.Value.Length)
             {
-                Text.Value = Text.Value.Remove(caretIndex, 1);
+                setTextFromUserEdit(Text.Value.Remove(caretIndex, 1));
                 caretMoved();
                 return true;
             }

--- a/Sakura.Framework/Graphics/UserInterface/TextBox.cs
+++ b/Sakura.Framework/Graphics/UserInterface/TextBox.cs
@@ -107,6 +107,26 @@ public abstract partial class TextBox : Container
     /// </summary>
     public int? LengthLimit { get; set; }
 
+    private double caretBlinkDuration = 750;
+
+    /// <summary>
+    /// Duration in milliseconds of a single caret fade (i.e. half of a full blink cycle: the time
+    /// to fade from visible to hidden, and again from hidden to visible). Defaults to 750ms.
+    /// Set to 0 to disable blinking and keep the caret permanently visible while focused.
+    /// </summary>
+    public double CaretBlinkDuration
+    {
+        get => caretBlinkDuration;
+        set
+        {
+            caretBlinkDuration = Math.Max(0, value);
+
+            // Apply the new timing immediately if the caret is currently active.
+            if (HasFocus)
+                resetCaretBlink();
+        }
+    }
+
     /// <summary>
     /// Dimmed hint text shown while the box is empty.
     /// </summary>
@@ -255,7 +275,11 @@ public abstract partial class TextBox : Container
     {
         Caret.ClearTransforms();
         Caret.Alpha = 1;
-        Caret.FadeTo(0, 750).Then().FadeTo(1, 750).Loop();
+
+        if (caretBlinkDuration <= 0)
+            return;
+
+        Caret.FadeTo(0, caretBlinkDuration).Then().FadeTo(1, caretBlinkDuration).Loop();
     }
 
     private void caretMoved()


### PR DESCRIPTION
If set the `TextBox.Text` reactive to change or just initialize the value in textbox, the caret position will be 1-2 position behind based on the space available. This PR fix these bugs. Also make caret "blink" duration be able to change