### PR TITLE
Bring fullscreen back on MacOS and add alignment for `FlowContainer`

### DIFF
--- a/Sakura.Framework.Benchmarks/Benchmarks/FlowContainerBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/FlowContainerBenchmarks.cs
@@ -1,0 +1,115 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using BenchmarkDotNet.Attributes;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+public class FlowContainerBenchmarks
+{
+    /// <summary>
+    /// Child counts to sweep. Small = typical UI (a row of buttons / stat labels),
+    /// large = stress (e.g. a long scrolling list re-flowed every frame).
+    /// </summary>
+    [Params(4, 50, 500)]
+    public int ChildCount;
+
+    private Container singleLineRoot = null!;
+    private ManualClock singleLineClock = null!;
+    private FlowContainer singleLineFlow = null!;
+
+    private Container wrappingRoot = null!;
+    private ManualClock wrappingClock = null!;
+    private FlowContainer wrappingFlow = null!;
+
+    private Container verticalRoot = null!;
+    private ManualClock verticalClock = null!;
+    private FlowContainer verticalFlow = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Horizontal, auto-sized: never wraps — one line of N children.
+        (singleLineRoot, singleLineClock) = BenchmarkTree.CreateRoot();
+        singleLineFlow = buildFlow(FlowDirection.Horizontal, autoSize: true, wrapWidth: 0);
+        singleLineRoot.Add(singleLineFlow);
+        BenchmarkTree.LoadAndSettle(singleLineRoot, singleLineClock);
+
+        // Horizontal, fixed width: children wrap into many lines.
+        (wrappingRoot, wrappingClock) = BenchmarkTree.CreateRoot();
+        wrappingFlow = buildFlow(FlowDirection.Horizontal, autoSize: false, wrapWidth: 400);
+        wrappingRoot.Add(wrappingFlow);
+        BenchmarkTree.LoadAndSettle(wrappingRoot, wrappingClock);
+
+        // Vertical, auto-sized: a column of N children (each its own row conceptually).
+        (verticalRoot, verticalClock) = BenchmarkTree.CreateRoot();
+        verticalFlow = buildFlow(FlowDirection.Vertical, autoSize: true, wrapWidth: 0);
+        verticalRoot.Add(verticalFlow);
+        BenchmarkTree.LoadAndSettle(verticalRoot, verticalClock);
+    }
+
+    private FlowContainer buildFlow(FlowDirection direction, bool autoSize, float wrapWidth)
+    {
+        var flow = new FlowContainer
+        {
+            Direction = direction,
+            Spacing = new Vector2(5, 5),
+        };
+
+        if (autoSize)
+            flow.AutoSizeAxes = Axes.Both;
+        else
+            flow.Size = new Vector2(wrapWidth, 600);
+
+        for (int i = 0; i < ChildCount; i++)
+        {
+            flow.Add(new Box
+            {
+                Size = new Vector2(40, 20),
+            });
+        }
+
+        return flow;
+    }
+
+    /// <summary>
+    /// Re-flows a single-line horizontal container. No wrapping, so this isolates the
+    /// per-child positioning cost plus whatever the grouping pass allocates for one line.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public void Layout_Horizontal_SingleLine()
+    {
+        singleLineFlow.Invalidate(InvalidationFlags.DrawInfo);
+        singleLineClock.CurrentTime += BenchmarkTree.FRAME_STEP_MS;
+        singleLineRoot.UpdateSubTree();
+    }
+
+    /// <summary>
+    /// Re-flows a fixed-width container whose children wrap into many lines.
+    /// This is the heaviest case for the line-grouping pass.
+    /// </summary>
+    [Benchmark]
+    public void Layout_Horizontal_Wrapping()
+    {
+        wrappingFlow.Invalidate(InvalidationFlags.DrawInfo);
+        wrappingClock.CurrentTime += BenchmarkTree.FRAME_STEP_MS;
+        wrappingRoot.UpdateSubTree();
+    }
+
+    /// <summary>
+    /// Re-flows a vertical column of children.
+    /// </summary>
+    [Benchmark]
+    public void Layout_Vertical_Column()
+    {
+        verticalFlow.Invalidate(InvalidationFlags.DrawInfo);
+        verticalClock.CurrentTime += BenchmarkTree.FRAME_STEP_MS;
+        verticalRoot.UpdateSubTree();
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Containers/TestFlowContainer.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestFlowContainer.cs
@@ -3,10 +3,12 @@
 
 using System.Linq;
 using NUnit.Framework;
+using Sakura.Framework.Extensions.DrawableExtensions;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Testing;
 using Sakura.Framework.Utilities;
@@ -62,7 +64,7 @@ public partial class TestFlowContainer : TestScene
                         Width = 1,
                         AutoSizeAxes = Axes.Y,
                         Direction = FlowDirection.Horizontal,
-                        Spacing = new Vector2(spacing, 0),
+                        Spacing = new Vector2(spacing),
                         Children = child_colors.Take(child_count).Select(c => (Drawable)new Box
                         {
                             Size = new Vector2(child_size),
@@ -119,5 +121,17 @@ public partial class TestFlowContainer : TestScene
         AddStep("Start", () => flow.Alignment = FlowAlignment.Start);
         AddStep("Center", () => flow.Alignment = FlowAlignment.Center);
         AddStep("End", () => flow.Alignment = FlowAlignment.End);
+    }
+
+    [Test]
+    public void TestResizeTransform()
+    {
+        AddStep("Add resize animation", () =>
+        {
+            foreach (var child in flow.Children)
+            {
+                child.ResizeTo(new Vector2(200), 1000, Easing.OutQuint);
+            }
+        });
     }
 }

--- a/Sakura.Framework.Tests/Visuals/Containers/TestFlowContainer.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestFlowContainer.cs
@@ -1,0 +1,123 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Linq;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Testing;
+using Sakura.Framework.Utilities;
+
+namespace Sakura.Framework.Tests.Visuals.Containers;
+
+public partial class TestFlowContainer : TestScene
+{
+    private FlowContainer flow = null!;
+    private Container frame = null!;
+
+    private const float child_size = 80;
+    private const float spacing = 10;
+    private const int child_count = 3;
+    private const float frame_width = 600;
+
+    /// <summary>
+    /// Total flow-axis extent of all children plus the gaps between them.
+    /// </summary>
+    private const float content_width = child_count * child_size + (child_count - 1) * spacing;
+
+    private static readonly Color[] child_colors =
+    {
+        Color.Crimson,
+        Color.Chartreuse,
+        Color.CornflowerBlue,
+        Color.DarkOrange,
+    };
+
+    [SetUp]
+    public void SetUp()
+    {
+        AddStep("Create flow", () =>
+        {
+            Clear();
+
+            Add(frame = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(frame_width, 300),
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Color = Color.DarkSlateGray
+                    },
+                    flow = new FlowContainer
+                    {
+                        // fixed full-width container so there is free space to align within.
+                        RelativeSizeAxes = Axes.X,
+                        Width = 1,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FlowDirection.Horizontal,
+                        Spacing = new Vector2(spacing, 0),
+                        Children = child_colors.Take(child_count).Select(c => (Drawable)new Box
+                        {
+                            Size = new Vector2(child_size),
+                            Color = c
+                        }).ToArray()
+                    }
+                }
+            });
+        });
+    }
+
+    private float firstChildX => flow.Children.First().Position.X;
+
+    [Test]
+    public void TestStartAlignment()
+    {
+        AddStep("Set Start", () => flow.Alignment = FlowAlignment.Start);
+        // default behavior: first child packed at the left edge (plus padding, which is zero here).
+        AddAssert("First child at left", () => Precision.AlmostEquals(firstChildX, 0));
+    }
+
+    [Test]
+    public void TestCenterAlignment()
+    {
+        AddStep("Set Center", () => flow.Alignment = FlowAlignment.Center);
+        // free space is split evenly on both sides.
+        float expected = (frame_width - content_width) / 2f;
+        AddAssert("First child centered", () => Precision.AlmostEquals(firstChildX, expected));
+    }
+
+    [Test]
+    public void TestEndAlignment()
+    {
+        AddStep("Set End", () => flow.Alignment = FlowAlignment.End);
+        // all free space pushed to the left so the row ends at the right edge.
+        float expected = frame_width - content_width;
+        AddAssert("First child at end offset", () => Precision.AlmostEquals(firstChildX, expected));
+    }
+
+    [Test]
+    public void TestAutoSizeIgnoresAlignment()
+    {
+        // an auto-sizing flow axis fits content exactly, so there is no free
+        // space to distribute and alignment must have no effect.
+        AddStep("Auto-size both axes", () => flow.AutoSizeAxes = Axes.Both);
+        AddStep("Set Center", () => flow.Alignment = FlowAlignment.Center);
+        AddAssert("First child still at left", () => Precision.AlmostEquals(firstChildX, 0));
+    }
+
+    [Test]
+    public void TestCycleAlignment()
+    {
+        // visual sanity check: step through each alignment by hand.
+        AddStep("Start", () => flow.Alignment = FlowAlignment.Start);
+        AddStep("Center", () => flow.Alignment = FlowAlignment.Center);
+        AddStep("End", () => flow.Alignment = FlowAlignment.End);
+    }
+}

--- a/Sakura.Framework/Graphics/Containers/FlowContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/FlowContainer.cs
@@ -17,6 +17,7 @@ public partial class FlowContainer : Container
 {
     private FlowDirection direction = FlowDirection.Horizontal;
     private Vector2 spacing = Vector2.Zero;
+    private FlowAlignment alignment = FlowAlignment.Start;
 
     /// <summary>
     /// The direction of flow layout on how children arranged.
@@ -51,6 +52,24 @@ public partial class FlowContainer : Container
     }
 
     /// <summary>
+    /// How children are aligned along the flow axis within each line.
+    /// Defaults to <see cref="FlowAlignment.Start"/>. Has no effect on an
+    /// auto-sizing axis, since the container then fits its content exactly.
+    /// </summary>
+    public FlowAlignment Alignment
+    {
+        get => alignment;
+        set
+        {
+            if (alignment == value)
+                return;
+
+            alignment = value;
+            Invalidate(InvalidationFlags.DrawInfo);
+        }
+    }
+
+    /// <summary>
     /// A flow container's layout always depends on its children's geometry,
     /// regardless of whether it is auto-sizing.
     /// </summary>
@@ -79,39 +98,72 @@ public partial class FlowContainer : Container
     /// </summary>
     protected virtual void PerformLayout()
     {
+        var children = Children;
+        int count = children.Count;
+        if (count == 0)
+        {
+            applyAutoSize(0, 0);
+            return;
+        }
+
+        bool horizontal = Direction == FlowDirection.Horizontal;
+        bool autoX = (AutoSizeAxes & Axes.X) != 0;
+        bool autoY = (AutoSizeAxes & Axes.Y) != 0;
+
         // use ChildSize, which is correct and respects Padding.
         var maxBounds = ChildSize;
 
-        float limitX = (AutoSizeAxes & Axes.X) != 0 ? float.MaxValue : maxBounds.X;
-        float limitY = (AutoSizeAxes & Axes.Y) != 0 ? float.MaxValue : maxBounds.Y;
+        // limit along the flow axis (no limit when that axis auto-sizes).
+        bool autoFlow = horizontal ? autoX : autoY;
+        float flowLimit = autoFlow ? float.MaxValue : (horizontal ? maxBounds.X : maxBounds.Y);
+
+        float flowSpacing = horizontal ? Spacing.X : Spacing.Y;
+        float crossSpacing = horizontal ? Spacing.Y : Spacing.X;
 
         float maxRight = 0;
         float maxBottom = 0;
+        float lineStartCross = 0; // cross-axis position of the current line
 
-        var currentPosPixels = Vector2.Zero;
-        float lineMaxSizePixels = 0;
-
-        foreach (var child in Children)
+        int i = 0;
+        while (i < count)
         {
-            // must manually calculate the child's pixel size, as its
-            // own .Update() hasn't run yet (so .DrawSize is from last frame).
-            var childDrawSizePixels = getChildDrawSize(child);
+            // find the [i, lineEnd) range that fits on this line
+            int lineEnd = i;
+            float lineFlowExtent = 0; // sum of item extents + interior gaps
+            float lineCrossExtent = 0; // tallest/widest item on the cross axis
 
-            // calculate total size in pixels
-            var childMarginPixels = child.Margin.Total;
-            var childTotalSizePixels = childDrawSizePixels + childMarginPixels;
-
-            if (Direction == FlowDirection.Horizontal)
+            while (lineEnd < count)
             {
-                // check for wrap (all in pixels)
-                if (currentPosPixels.X > 0 && currentPosPixels.X + childTotalSizePixels.X > limitX)
-                {
-                    currentPosPixels.X = 0;
-                    currentPosPixels.Y += lineMaxSizePixels + Spacing.Y;
-                    lineMaxSizePixels = 0;
-                }
+                var size = getChildTotalSize(children[lineEnd]);
+                float flow = horizontal ? size.X : size.Y;
+                float cross = horizontal ? size.Y : size.X;
 
-                // set child's position.
+                // would adding this child overflow the line? (never break a line of one)
+                float tentative = lineEnd == i ? flow : lineFlowExtent + flowSpacing + flow;
+                if (lineEnd > i && tentative > flowLimit)
+                    break;
+
+                lineFlowExtent = tentative;
+                if (cross > lineCrossExtent) lineCrossExtent = cross;
+                lineEnd++;
+            }
+
+            // alignment: distribute free space along the flow axis
+            float free = autoFlow || flowLimit == float.MaxValue ? 0 : Math.Max(0, flowLimit - lineFlowExtent);
+            float currentFlow = Alignment switch
+            {
+                FlowAlignment.Center => free / 2f,
+                FlowAlignment.End => free,
+                _ => 0f,
+            };
+
+            // position pass over the same range
+            for (int j = i; j < lineEnd; j++)
+            {
+                var child = children[j];
+                var drawSize = getChildDrawSize(child);
+                var totalSize = drawSize + child.Margin.Total;
+
                 // must control these properties for layout to work.
                 if (child.RelativePositionAxes != Axes.None)
                     child.RelativePositionAxes = Axes.None; // reset to absolute positioning
@@ -120,77 +172,59 @@ public partial class FlowContainer : Container
                 if (child.Origin != Anchor.TopLeft)
                     child.Origin = Anchor.TopLeft; // Reset origin to top-left
 
-                // calculate final pixel position for the child (including its margin)
-                var childPosPixels = new Vector2(currentPosPixels.X + child.Margin.Left, currentPosPixels.Y + child.Margin.Top);
+                // resolve flow/cross coordinates back into x/y.
+                // for horizontal flow, X is the flow axis and Y is the cross axis.
+                // for vertical flow, Y is the flow axis and X is the cross axis.
+                Vector2 basePos = horizontal
+                    ? new Vector2(currentFlow, lineStartCross)
+                    : new Vector2(lineStartCross, currentFlow);
+
+                // include the child's own margin and the container's padding.
+                var childPosPixels = new Vector2(basePos.X + child.Margin.Left, basePos.Y + child.Margin.Top);
                 var finalPos = new Vector2(childPosPixels.X + Padding.Left, childPosPixels.Y + Padding.Top);
 
                 if (!Precision.AlmostEquals(child.Position, finalPos))
-                    // Apply position (offset by Padding)
                     child.Position = finalPos;
 
-                // Track content size
-                float childRight = childPosPixels.X + childDrawSizePixels.X + child.Margin.Right;
-                float childBottom = childPosPixels.Y + childDrawSizePixels.Y + child.Margin.Bottom;
+                // track content size (for auto-sizing).
+                float childRight = childPosPixels.X + drawSize.X + child.Margin.Right;
+                float childBottom = childPosPixels.Y + drawSize.Y + child.Margin.Bottom;
 
                 if (childRight > maxRight) maxRight = childRight;
                 if (childBottom > maxBottom) maxBottom = childBottom;
 
-                // Advance flow
-                currentPosPixels.X += childTotalSizePixels.X + Spacing.X;
-                lineMaxSizePixels = Math.Max(lineMaxSizePixels, childTotalSizePixels.Y);
-            }
-            else // Vertical
-            {
-                // check for wrap (all in pixels)
-                if (currentPosPixels.Y > 0 && currentPosPixels.Y + childTotalSizePixels.Y > limitY)
-                {
-                    currentPosPixels.Y = 0;
-                    currentPosPixels.X += lineMaxSizePixels + Spacing.X;
-                    lineMaxSizePixels = 0;
-                }
-
-                // set child's position
-                if (child.RelativePositionAxes != Axes.None)
-                    child.RelativePositionAxes = Axes.None;
-                if (child.Anchor != Anchor.TopLeft)
-                    child.Anchor = Anchor.TopLeft;
-                if (child.Origin != Anchor.TopLeft)
-                    child.Origin = Anchor.TopLeft;
-
-                // calculate final pixel position for the child (including its margin)
-                var childPosPixels = new Vector2(currentPosPixels.X + child.Margin.Left, currentPosPixels.Y + child.Margin.Top);
-                var finalPos = new Vector2(childPosPixels.X + Padding.Left, childPosPixels.Y + Padding.Top);
-
-                if (!Precision.AlmostEquals(child.Position, finalPos))
-                    // Apply position (offset by Padding)
-                    child.Position = finalPos;
-
-                // Track content size
-                float childRight = childPosPixels.X + childDrawSizePixels.X + child.Margin.Right;
-                float childBottom = childPosPixels.Y + childDrawSizePixels.Y + child.Margin.Bottom;
-
-                if (childRight > maxRight) maxRight = childRight;
-                if (childBottom > maxBottom) maxBottom = childBottom;
-
-                // Advance flow
-                currentPosPixels.Y += childTotalSizePixels.Y + Spacing.Y;
-                lineMaxSizePixels = Math.Max(lineMaxSizePixels, childTotalSizePixels.X);
+                // advance along the flow axis.
+                currentFlow += (horizontal ? totalSize.X : totalSize.Y) + flowSpacing;
             }
 
-            Vector2 newSize = Size;
-
-            if ((AutoSizeAxes & Axes.X) != 0)
-                newSize.X = maxRight + Padding.Right;
-
-            if ((AutoSizeAxes & Axes.Y) != 0)
-                newSize.Y = maxBottom + Padding.Bottom;
-
-            if (!Precision.AlmostEquals(Size, newSize))
-            {
-                Size = newSize;
-                // Parent?.Invalidate(InvalidationFlags.DrawInfo);
-            }
+            // advance to the next line along the cross axis.
+            lineStartCross += lineCrossExtent + crossSpacing;
+            i = lineEnd;
         }
+
+        applyAutoSize(maxRight, maxBottom);
+    }
+
+    /// <summary>
+    /// Total size of a child along both axes (draw size plus margin), used by the measure pass.
+    /// </summary>
+    private Vector2 getChildTotalSize(Drawable child) => getChildDrawSize(child) + child.Margin.Total;
+
+    /// <summary>
+    /// Applies the auto-sized dimensions from the computed content bounds.
+    /// </summary>
+    private void applyAutoSize(float maxRight, float maxBottom)
+    {
+        Vector2 newSize = Size;
+
+        if ((AutoSizeAxes & Axes.X) != 0)
+            newSize.X = maxRight + Padding.Right;
+
+        if ((AutoSizeAxes & Axes.Y) != 0)
+            newSize.Y = maxBottom + Padding.Bottom;
+
+        if (!Precision.AlmostEquals(Size, newSize))
+            Size = newSize;
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Primitives/FlowAlignment.cs
+++ b/Sakura.Framework/Graphics/Primitives/FlowAlignment.cs
@@ -1,0 +1,29 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Graphics.Primitives;
+
+/// <summary>
+/// Defines how children are aligned along the flow axis within each line.
+/// Has no visible effect on axes that are auto-sizing, since the container
+/// then fits its content exactly and there is no free space to distribute.
+/// </summary>
+public enum FlowAlignment
+{
+    /// <summary>
+    /// Children are packed at the start of the line (left for horizontal,
+    /// top for vertical). This is the default and matches the original behavior.
+    /// </summary>
+    Start,
+
+    /// <summary>
+    /// Children are centered within the available space along the flow axis.
+    /// </summary>
+    Center,
+
+    /// <summary>
+    /// Children are packed at the end of the line (right for horizontal,
+    /// bottom for vertical).
+    /// </summary>
+    End
+}

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -672,10 +672,7 @@ public abstract class AppHost : IDisposable
                         Window.WindowMode = WindowMode.Borderless;
                         break;
                     case WindowMode.Borderless:
-                        if (RuntimeInfo.IsMacOS)
-                            Window.WindowMode = WindowMode.Windowed;
-                        else
-                            Window.WindowMode = WindowMode.Fullscreen;
+                        Window.WindowMode = WindowMode.Fullscreen;
                         break;
                     case WindowMode.Fullscreen:
                         Window.WindowMode = WindowMode.Windowed;

--- a/Sakura.Framework/Platform/SDLWindow.cs
+++ b/Sakura.Framework/Platform/SDLWindow.cs
@@ -372,13 +372,6 @@ public class SDLWindow : IWindow
             windowFlags |= SDL_WindowFlags.SDL_WINDOW_RESIZABLE;
         }
 
-        if (RuntimeInfo.IsMacOS && windowMode == WindowMode.Fullscreen)
-        {
-            // SDL's full screen on MacOS has a lot of issues so we force MacOS to use only window and borderless window modes
-            Logger.Warning("Fullscreen mode is not supported on MacOS due to a lot of issues with SDL implementation, falling back to Borderless window mode.");
-            windowMode = WindowMode.Borderless;
-        }
-
         // In SDL3 both borderless-desktop and exclusive fullscreen use SDL_WINDOW_FULLSCREEN;
         // the distinction is made after creation via SDL_SetWindowFullscreenMode
         // (null mode = borderless desktop, explicit mode = exclusive).
@@ -436,10 +429,15 @@ public class SDLWindow : IWindow
 
         if (windowMode == WindowMode.Fullscreen)
         {
-            // Exclusive fullscreen: pin the window to the display's current mode.
-            var mode = SDL_GetCurrentDisplayMode(SDL_GetDisplayForWindow(window));
-            SDL_SetWindowFullscreenMode(window, mode);
-            SDL_SetWindowFullscreen(window, true);
+            WindowMode effectiveMode = applyExclusiveFullscreen();
+
+            if (effectiveMode != windowMode)
+            {
+                windowMode = effectiveMode;
+                WindowModeReactive.Value = effectiveMode;
+                if (windowConfig != null)
+                    windowConfig.Get<WindowMode>(FrameworkSetting.WindowMode).Value = effectiveMode;
+            }
         }
 
         SDL_AddEventWatch(&resizeEventWatch, IntPtr.Zero);
@@ -659,22 +657,105 @@ public class SDLWindow : IWindow
         return true;
     }
 
+    /// <summary>
+    /// Applies exclusive fullscreen: pins the window to the display's current mode. Returns the mode
+    /// that was actually applied — <see cref="WindowMode.Fullscreen"/> on success, or
+    /// <see cref="WindowMode.Borderless"/> if the display mode could not be resolved (in which case
+    /// borderless-desktop fullscreen is applied as a safe fallback).
+    /// </summary>
+    /// <remarks>
+    /// Exclusive fullscreen on macOS historically misbehaved under SDL (wrong drawable size, black
+    /// screens, stale refresh rate). We harden the transition here so it is reliable on every
+    /// platform: validate the display mode before handing it to SDL, fall back to borderless if it is
+    /// unavailable, then <c>SDL_SyncWindow</c> to force the mode change to complete before we read
+    /// back any sizes, and finally re-query the drawable size and refresh rate (both can change with
+    /// the mode, especially across HiDPI/Retina backing-scale boundaries).
+    /// </remarks>
+    private unsafe WindowMode applyExclusiveFullscreen()
+    {
+        var mode = SDL_GetCurrentDisplayMode(SDL_GetDisplayForWindow(window));
+
+        if (mode == null)
+        {
+            Logger.Warning("Could not resolve the display mode for exclusive fullscreen; falling back to Borderless.");
+            SDL_SetWindowFullscreenMode(window, null);
+            SDL_SetWindowFullscreen(window, true);
+            SDL_SyncWindow(window);
+            return WindowMode.Borderless;
+        }
+
+        SDL_SetWindowFullscreenMode(window, mode);
+        SDL_SetWindowFullscreen(window, true);
+
+        // Block until the fullscreen transition is fully applied. Without this the window may still
+        // report its pre-fullscreen (or zero) size on the next query, which on macOS manifests as a
+        // black screen or half-resolution surface.
+        SDL_SyncWindow(window);
+
+        // The active display mode and Retina backing scale can differ in fullscreen, so refresh the
+        // cached refresh rate; size is refreshed by the caller via handleSizeChanged().
+        DisplayHz = getDisplayRefreshRate();
+
+        return WindowMode.Fullscreen;
+    }
+
     private unsafe void setWindowMode(WindowMode newMode)
     {
         if (windowMode == newMode)
             return;
 
-        if (RuntimeInfo.IsMacOS && newMode == WindowMode.Fullscreen)
+        // The effective mode may differ from the requested one if exclusive fullscreen falls back to
+        // borderless (see applyExclusiveFullscreen). We persist the effective mode below so config and
+        // the reactive reflect what is actually on screen.
+        WindowMode effectiveMode = newMode;
+
+        if (window != null)
         {
-            newMode = WindowMode.Borderless;
+            switch (newMode)
+            {
+                case WindowMode.Windowed:
+                    SDL_SetWindowFullscreen(window, false);
+                    SDL_SetWindowBordered(window, true);
+
+                    if (windowConfig != null)
+                    {
+                        int savedX = windowConfig.Get<int>(FrameworkSetting.WindowX).Value;
+                        int savedY = windowConfig.Get<int>(FrameworkSetting.WindowY).Value;
+                        int savedW = windowConfig.Get<int>(FrameworkSetting.WindowWidth).Value;
+                        int savedH = windowConfig.Get<int>(FrameworkSetting.WindowHeight).Value;
+
+                        if (savedW > 0 && savedH > 0)
+                            SDL_SetWindowSize(window, savedW, savedH);
+
+                        if (savedX != -1 && savedY != -1 && isPositionOnConnectedDisplay(savedX, savedY))
+                            SDL_SetWindowPosition(window, savedX, savedY);
+                        else
+                            SDL_SetWindowPosition(window, windowpos_centered, windowpos_centered);
+                    }
+                    else
+                    {
+                        SDL_SetWindowPosition(window, windowpos_centered, windowpos_centered);
+                    }
+                    break;
+
+                case WindowMode.Borderless:
+                    // null fullscreen mode = borderless fullscreen desktop in SDL3.
+                    SDL_SetWindowFullscreenMode(window, null);
+                    SDL_SetWindowFullscreen(window, true);
+                    break;
+
+                case WindowMode.Fullscreen:
+                    effectiveMode = applyExclusiveFullscreen();
+                    break;
+            }
         }
 
-        windowMode = newMode;
-        WindowModeReactive.Value = newMode;
+        windowMode = effectiveMode;
+        WindowModeReactive.Value = effectiveMode;
 
         if (windowConfig != null)
         {
-            windowConfig.Get<WindowMode>(FrameworkSetting.WindowMode).Value = newMode;
+            windowConfig.Get<WindowMode>(FrameworkSetting.WindowMode).Value = effectiveMode;
         }
         else
         {
@@ -683,51 +764,11 @@ public class SDLWindow : IWindow
 
         if (window == null) return;
 
-        switch (newMode)
-        {
-            case WindowMode.Windowed:
-                SDL_SetWindowFullscreen(window, false);
-                SDL_SetWindowBordered(window, true);
-
-                if (windowConfig != null)
-                {
-                    int savedX = windowConfig.Get<int>(FrameworkSetting.WindowX).Value;
-                    int savedY = windowConfig.Get<int>(FrameworkSetting.WindowY).Value;
-                    int savedW = windowConfig.Get<int>(FrameworkSetting.WindowWidth).Value;
-                    int savedH = windowConfig.Get<int>(FrameworkSetting.WindowHeight).Value;
-
-                    if (savedW > 0 && savedH > 0)
-                        SDL_SetWindowSize(window, savedW, savedH);
-
-                    if (savedX != -1 && savedY != -1 && isPositionOnConnectedDisplay(savedX, savedY))
-                        SDL_SetWindowPosition(window, savedX, savedY);
-                    else
-                        SDL_SetWindowPosition(window, windowpos_centered, windowpos_centered);
-                }
-                else
-                {
-                    SDL_SetWindowPosition(window, windowpos_centered, windowpos_centered);
-                }
-                break;
-
-            case WindowMode.Borderless:
-                // null fullscreen mode = borderless fullscreen desktop in SDL3.
-                SDL_SetWindowFullscreenMode(window, null);
-                SDL_SetWindowFullscreen(window, true);
-                break;
-
-            case WindowMode.Fullscreen:
-                var mode = SDL_GetCurrentDisplayMode(SDL_GetDisplayForWindow(window));
-                SDL_SetWindowFullscreenMode(window, mode);
-                SDL_SetWindowFullscreen(window, true);
-                break;
-        }
-
         // Mode changes usually generate RESIZED events as well; handleSizeChanged dedupes
         // so whichever path runs first wins and the other is a no-op.
         handleSizeChanged();
 
-        Logger.Debug($"Window mode changed to {newMode}");
+        Logger.Debug($"Window mode changed to {effectiveMode}");
     }
 
     private unsafe void handleSdlEvents()

--- a/Sakura.Framework/Sakura.Framework.csproj
+++ b/Sakura.Framework/Sakura.Framework.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="ManagedBass.Fx" Version="4.0.2" />
     <PackageReference Include="ManagedBass.Mix" Version="4.0.2" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="Sakura.Framework.NativeLibraries" Version="2026.618.0" />
+    <PackageReference Include="Sakura.Framework.NativeLibraries" Version="2026.625.0" />
     <PackageReference Include="Sakura.Framework.SourceGenerators" Version="2026.622.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Since SDL3 exclusive fullscreen mode "seem" to work well so...🙏 hope it work. But tried it and work really well

Also add `Alignment` supprot to `FlowContainer` so you can adjust the position of how should the child align itself. (Note that this will not work if use `AutoSizeAxes`)