### PR TITLE
Fix basic slider bar not update its size if update value too fast

### DIFF
--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
@@ -268,22 +268,13 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
     [Test]
     public void TestContinuousDriveSnapsFill()
     {
-        // Simulate a value driven repeatedly within the same frame (e.g. a slider tracking playback
-        // position, updated every Update()). Successive changes arrive with ~zero gap, so the slider
-        // should detect a continuous drive and snap to the latest target rather than easing.
-        //
-        // NOTE: driving across separate AddSteps would NOT reproduce this — the test runner leaves a
-        // gap between steps, which the heuristic correctly reads as isolated changes. The drive must
-        // happen within a single step to be same-frame.
         AddStep("Drive value continuously to 100", () =>
         {
             slider.Current.Value = 0f;
 
             for (int i = 1; i <= 10; i++)
                 slider.Current.Value = i * 10f;
-
-            // Snapped same-frame: the fill is already full, no transform pending. (An eased change
-            // would leave selection size unchanged this frame, i.e. CurrentFillWidth still ~0.)
+            
             Assert.That(slider.CurrentFillWidth, Is.EqualTo(1f).Within(0.01f), "continuous drive should snap the fill");
         });
     }

--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Graphics.UserInterface;
 using Sakura.Framework.Input;
 using Sakura.Framework.Maths;
@@ -262,5 +263,49 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         AddStep("Click 1/4", () => InputManager.Click(MouseButton.Left));
         AddAssert("First slider value is roughly 25", () => Precision.AlmostEquals(slider.Current.Value, 25f, 2f));
         AddAssert("Second slider value is still roughly 75", () => Precision.AlmostEquals(slider2.Current.Value, 75f, 2f));
+    }
+
+    [Test]
+    public void TestContinuousDriveSnapsFill()
+    {
+        // Simulate a value driven repeatedly within the same frame (e.g. a slider tracking playback
+        // position, updated every Update()). Successive changes arrive with ~zero gap, so the slider
+        // should detect a continuous drive and snap to the latest target rather than easing.
+        //
+        // NOTE: driving across separate AddSteps would NOT reproduce this — the test runner leaves a
+        // gap between steps, which the heuristic correctly reads as isolated changes. The drive must
+        // happen within a single step to be same-frame.
+        AddStep("Drive value continuously to 100", () =>
+        {
+            slider.Current.Value = 0f;
+
+            for (int i = 1; i <= 10; i++)
+                slider.Current.Value = i * 10f;
+
+            // Snapped same-frame: the fill is already full, no transform pending. (An eased change
+            // would leave selection size unchanged this frame, i.e. CurrentFillWidth still ~0.)
+            Assert.That(slider.CurrentFillWidth, Is.EqualTo(1f).Within(0.01f), "continuous drive should snap the fill");
+        });
+    }
+
+    [Test]
+    public void TestIsolatedChangeAnimatesFill()
+    {
+        AddStep("Set up long linear fill animation", () =>
+        {
+            slider.FillAnimationDuration = 5000;
+            slider.FillAnimationEasing = Easing.None;
+        });
+
+        AddStep("Set value to 0", () => slider.Current.Value = 0f);
+        AddWaitStep("Let fill settle at 0", 200);
+
+        AddStep("Jump value to 100 and check it eases", () =>
+        {
+            slider.Current.Value = 100f;
+            Assert.That(slider.CurrentFillWidth, Is.LessThan(0.5f), "fill should still be animating, not snapped");
+        });
+
+        AddUntilStep("Fill eventually reaches full", () => Precision.AlmostEquals(slider.CurrentFillWidth, 1f, 0.02f));
     }
 }

--- a/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
@@ -35,6 +35,18 @@ public partial class BasicSliderBar<T> : SliderBar<T> where T : struct, INumber<
     private readonly Box background;
     private readonly Box selection;
 
+    /// <summary>
+    /// Clock time (ms) at which the selection fill was last updated
+    /// </summary>
+    private double lastFillUpdateTime = double.NaN;
+
+    /// <summary>
+    /// The selection fill's current width as a fraction of the full track, in [0, 1].
+    /// While an animation is in flight this reflects the in-progress (eased) value rather than the
+    /// final target, so it can be used to observe the fill animation.
+    /// </summary>
+    public float CurrentFillWidth => selection.Size.X;
+
     public BasicSliderBar()
     {
         Size = new Vector2(200, 20);
@@ -61,11 +73,27 @@ public partial class BasicSliderBar<T> : SliderBar<T> where T : struct, INumber<
 
     protected override void OnValueChanged(T value)
     {
-        // Clear any in-flight resize so rapid changes (e.g. dragging) animate from the current
-        // size rather than fighting a stale transform. The selection box only ever runs resize
-        // transforms, so clearing all of them here is safe.
+        var target = new Vector2(GetFillFraction(), 1);
+
         selection.ClearTransforms();
-        selection.ResizeTo(new Vector2(GetFillFraction(), 1), FillAnimationDuration, FillAnimationEasing);
+
+        double now = selection.Clock.CurrentTime;
+        double sinceLast = now - lastFillUpdateTime;
+        lastFillUpdateTime = now;
+
+        // there are sometime that the easing time is more than the new value change event
+        // lead to the size not even update properly since it's clear transformation too quick
+        // just calculate whether it fast enough to considered it as just skip it
+        double frameTime = selection.Clock.ElapsedFrameTime;
+        double continuousWindow = frameTime > 0 ? frameTime * 2.5 : 0;
+
+        bool isContinuousDrive = !double.IsNaN(sinceLast)
+                                 && (sinceLast <= 0 || sinceLast <= continuousWindow);
+
+        if (isContinuousDrive || FillAnimationDuration <= 0)
+            selection.Size = target;
+        else
+            selection.ResizeTo(target, FillAnimationDuration, FillAnimationEasing);
     }
 
     protected override void OnFocusGained() => BorderColor = FocusColor;


### PR DESCRIPTION
I just add the easing support in `BasicSliderBar` but notice that when not focus window (60 FPS update) the sliderbar value box just stop update itself. This due to the animation that set as 150 ms easing got `ClearTransform` too fast. So I add a bit of check that if the value update really faster than set easing time, just skip  easing entirely. Also add a visual test.