### PR TITLE
Add auto size transform container

### DIFF
--- a/Sakura.Framework.Benchmarks/Benchmarks/ConstructionBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/ConstructionBenchmarks.cs
@@ -44,6 +44,27 @@ public class ConstructionBenchmarks
         Size = new Vector2(100, 100),
     };
 
+    [Benchmark]
+    public Container NewAutoSizedContainer() => new Container
+    {
+        AutoSizeAxes = Axes.Both,
+        Children = new Drawable[]
+        {
+            new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(10, 10)
+            },
+            new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(30, 80)
+            }
+        }
+     };
+
     /// <summary>
     /// The full spawn path: construct, add to a loaded parent (triggers synchronous Load,
     /// dependency injection, clock re-wiring, topology invalidation), then remove.

--- a/Sakura.Framework.Benchmarks/Benchmarks/InputBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/InputBenchmarks.cs
@@ -10,22 +10,7 @@ using Sakura.Framework.Timing;
 namespace Sakura.Framework.Benchmarks.Benchmarks;
 
 /// <summary>
-/// Measures input handling through the central <see cref="InputManager"/>. After the input-flow
-/// refactor, the tree is no longer walked per-event: <see cref="InputManager.BuildQueues(Drawable, Vector2)"/>
-/// walks it once per frame to build the positional and non-positional queues, and the per-event
-/// <c>Dispatch*</c> methods then iterate those flat queues. Those are two very different costs, so
-/// they are benchmarked separately:
-///
-/// <list type="bullet">
-/// <item><description><b>BuildQueues</b> is the per-frame tree walk — the new hot path whose cost
-/// scales with tree size, and where the real work (and any allocation) now lives.</description></item>
-/// <item><description><b>Dispatch*</b> is the per-event cost — a flat queue iteration. Mouse events
-/// can arrive at up to 1000 Hz and key events are the latency-critical path of a rhythm game.</description></item>
-/// </list>
-///
-/// The dispatch benchmarks rebuild the queues in <see cref="IterationSetup"/> so they iterate a
-/// populated queue (an empty queue returns instantly and measures nothing). Every benchmark stores
-/// its result into a consumed field so the JIT cannot eliminate the call.
+/// Measures input handling through the central <see cref="InputManager"/>
 /// </summary>
 [MemoryDiagnoser]
 public class InputBenchmarks
@@ -40,8 +25,14 @@ public class InputBenchmarks
     [Params(10, 100)]
     public int ChildrenPerContainer;
 
-    private Container root = null!;
-    private ManualClock clock = null!;
+    // Inert tree: boxes that handle nothing, so dispatch walks the full queue (worst case).
+    private Container inertRoot = null!;
+    private ManualClock inertClock = null!;
+
+    // Tree with a front-most consuming handler under the cursor (realistic early-out).
+    private Container handledRoot = null!;
+    private ManualClock handledClock = null!;
+
     private InputManager manager = null!;
 
     private MouseEvent mouseMoveHit;
@@ -54,15 +45,25 @@ public class InputBenchmarks
     private static readonly Vector2 hit_point = new Vector2(640, 360);
     private static readonly Vector2 miss_point = new Vector2(-100, -100);
 
-    // Consumed so dispatch results can't be optimised away (the source of the suspicious 0.0000 ns rows).
+    // Consumed so dispatch results can't be optimised away
     private bool sink;
 
     [GlobalSetup]
     public void Setup()
     {
-        (root, clock) = BenchmarkTree.CreateRoot();
-        BenchmarkTree.AddGrid(root, Containers, ChildrenPerContainer);
-        BenchmarkTree.LoadAndSettle(root, clock);
+        (inertRoot, inertClock) = BenchmarkTree.CreateRoot();
+        BenchmarkTree.AddGrid(inertRoot, Containers, ChildrenPerContainer);
+        BenchmarkTree.LoadAndSettle(inertRoot, inertClock);
+
+        (handledRoot, handledClock) = BenchmarkTree.CreateRoot();
+        BenchmarkTree.AddGrid(handledRoot, Containers, ChildrenPerContainer);
+        // Added last and full-screen so it sits at the front of both queues and covers the hit point,
+        // giving every dispatch a first-entry consumer to short-circuit on.
+        handledRoot.Add(new HandlerBox
+        {
+            Size = new Vector2(1280, 720),
+        });
+        BenchmarkTree.LoadAndSettle(handledRoot, handledClock);
 
         manager = new InputManager();
 
@@ -77,71 +78,119 @@ public class InputBenchmarks
         scrollEvent = new ScrollEvent(hitState, new Vector2(0, 1));
     }
 
-    // ---- Queue building (per-frame tree walk) ----------------------------------------------------
+    #region Queue building (per-frame tree walk)
 
     /// <summary>
     /// Rebuilds both queues for a point over the playfield. This is the per-frame cost that replaced
     /// the old recursive per-event traversal, and the number that matters for frame budget.
     /// </summary>
     [Benchmark(Baseline = true)]
-    public void BuildQueues_OverTree() => manager.BuildQueues(root, hit_point);
+    public void BuildQueues_OverTree() => manager.BuildQueues(inertRoot, hit_point);
 
     /// <summary>
     /// Rebuilds both queues for a point outside every drawable. The positional walk stops early
     /// (nothing receives), isolating the non-positional walk plus the positional reject cost.
     /// </summary>
     [Benchmark]
-    public void BuildQueues_MissesTree() => manager.BuildQueues(root, miss_point);
+    public void BuildQueues_MissesTree() => manager.BuildQueues(inertRoot, miss_point);
 
-    // ---- Dispatch (per-event flat-queue iteration) -----------------------------------------------
+    #endregion
 
-    [IterationSetup(Targets = new[]
+    #region Dispatch, worst case: build + walk a queue that no one consumes
+
+    /// <summary>
+    /// Mouse move over the inert playfield: hover enter/leave reconciliation against a freshly built
+    /// positional queue, nothing consuming. Subtract <see cref="BuildQueues_OverTree"/> for the
+    /// dispatch-only cost.
+    /// </summary>
+    [Benchmark]
+    public void MouseMove_OverTree()
     {
-        nameof(MouseMove_OverTree),
-        nameof(MouseDownUp_OverTree),
-        nameof(Scroll_OverTree),
-        nameof(KeyDown_Dispatch)
-    })]
-    public void BuildQueuesForHit() => manager.BuildQueues(root, hit_point);
-
-    [IterationSetup(Target = nameof(MouseMove_MissesTree))]
-    public void BuildQueuesForMiss() => manager.BuildQueues(root, miss_point);
+        manager.BuildQueues(inertRoot, hit_point);
+        sink = manager.DispatchMouseMove(mouseMoveHit);
+    }
 
     /// <summary>
-    /// A mouse move over the playfield: drag-capture delivery (none here) plus the hover
-    /// enter/leave reconciliation against the freshly built positional queue.
+    /// Mouse move outside all drawables — empty positional queue, pure hover-reconciliation overhead.
     /// </summary>
     [Benchmark]
-    public void MouseMove_OverTree() => sink = manager.DispatchMouseMove(mouseMoveHit);
+    public void MouseMove_MissesTree()
+    {
+        manager.BuildQueues(inertRoot, miss_point);
+        sink = manager.DispatchMouseMove(mouseMoveMiss);
+    }
 
     /// <summary>
-    /// A mouse move outside all drawables — the positional queue is empty, so this measures the
-    /// pure hover-reconciliation overhead with nothing under the cursor.
-    /// </summary>
-    [Benchmark]
-    public void MouseMove_MissesTree() => sink = manager.DispatchMouseMove(mouseMoveMiss);
-
-    /// <summary>
-    /// A full press → release pair, walking the positional queue front-to-back. The down also sets
-    /// the drag-capture target and the up releases it, exercising that bookkeeping.
+    /// A press → release pair over the inert tree, walking the positional queue front-to-back. The
+    /// down sets the drag-capture target and the up releases it.
     /// </summary>
     [Benchmark]
     public void MouseDownUp_OverTree()
     {
+        manager.BuildQueues(inertRoot, hit_point);
         sink = manager.DispatchMouseDown(mouseDown);
         sink = manager.DispatchMouseUp(mouseUp);
     }
 
     /// <summary>
-    /// A key press dispatched down the non-positional queue. Replaces the old "broadcast to every
-    /// drawable" measurement — keys now stop at the first consumer in the flat queue.
+    /// Worst-case key dispatch: nothing consumes, so the walk visits every entry of the
+    /// non-positional queue (the whole tree). This is the row that scales linearly with tree size.
     /// </summary>
     [Benchmark]
-    public void KeyDown_Dispatch() => sink = manager.DispatchKeyDown(keyEvent);
+    public void KeyDown_OverTree()
+    {
+        manager.BuildQueues(inertRoot, hit_point);
+        sink = manager.DispatchKeyDown(keyEvent);
+    }
 
     /// <summary>
-    /// A scroll routed positionally; the first queue entry under the cursor that handles it wins.
+    /// Scroll routed positionally over the inert tree; nothing consumes.
     /// </summary>
     [Benchmark]
-    public void Scroll_OverTree() => sink = manager.DispatchScroll(scrollEvent);
+    public void Scroll_OverTree()
+    {
+        manager.BuildQueues(inertRoot, hit_point);
+        sink = manager.DispatchScroll(scrollEvent);
+    }
+
+    #endregion
+
+    #region Dispatch, realistic early-out: a front-most handler consumes the event
+
+    /// <summary>
+    /// Key dispatch with a front-most consumer: the walk stops at the first queue entry. Compare with
+    /// <see cref="KeyDown_OverTree"/> to see how much the consume-and-stop short-circuit saves, and
+    /// whether the worst-case linear scaling actually bites when a real handler is present.
+    /// </summary>
+    [Benchmark]
+    public void KeyDown_Handled()
+    {
+        manager.BuildQueues(handledRoot, hit_point);
+        sink = manager.DispatchKeyDown(keyEvent);
+    }
+
+    /// <summary>
+    /// Scroll dispatch with a front-most consumer under the cursor; stops at the first entry.
+    /// </summary>
+    [Benchmark]
+    public void Scroll_Handled()
+    {
+        manager.BuildQueues(handledRoot, hit_point);
+        sink = manager.DispatchScroll(scrollEvent);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// A drawable that consumes every input it is offered, used to measure the early-out dispatch
+    /// path. Front-most and full-screen in the handled tree, so it is the first queue entry for both
+    /// positional and non-positional dispatch.
+    /// </summary>
+    private partial class HandlerBox : Box
+    {
+        public override bool OnKeyDown(KeyEvent e) => true;
+        public override bool OnScroll(ScrollEvent e) => true;
+        public override bool OnMouseDown(MouseButtonEvent e) => true;
+        public override bool OnMouseUp(MouseButtonEvent e) => true;
+    }
 }

--- a/Sakura.Framework.Benchmarks/Benchmarks/InputBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/InputBenchmarks.cs
@@ -10,66 +10,138 @@ using Sakura.Framework.Timing;
 namespace Sakura.Framework.Benchmarks.Benchmarks;
 
 /// <summary>
-/// Measures input event propagation through the drawable hierarchy. Mouse events can arrive
-/// at up to 1000 Hz and key events are the latency-critical path of a rhythm game, so both
-/// the time and the per-event allocations here matter a lot.
+/// Measures input handling through the central <see cref="InputManager"/>. After the input-flow
+/// refactor, the tree is no longer walked per-event: <see cref="InputManager.BuildQueues(Drawable, Vector2)"/>
+/// walks it once per frame to build the positional and non-positional queues, and the per-event
+/// <c>Dispatch*</c> methods then iterate those flat queues. Those are two very different costs, so
+/// they are benchmarked separately:
+///
+/// <list type="bullet">
+/// <item><description><b>BuildQueues</b> is the per-frame tree walk — the new hot path whose cost
+/// scales with tree size, and where the real work (and any allocation) now lives.</description></item>
+/// <item><description><b>Dispatch*</b> is the per-event cost — a flat queue iteration. Mouse events
+/// can arrive at up to 1000 Hz and key events are the latency-critical path of a rhythm game.</description></item>
+/// </list>
+///
+/// The dispatch benchmarks rebuild the queues in <see cref="IterationSetup"/> so they iterate a
+/// populated queue (an empty queue returns instantly and measures nothing). Every benchmark stores
+/// its result into a consumed field so the JIT cannot eliminate the call.
 /// </summary>
 [MemoryDiagnoser]
 public class InputBenchmarks
 {
+    /// <summary>
+    /// Number of column containers in the grid. Combined with <see cref="ChildrenPerContainer"/>
+    /// this sets the tree size, which is what <see cref="BuildQueues"/> cost scales with.
+    /// </summary>
+    [Params(10)]
+    public int Containers;
+
+    [Params(10, 100)]
+    public int ChildrenPerContainer;
+
     private Container root = null!;
     private ManualClock clock = null!;
+    private InputManager manager = null!;
 
     private MouseEvent mouseMoveHit;
     private MouseEvent mouseMoveMiss;
+    private MouseButtonEvent mouseDown;
+    private MouseButtonEvent mouseUp;
     private KeyEvent keyEvent;
     private ScrollEvent scrollEvent;
+
+    private static readonly Vector2 hit_point = new Vector2(640, 360);
+    private static readonly Vector2 miss_point = new Vector2(-100, -100);
+
+    // Consumed so dispatch results can't be optimised away (the source of the suspicious 0.0000 ns rows).
+    private bool sink;
 
     [GlobalSetup]
     public void Setup()
     {
         (root, clock) = BenchmarkTree.CreateRoot();
-        BenchmarkTree.AddGrid(root, 10, 100);
+        BenchmarkTree.AddGrid(root, Containers, ChildrenPerContainer);
         BenchmarkTree.LoadAndSettle(root, clock);
 
-        var hitState = new MouseState
-        {
-            Position = new Vector2(640, 360)
-        };
+        manager = new InputManager();
+
+        var hitState = new MouseState { Position = hit_point };
+        var missState = new MouseState { Position = miss_point };
+
         mouseMoveHit = new MouseEvent(hitState, new Vector2(1, 0));
-
-        var missState = new MouseState
-        {
-            Position = new Vector2(-100, -100)
-        };
         mouseMoveMiss = new MouseEvent(missState, new Vector2(1, 0));
-
+        mouseDown = new MouseButtonEvent(hitState, MouseButton.Left, 1);
+        mouseUp = new MouseButtonEvent(hitState, MouseButton.Left, 1);
         keyEvent = new KeyEvent(Key.Z, KeyModifiers.None, false);
         scrollEvent = new ScrollEvent(hitState, new Vector2(0, 1));
     }
 
+    // ---- Queue building (per-frame tree walk) ----------------------------------------------------
+
     /// <summary>
-    /// Mouse move over the playfield (hits drawables, triggers hover checks down the tree).
+    /// Rebuilds both queues for a point over the playfield. This is the per-frame cost that replaced
+    /// the old recursive per-event traversal, and the number that matters for frame budget.
     /// </summary>
     [Benchmark(Baseline = true)]
-    public bool MouseMove_OverTree() => root.OnMouseMove(mouseMoveHit);
+    public void BuildQueues_OverTree() => manager.BuildQueues(root, hit_point);
 
     /// <summary>
-    /// Mouse move outside all drawables — still traverses; measures the pure routing overhead.
+    /// Rebuilds both queues for a point outside every drawable. The positional walk stops early
+    /// (nothing receives), isolating the non-positional walk plus the positional reject cost.
     /// </summary>
     [Benchmark]
-    public bool MouseMove_MissesTree() => root.OnMouseMove(mouseMoveMiss);
+    public void BuildQueues_MissesTree() => manager.BuildQueues(root, miss_point);
+
+    // ---- Dispatch (per-event flat-queue iteration) -----------------------------------------------
+
+    [IterationSetup(Targets = new[]
+    {
+        nameof(MouseMove_OverTree),
+        nameof(MouseDownUp_OverTree),
+        nameof(Scroll_OverTree),
+        nameof(KeyDown_Dispatch)
+    })]
+    public void BuildQueuesForHit() => manager.BuildQueues(root, hit_point);
+
+    [IterationSetup(Target = nameof(MouseMove_MissesTree))]
+    public void BuildQueuesForMiss() => manager.BuildQueues(root, miss_point);
 
     /// <summary>
-    /// A key press. Currently broadcast to every drawable in the tree; this measures
-    /// the full press → handled round trip on a 1000-drawable scene.
+    /// A mouse move over the playfield: drag-capture delivery (none here) plus the hover
+    /// enter/leave reconciliation against the freshly built positional queue.
     /// </summary>
     [Benchmark]
-    public bool KeyDown_Broadcast() => root.OnKeyDown(keyEvent);
+    public void MouseMove_OverTree() => sink = manager.DispatchMouseMove(mouseMoveHit);
 
     /// <summary>
-    /// Scroll routed positionally like clicks are.
+    /// A mouse move outside all drawables — the positional queue is empty, so this measures the
+    /// pure hover-reconciliation overhead with nothing under the cursor.
     /// </summary>
     [Benchmark]
-    public bool Scroll_OverTree() => root.OnScroll(scrollEvent);
+    public void MouseMove_MissesTree() => sink = manager.DispatchMouseMove(mouseMoveMiss);
+
+    /// <summary>
+    /// A full press → release pair, walking the positional queue front-to-back. The down also sets
+    /// the drag-capture target and the up releases it, exercising that bookkeeping.
+    /// </summary>
+    [Benchmark]
+    public void MouseDownUp_OverTree()
+    {
+        sink = manager.DispatchMouseDown(mouseDown);
+        sink = manager.DispatchMouseUp(mouseUp);
+    }
+
+    /// <summary>
+    /// A key press dispatched down the non-positional queue. Replaces the old "broadcast to every
+    /// drawable" measurement — keys now stop at the first consumer in the flat queue.
+    /// </summary>
+    [Benchmark]
+    public void KeyDown_Dispatch() => sink = manager.DispatchKeyDown(keyEvent);
+
+    /// <summary>
+    /// A scroll routed positionally; the first queue entry under the cursor that handles it wins.
+    /// </summary>
+    [Benchmark]
+    public void Scroll_OverTree() => sink = manager.DispatchScroll(scrollEvent);
 }

--- a/Sakura.Framework.Tests/Graphics/ContainerAutoSizeEasingTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ContainerAutoSizeEasingTest.cs
@@ -1,0 +1,250 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Transforms;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+[TestFixture]
+public class ContainerAutoSizeEasingTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock { CurrentTime = 1000 };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+    }
+
+    private void frame(double advanceMs = 16)
+    {
+        manual.CurrentTime += advanceMs;
+        root.UpdateSubTree();
+    }
+
+    private void settle()
+    {
+        for (int i = 0; i < 3; i++)
+            frame();
+    }
+
+    /// <summary>
+    /// Replacement of NUnit's <c>.Within()</c> with Sakura's Vector2
+    /// </summary>
+    private static void assertSize(Vector2 actual, float x, float y, string? message = null)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.X, Is.EqualTo(x).Within(0.01f), message);
+            Assert.That(actual.Y, Is.EqualTo(y).Within(0.01f), message);
+        });
+    }
+
+    [Test]
+    public void TestDefaultsAreUnchanged()
+    {
+        var panel = new Container { AutoSizeAxes = Axes.Both };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(panel.AutoSizeDuration, Is.EqualTo(0), "AutoSizeDuration must default to 0 (instant).");
+            Assert.That(panel.AutoSizeEasing, Is.EqualTo(Easing.None), "AutoSizeEasing must default to None.");
+        });
+    }
+
+    [Test]
+    public void TestZeroDurationSnapsInstantly()
+    {
+        var panel = new Container { AutoSizeAxes = Axes.Both };
+        var box = new Box { Size = new Vector2(50, 40) };
+        panel.Add(box);
+        root.Add(panel);
+        settle();
+
+        assertSize(panel.Size, 50, 40);
+
+        box.Size = new Vector2(120, 90);
+        frame();
+        frame();
+
+        assertSize(panel.Size, 120, 90, "A zero-duration auto-size must snap to the new size.");
+    }
+
+    [Test]
+    public void TestAnimatedAutoSizeIsGradualThenSettlesExactly()
+    {
+        var panel = new Container
+        {
+            AutoSizeAxes = Axes.Both,
+            AutoSizeDuration = 200,
+            AutoSizeEasing = Easing.None
+        };
+        var box = new Box
+        {
+            Size = new Vector2(100, 100)
+        };
+        panel.Add(box);
+        root.Add(panel);
+        settle();
+
+        manual.CurrentTime += 400;
+        root.UpdateSubTree();
+        root.UpdateSubTree();
+        assertSize(panel.Size, 100, 100);
+
+        box.Size = new Vector2(300, 300);
+
+        frame();
+        double startTime = manual.CurrentTime;
+
+        manual.CurrentTime = startTime + 100;
+        root.UpdateSubTree();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(panel.Size.X, Is.GreaterThan(120f), "Animated auto-size must have started growing by the midpoint.");
+            Assert.That(panel.Size.X, Is.LessThan(280f), "Animated auto-size must not have completed at the midpoint.");
+        });
+
+        manual.CurrentTime = startTime + 400;
+        root.UpdateSubTree();
+        root.UpdateSubTree();
+
+        assertSize(panel.Size, 300, 300, "Animated auto-size must settle exactly on the computed target.");
+    }
+
+    [Test]
+    public void TestAnimatedAutoSizeShrinks()
+    {
+        var panel = new Container
+        {
+            AutoSizeAxes = Axes.Both,
+            AutoSizeDuration = 200
+        };
+        var big = new Box { Size = new Vector2(300, 200) };
+        var small = new Box { Size = new Vector2(50, 50) };
+        panel.Add(big);
+        panel.Add(small);
+        root.Add(panel);
+        settle();
+
+        manual.CurrentTime += 400;
+        root.UpdateSubTree();
+        root.UpdateSubTree();
+        assertSize(panel.Size, 300, 200);
+
+        panel.Remove(big);
+        frame();
+        manual.CurrentTime += 400;
+        root.UpdateSubTree();
+        root.UpdateSubTree();
+
+        assertSize(panel.Size, 50, 50, "Animated auto-size must shrink to the new (smaller) target.");
+    }
+
+    [Test]
+    public void TestRetargetMidAnimationSettlesOnLatestTarget()
+    {
+        var panel = new Container
+        {
+            AutoSizeAxes = Axes.Both,
+            AutoSizeDuration = 200
+        };
+        var box = new Box
+        {
+            Size = new Vector2(100, 100)
+        };
+        panel.Add(box);
+        root.Add(panel);
+        settle();
+
+        manual.CurrentTime += 400;
+        root.UpdateSubTree();
+        root.UpdateSubTree();
+        assertSize(panel.Size, 100, 100);
+
+        box.Size = new Vector2(400, 400);
+        frame();
+        manual.CurrentTime += 50; // partway
+        root.UpdateSubTree();
+        Assert.That(panel.Size.X, Is.LessThan(400f));
+
+        box.Size = new Vector2(250, 250);
+        frame();
+        manual.CurrentTime += 400;
+        root.UpdateSubTree();
+        root.UpdateSubTree();
+
+        assertSize(panel.Size, 250, 250, "A mid-animation re-target must settle on the latest target.");
+    }
+
+    [Test]
+    public void TestSwitchingDurationToZeroCancelsAnimation()
+    {
+        var panel = new Container
+        {
+            AutoSizeAxes = Axes.Both,
+            AutoSizeDuration = 500
+        };
+        var box = new Box { Size = new Vector2(100, 100) };
+        panel.Add(box);
+        root.Add(panel);
+        settle();
+
+        box.Size = new Vector2(300, 300);
+        frame();
+        manual.CurrentTime += 50;
+        root.UpdateSubTree();
+        Assert.That(panel.Size.X, Is.LessThan(300f), "Animation should be in progress.");
+
+        panel.AutoSizeDuration = 0;
+        frame();
+        frame();
+
+        assertSize(panel.Size, 300, 300, "Setting AutoSizeDuration to 0 must cancel the animation and snap to the target.");
+    }
+
+    [Test]
+    public void TestNonAutoSizedContainerIgnoresDuration()
+    {
+        var panel = new Container
+        {
+            Size = new Vector2(200, 150),
+            AutoSizeDuration = 500,
+            AutoSizeEasing = Easing.OutQuint
+        };
+        var box = new Box { Size = new Vector2(50) };
+        panel.Add(box);
+        root.Add(panel);
+        settle();
+
+        assertSize(panel.Size, 200, 150, "A non-auto-sized container keeps its explicit size.");
+
+        box.Size = new Vector2(400, 400);
+        frame();
+        frame();
+
+        assertSize(panel.Size, 200, 150, "A non-auto-sized container must ignore child size changes entirely.");
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/DeferredClockInheritanceTest.cs
+++ b/Sakura.Framework.Tests/Graphics/DeferredClockInheritanceTest.cs
@@ -1,0 +1,224 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Extensions.DrawableExtensions;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Regression tests for the construction-time clock-inheritance deferral
+/// after decrease allocation
+/// </summary>
+[TestFixture]
+public class DeferredClockInheritanceTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock { CurrentTime = 1000 };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+
+        advanceTo(1000);
+    }
+
+    private void advanceTo(double time)
+    {
+        manual.CurrentTime = time;
+        root.UpdateSubTree();
+    }
+
+    [Test]
+    public void TestNestedConstructionInheritsClockOnAttach()
+    {
+        // The whole tree is built before being attached anywhere, so every Add happens on an
+        // unloaded container and defers clock inheritance. Attaching the outermost to the loaded
+        // root must inherit the clock all the way down.
+        var inner = new Container { Size = new Vector2(100) };
+        var middle = new Container { Size = new Vector2(200) };
+        var box = new Box { Size = new Vector2(10) };
+
+        inner.Add(box);
+        middle.Add(inner);
+
+        // nothing in the detached tree is loaded yet.
+        Assert.Multiple(() =>
+        {
+            Assert.That(middle.IsLoaded, Is.False);
+            Assert.That(inner.IsLoaded, Is.False);
+            Assert.That(box.IsLoaded, Is.False);
+        });
+
+        root.Add(middle);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(middle.Clock, Is.SameAs(root.Clock));
+            Assert.That(inner.Clock, Is.SameAs(root.Clock));
+            Assert.That(box.Clock, Is.SameAs(root.Clock), "Deferred inheritance must reach every descendant on attach.");
+        });
+
+        advanceTo(1500);
+        Assert.That(box.Clock.CurrentTime, Is.EqualTo(1500).Within(0.001), "The shared clock must drive the deepest child.");
+    }
+
+    [Test]
+    public void TestChildrenInitializerInheritsClockOnAttach()
+    {
+        // Same as above but using the Children collection initializer (the common construction
+        // pattern and the one exercised by the benchmark).
+        Container middle = null!;
+        Box box = null!;
+
+        var outer = new Container
+        {
+            Size = new Vector2(300),
+            Children = new Drawable[]
+            {
+                middle = new Container
+                {
+                    Size = new Vector2(200),
+                    Children = new Drawable[]
+                    {
+                        box = new Box { Size = new Vector2(10) }
+                    }
+                }
+            }
+        };
+
+        root.Add(outer);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outer.Clock, Is.SameAs(root.Clock));
+            Assert.That(middle.Clock, Is.SameAs(root.Clock));
+            Assert.That(box.Clock, Is.SameAs(root.Clock));
+        });
+    }
+
+    [Test]
+    public void TestDirectAddToLoadedRootInheritsImmediately()
+    {
+        // adding directly to a loaded container inherits at once.
+        var box = new Box { Size = new Vector2(10) };
+        root.Add(box);
+
+        Assert.That(box.Clock, Is.SameAs(root.Clock));
+    }
+
+    [Test]
+    public void TestCustomClockSurvivesDeferredConstruction()
+    {
+        var childManual = new ManualClock { CurrentTime = 0 };
+        var custom = new FramedClock(childManual);
+
+        var box = new Box { Size = new Vector2(10) };
+        box.Clock = custom; // explicit clock => hasCustomClock
+
+        var holder = new Container { Size = new Vector2(200) };
+        holder.Add(box); // deferred (holder unloaded)
+        root.Add(holder);
+
+        Assert.That(box.Clock, Is.SameAs(custom), "An explicitly-assigned clock must survive deferred construction and attach.");
+
+        // The custom clock is independent of the parent timeline.
+        advanceTo(2000);
+        Assert.That(box.Clock.CurrentTime, Is.EqualTo(0).Within(0.001));
+
+        childManual.CurrentTime = 250;
+        advanceTo(2100);
+        Assert.That(box.Clock.CurrentTime, Is.EqualTo(250).Within(0.001), "The custom clock must still be processed each frame.");
+    }
+
+    [Test]
+    public void TestTransformScheduledDuringConstructionRebasesOnAttach()
+    {
+        // A transform queued on a child while the tree is still detached must begin at attach time
+        // on the shared timeline — the deferral must not break transform rebasing.
+        var box = new Box { Size = new Vector2(10) };
+        var holder = new Container { Size = new Vector2(200) };
+        holder.Add(box); // deferred
+
+        box.FadeOut(100); // scheduled before the tree is attached to the loaded root
+
+        root.Add(holder); // box now inherits root.Clock and the fade rebases to attach time
+
+        // Halfway through the fade on the shared timeline.
+        advanceTo(1050);
+        Assert.That(box.Alpha, Is.EqualTo(0.5f).Within(0.05f),
+            "A transform queued during detached construction must begin at attach time.");
+
+        advanceTo(1150);
+        Assert.That(box.Alpha, Is.EqualTo(0f).Within(0.001f));
+    }
+
+    [Test]
+    public void TestScheduledTaskDuringConstructionRunsAfterAttach()
+    {
+        bool ran = false;
+
+        var box = new Box { Size = new Vector2(10) };
+        var holder = new Container { Size = new Vector2(200) };
+        holder.Add(box); // deferred
+
+        box.Schedule(() => ran = true);
+
+        root.Add(holder);
+        advanceTo(1001);
+
+        Assert.That(ran, Is.True, "A task scheduled during detached construction must run once the tree is attached and updated.");
+    }
+
+    [Test]
+    public void TestClockReassignmentReachesDeferredSubtree()
+    {
+        var middle = new Container { Size = new Vector2(200) };
+        var box = new Box { Size = new Vector2(10) };
+        middle.Add(box); // deferred
+        root.Add(middle);
+
+        var newManual = new ManualClock { CurrentTime = 5000 };
+        root.Clock = new FramedClock(newManual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(middle.Clock, Is.SameAs(root.Clock));
+            Assert.That(box.Clock, Is.SameAs(root.Clock), "Reassigning the root clock must propagate to a formerly-deferred subtree.");
+        });
+    }
+
+    [Test]
+    public void TestContainerLoadedBeforeAddingChildInheritsImmediately()
+    {
+        // A container that is already loaded (because it was attached first) takes the immediate
+        // inheritance path when children are added afterwards.
+        var holder = new Container { Size = new Vector2(200) };
+        root.Add(holder); // holder is now loaded
+        Assert.That(holder.IsLoaded, Is.True);
+
+        var box = new Box { Size = new Vector2(10) };
+        holder.Add(box); // immediate path
+
+        Assert.That(box.Clock, Is.SameAs(root.Clock));
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/RelativeChildSpaceTest.cs
+++ b/Sakura.Framework.Tests/Graphics/RelativeChildSpaceTest.cs
@@ -1,0 +1,291 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Headless behavioural tests for the relative-child coordinate space
+/// (<see cref="Container.RelativeChildSize"/> / <see cref="Container.RelativeChildOffset"/>)
+/// </summary>
+[TestFixture]
+public class RelativeChildSpaceTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock { CurrentTime = 1000 };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+    }
+
+    private void frame() => frame(16);
+
+    private void frame(double advanceMs)
+    {
+        manual.CurrentTime += advanceMs;
+        root.UpdateSubTree();
+    }
+
+    private void settle()
+    {
+        for (int i = 0; i < 3; i++)
+            frame();
+    }
+
+    /// <summary>
+    /// Asserts a <see cref="Vector2"/> componentwise. NUnit's <c>.Within()</c> tolerance is not
+    /// supported on the framework's custom <see cref="Vector2"/>, so comparisons assert
+    /// <c>.X</c>/<c>.Y</c> individually.
+    /// </summary>
+    private static void assertVector(Vector2 actual, float x, float y, string? message = null)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.X, Is.EqualTo(x).Within(0.01f), message);
+            Assert.That(actual.Y, Is.EqualTo(y).Within(0.01f), message);
+        });
+    }
+
+    [Test]
+    public void TestDefaults()
+    {
+        var container = new Container { Size = new Vector2(400) };
+
+        assertVector(container.RelativeChildSize, 1, 1, "RelativeChildSize must default to One.");
+        assertVector(container.RelativeChildOffset, 0, 0, "RelativeChildOffset must default to Zero.");
+    }
+
+    [Test]
+    public void TestDefaultRelativeResolutionUnchanged()
+    {
+        // With the defaults, a relatively-sized/positioned child must resolve exactly as it did
+        // before the feature existed: size = relative * ChildSize, position = relative * ChildSize.
+        var container = new Container { Position = new Vector2(0, 0), Size = new Vector2(400) };
+        var child = new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            RelativePositionAxes = Axes.Both,
+            Size = new Vector2(0.5f),
+            Position = new Vector2(0.25f)
+        };
+        container.Add(child);
+        root.Add(container);
+        settle();
+
+        assertVector(child.DrawSize, 200, 200, "0.5 of 400px = 200px.");
+        Assert.Multiple(() =>
+        {
+            Assert.That(child.DrawRectangle.X, Is.EqualTo(100).Within(0.01f), "0.25 of 400px = 100px from the container's left.");
+            Assert.That(child.DrawRectangle.Y, Is.EqualTo(100).Within(0.01f));
+        });
+    }
+
+    [Test]
+    public void TestRelativeChildSizeScalesRelativeSize()
+    {
+        var container = new Container { Size = new Vector2(400) };
+        var child = new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            Size = new Vector2(0.5f)
+        };
+        container.Add(child);
+        root.Add(container);
+        settle();
+
+        assertVector(child.DrawSize, 200, 200);
+
+        // Doubling the relative space halves the resolved pixel size for the same relative value.
+        container.RelativeChildSize = new Vector2(2);
+        frame();
+        frame();
+        assertVector(child.DrawSize, 100, 100, "RelativeChildSize (2,2) maps relative 0.5 to 0.5/2*400 = 100px.");
+
+        // Halving the relative space doubles it.
+        container.RelativeChildSize = new Vector2(0.5f);
+        frame();
+        frame();
+        assertVector(child.DrawSize, 400, 400, "RelativeChildSize (0.5,0.5) maps relative 0.5 to 0.5/0.5*400 = 400px.");
+    }
+
+    [Test]
+    public void TestRelativeChildSizeScalesRelativePosition()
+    {
+        var container = new Container { Position = new Vector2(0, 0), Size = new Vector2(400) };
+        var child = new Box
+        {
+            RelativePositionAxes = Axes.Both,
+            Size = new Vector2(20),
+            Position = new Vector2(0.5f)
+        };
+        container.Add(child);
+        root.Add(container);
+        settle();
+
+        // Default: relative position 0.5 -> 200px.
+        Assert.That(child.DrawRectangle.X, Is.EqualTo(200).Within(0.01f));
+
+        container.RelativeChildSize = new Vector2(2);
+        frame();
+        frame();
+
+        // 0.5 / 2 * 400 = 100px.
+        Assert.That(child.DrawRectangle.X, Is.EqualTo(100).Within(0.01f),
+            "RelativeChildSize must scale relative position as well as relative size.");
+    }
+
+    [Test]
+    public void TestRelativeChildOffsetShiftsPositionNotSize()
+    {
+        var container = new Container { Position = new Vector2(0, 0), Size = new Vector2(400) };
+        var child = new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            RelativePositionAxes = Axes.Both,
+            Size = new Vector2(0.5f),
+            Position = new Vector2(0.25f)
+        };
+        container.Add(child);
+        root.Add(container);
+        settle();
+
+        Assert.That(child.DrawRectangle.X, Is.EqualTo(100).Within(0.01f));
+        assertVector(child.DrawSize, 200, 200);
+
+        // Offset by 0.25: child at relative position 0.25 now resolves to pixel 0.
+        container.RelativeChildOffset = new Vector2(0.25f);
+        frame();
+        frame();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(child.DrawRectangle.X, Is.EqualTo(0).Within(0.01f),
+                "RelativeChildOffset must shift the relative-space origin (0.25 - 0.25) * 400 = 0.");
+            Assert.That(child.DrawRectangle.Y, Is.EqualTo(0).Within(0.01f));
+        });
+        assertVector(child.DrawSize, 200, 200, "RelativeChildOffset must not affect resolved size.");
+    }
+
+    [Test]
+    public void TestNonRelativeChildIsUnaffected()
+    {
+        // A child with absolute (non-relative) position/size must ignore the relative-space settings.
+        var container = new Container
+        {
+            Position = new Vector2(0, 0),
+            Size = new Vector2(400),
+            RelativeChildSize = new Vector2(2),
+            RelativeChildOffset = new Vector2(0.3f)
+        };
+        var child = new Box
+        {
+            Size = new Vector2(60),
+            Position = new Vector2(40, 30)
+        };
+        container.Add(child);
+        root.Add(container);
+        settle();
+
+        assertVector(child.DrawSize, 60, 60, "Absolute size must be unaffected.");
+        Assert.Multiple(() =>
+        {
+            Assert.That(child.DrawRectangle.X, Is.EqualTo(40).Within(0.01f), "Absolute position must be unaffected.");
+            Assert.That(child.DrawRectangle.Y, Is.EqualTo(30).Within(0.01f));
+        });
+    }
+
+    [Test]
+    public void TestZeroRelativeChildSizeThrows()
+    {
+        var container = new Container { Size = new Vector2(400) };
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<System.ArgumentException>(() => container.RelativeChildSize = new Vector2(0, 1),
+                "Zero on the X axis must be rejected.");
+            Assert.Throws<System.ArgumentException>(() => container.RelativeChildSize = new Vector2(1, 0),
+                "Zero on the Y axis must be rejected.");
+            Assert.Throws<System.ArgumentException>(() => container.RelativeChildSize = Vector2.Zero,
+                "Zero on both axes must be rejected.");
+        });
+
+        // The rejected assignments must not have mutated the property.
+        assertVector(container.RelativeChildSize, 1, 1);
+    }
+
+    [Test]
+    public void TestChangingRelativeChildSizeCascadesToChildren()
+    {
+        // Changing the relative space must invalidate and re-resolve every child the next pass.
+        var container = new Container { Size = new Vector2(400) };
+        var a = new Box { RelativeSizeAxes = Axes.Both, Size = new Vector2(0.5f) };
+        var b = new Box { RelativeSizeAxes = Axes.Both, Size = new Vector2(0.25f) };
+        container.Add(a);
+        container.Add(b);
+        root.Add(container);
+        settle();
+
+        Assert.That(a.DrawSize.X, Is.EqualTo(200).Within(0.01f));
+        Assert.That(b.DrawSize.X, Is.EqualTo(100).Within(0.01f));
+
+        container.RelativeChildSize = new Vector2(2);
+        frame();
+        frame();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a.DrawSize.X, Is.EqualTo(100).Within(0.01f), "Child A must re-resolve after the relative space changes.");
+            Assert.That(b.DrawSize.X, Is.EqualTo(50).Within(0.01f), "Child B must re-resolve after the relative space changes.");
+        });
+    }
+
+    [Test]
+    public void TestRelativeChildSizeRespectsPadding()
+    {
+        // The relative space is built on ChildSize (DrawSize minus padding), so padding must still
+        // apply on top of RelativeChildSize scaling.
+        var container = new Container
+        {
+            Size = new Vector2(400),
+            Padding = new MarginPadding(50) // content area = 300x300
+        };
+        var child = new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            Size = new Vector2(1f)
+        };
+        container.Add(child);
+        root.Add(container);
+        settle();
+
+        assertVector(child.DrawSize, 300, 300, "Relative 1.0 fills the padded content area (300px), not the full 400px.");
+
+        container.RelativeChildSize = new Vector2(2);
+        frame();
+        frame();
+
+        assertVector(child.DrawSize, 150, 150, "RelativeChildSize scales within the padded content area: 1.0/2*300 = 150px.");
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Containers/TestContainerAutoSizeEasing.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestContainerAutoSizeEasing.cs
@@ -1,0 +1,146 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Transforms;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Testing;
+
+namespace Sakura.Framework.Tests.Visuals.Containers;
+
+public partial class TestContainerAutoSizeEasing : TestScene
+{
+    private Container autoSizeContainer = null!;
+    private Box background = null!;
+    private readonly List<Box> contentBoxes = new List<Box>();
+
+    [SetUp]
+    public void SetUp()
+    {
+        AddStep("Create auto-size container", () =>
+        {
+            contentBoxes.Clear();
+
+            autoSizeContainer = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                AutoSizeDuration = 500,
+                AutoSizeEasing = Easing.OutQuint,
+                Padding = new MarginPadding(10),
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Color = Color.DarkSlateGray
+                    },
+                    new Box
+                    {
+                        Size = new Vector2(100),
+                        Color = Color.Red
+                    }
+                }
+            };
+        });
+
+        AddStep("Add container", () => Add(autoSizeContainer));
+    }
+
+    [Test]
+    public void TestGrowAndShrink()
+    {
+        AddUntilStep("Container settles at 120x120", () => autoSizeContainer.Size == new Vector2(120));
+
+        AddStep("Add a wide child", () =>
+        {
+            var box = new Box
+            {
+                Y = 100,
+                Size = new Vector2(260, 60),
+                Color = Color.SkyBlue
+            };
+            contentBoxes.Add(box);
+            autoSizeContainer.Add(box);
+        });
+
+        AddUntilStep("Container grew to fit wide child", () => autoSizeContainer.Size == new Vector2(280, 180));
+
+        AddStep("Remove the wide child", () =>
+        {
+            var box = contentBoxes[^1];
+            contentBoxes.Remove(box);
+            autoSizeContainer.Remove(box);
+        });
+
+        AddUntilStep("Container shrank back to 120x120", () => autoSizeContainer.Size == new Vector2(120));
+    }
+
+    [Test]
+    public void TestInstantWhenZeroDuration()
+    {
+        AddStep("Set duration to 0", () => autoSizeContainer.AutoSizeDuration = 0);
+
+        AddStep("Add a tall child", () =>
+        {
+            var box = new Box
+            {
+                Y = 100,
+                Size = new Vector2(80, 200),
+                Color = Color.Orange
+            };
+            contentBoxes.Add(box);
+            autoSizeContainer.Add(box);
+        });
+
+        AddUntilStep("Container snapped to new height", () => autoSizeContainer.Size == new Vector2(120, 320));
+    }
+
+    [Test]
+    public void TestEasingPlayground()
+    {
+        AddSliderStep("Auto-size duration", 0d, 2000d, 500d, v => autoSizeContainer.AutoSizeDuration = v);
+
+        addEasingStep(Easing.None);
+        addEasingStep(Easing.OutQuint);
+        addEasingStep(Easing.OutBack);
+        addEasingStep(Easing.OutElastic);
+    }
+
+    private void addEasingStep(Easing easing)
+    {
+        AddStep($"Easing: {easing} + toggle size", () =>
+        {
+            autoSizeContainer.AutoSizeEasing = easing;
+
+            if (contentBoxes.Count > 0)
+            {
+                var box = contentBoxes[^1];
+                contentBoxes.Remove(box);
+                autoSizeContainer.Remove(box);
+            }
+            else
+            {
+                var box = new Box
+                {
+                    X = 100,
+                    Size = new Vector2(200, 100),
+                    Color = Color.MediumPurple
+                };
+                contentBoxes.Add(box);
+                autoSizeContainer.Add(box);
+            }
+        });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        AddStep("Clear all children", Clear);
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Containers/TestRelativeChildSpace.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestRelativeChildSpace.cs
@@ -1,0 +1,120 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Testing;
+using Sakura.Framework.Utilities;
+
+namespace Sakura.Framework.Tests.Visuals.Containers;
+
+public partial class TestRelativeChildSpace : TestScene
+{
+    private Container container = null!;
+    private Box relativeChild = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        AddStep("Create container with relative child", () =>
+        {
+            container = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(400),
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Color = Color.DarkSlateGray
+                    },
+                    relativeChild = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.Both,
+                        Size = new Vector2(0.5f),
+                        Position = new Vector2(0.25f),
+                        Color = Color.OrangeRed
+                    }
+                }
+            };
+        });
+
+        AddStep("Add container", () => Add(container));
+    }
+
+    [Test]
+    public void TestDefaultRelativeSpace()
+    {
+        AddUntilStep("Child resolves to 200x200", () => Precision.AlmostEquals(relativeChild.DrawSize, new Vector2(200), 0.5f));
+
+        AddAssert("RelativeChildSize defaults to One", () => container.RelativeChildSize == Vector2.One);
+        AddAssert("RelativeChildOffset defaults to Zero", () => container.RelativeChildOffset == Vector2.Zero);
+    }
+
+    [Test]
+    public void TestRelativeChildSize()
+    {
+        AddUntilStep("Child starts at 200x200", () => Precision.AlmostEquals(relativeChild.DrawSize, new Vector2(200), 0.5f));
+
+        AddStep("Set RelativeChildSize to (2,2)", () => container.RelativeChildSize = new Vector2(2));
+        AddUntilStep("Child shrinks to 100x100", () => Precision.AlmostEquals(relativeChild.DrawSize, new Vector2(100), 0.5f));
+
+        AddStep("Set RelativeChildSize to (0.5,0.5)", () => container.RelativeChildSize = new Vector2(0.5f));
+        AddUntilStep("Child grows to 400x400", () => Precision.AlmostEquals(relativeChild.DrawSize, new Vector2(400), 0.5f));
+
+        AddStep("Reset RelativeChildSize", () => container.RelativeChildSize = Vector2.One);
+        AddUntilStep("Child back to 200x200", () => Precision.AlmostEquals(relativeChild.DrawSize, new Vector2(200), 0.5f));
+    }
+
+    [Test]
+    public void TestRelativeChildOffset()
+    {
+        RectangleF beforeOffset = default;
+        RectangleF parentRect = default;
+        AddStep("Capture child & parent screen rects", () =>
+        {
+            beforeOffset = relativeChild.DrawRectangle;
+            parentRect = container.DrawRectangle;
+        });
+        
+        AddStep("Set RelativeChildOffset to (0.25,0.25)", () => container.RelativeChildOffset = new Vector2(0.25f));
+        AddUntilStep("Child size unchanged at 200x200", () => Precision.AlmostEquals(relativeChild.DrawSize, new Vector2(200), 0.5f));
+        AddUntilStep("Child moved up-left by 0.25 of parent extent", () =>
+            Precision.AlmostEquals(relativeChild.DrawRectangle.X, beforeOffset.X - 0.25f * parentRect.Width, 1f) &&
+            Precision.AlmostEquals(relativeChild.DrawRectangle.Y, beforeOffset.Y - 0.25f * parentRect.Height, 1f));
+
+        AddStep("Reset RelativeChildOffset", () => container.RelativeChildOffset = Vector2.Zero);
+        AddUntilStep("Child returns to original position", () =>
+            Precision.AlmostEquals(relativeChild.DrawRectangle.X, beforeOffset.X, 1f) &&
+            Precision.AlmostEquals(relativeChild.DrawRectangle.Y, beforeOffset.Y, 1f));
+    }
+
+    [Test]
+    public void TestNonZeroValidation()
+    {
+        AddAssert("Zero RelativeChildSize throws", () =>
+        {
+            try
+            {
+                container.RelativeChildSize = new Vector2(0, 1);
+                return false;
+            }
+            catch (System.ArgumentException)
+            {
+                return true;
+            }
+        });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        AddStep("Clear all children", Clear);
+    }
+}

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -8,6 +8,7 @@ using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Input;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Utilities;
@@ -105,6 +106,41 @@ public partial class Container : Drawable
     /// Control which axes that this container automatically sized based on its children's sizes.
     /// </summary>
     public Axes AutoSizeAxes { get; set; } = Axes.None;
+
+    /// <summary>
+    /// The duration (in milliseconds) over which the container animates toward a new auto-size target.
+    /// When 0 (the default), the container snaps to its computed size instantly.
+    /// Only meaningful when <see cref="AutoSizeAxes"/> is not <see cref="Axes.None"/>.
+    /// </summary>
+    public double AutoSizeDuration { get; set; }
+
+    /// <summary>
+    /// The easing function used when animating toward a new auto-size target.
+    /// Only meaningful when <see cref="AutoSizeDuration"/> is greater than 0.
+    /// </summary>
+    public Easing AutoSizeEasing { get; set; } = Easing.None;
+
+    /// <summary>
+    /// The in-flight auto-size animation, if any. Re-targeted (rather than recreated) when the
+    /// computed auto-size changes mid-animation so children changing rapidly produce a smooth glide.
+    /// </summary>
+    private AutoSizeTransform? autoSizeTransform;
+
+    /// <summary>
+    /// The auto-size target the in-flight <see cref="autoSizeTransform"/> is currently heading toward.
+    /// Used to avoid re-targeting the animation when the computed size has not actually changed.
+    /// </summary>
+    private Vector2 autoSizeTarget;
+
+    /// <summary>
+    /// Assigns the container's size directly, bypassing the auto-size animation path.
+    /// Invoked by <see cref="AutoSizeTransform"/> as the animation progresses.
+    /// </summary>
+    internal void ApplyAutoSize(Vector2 newSize)
+    {
+        if (Size != newSize)
+            Size = newSize;
+    }
 
     public IReadOnlyList<Drawable> Children
     {
@@ -503,11 +539,42 @@ public partial class Container : Drawable
         if ((AutoSizeAxes & Axes.Y) != 0)
             currentSize.Y = maxBound.Y;
 
-        // Only assign if changed to prevent constant invalidation.
-        // The Size setter raises the own-geometry invalidation (cascading to children)
-        // and notifies an interested parent, so no explicit invalidation is needed here.
-        if (Size != currentSize)
-            Size = currentSize;
+        if (AutoSizeDuration <= 0)
+        {
+            if (autoSizeTransform != null)
+            {
+                RemoveTransform(autoSizeTransform);
+                autoSizeTransform = null;
+            }
+
+            if (Size != currentSize)
+                Size = currentSize;
+
+            return;
+        }
+
+        if (autoSizeTransform == null || autoSizeTarget != currentSize)
+        {
+            if (autoSizeTransform == null && Size == currentSize)
+                return;
+
+            if (autoSizeTransform != null)
+                RemoveTransform(autoSizeTransform);
+
+            autoSizeTarget = currentSize;
+            double startTime = Clock.CurrentTime;
+
+            autoSizeTransform = new AutoSizeTransform
+            {
+                StartValue = Size,
+                EndValue = currentSize,
+                Easing = AutoSizeEasing,
+                StartTime = startTime,
+                EndTime = startTime + AutoSizeDuration
+            };
+
+            AddTransform(autoSizeTransform);
+        }
     }
 
     protected override DrawNode CreateDrawNode() => new ContainerDrawNode();

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -148,10 +148,10 @@ public partial class Container : Drawable
         set
         {
             Clear();
-            foreach (var child in value)
-            {
-                Add(child);
-            }
+
+            int count = value.Count;
+            for (int i = 0; i < count; i++)
+                Add(value[i]);
         }
     }
 
@@ -301,7 +301,8 @@ public partial class Container : Drawable
 
         // Share our clock by reference (unless the child has an explicitly-assigned clock).
         // This must happen before Load() so anything scheduled during load uses the right timeline.
-        drawable.InheritClock(Clock);
+        if (IsLoaded)
+            drawable.InheritClock(Clock);
 
         // The (possibly re-added, previously clean) drawable needs a full geometry pass
         // relative to its new parent; its own Update cascades this through its subtree.
@@ -676,6 +677,7 @@ public partial class Container : Drawable
         base.Load();
         foreach (var child in children)
         {
+            child.InheritClock(Clock);
             child.Load();
         }
     }

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -169,6 +169,62 @@ public partial class Container : Drawable
         }
     }
 
+    private Vector2 relativeChildSize = Vector2.One;
+
+    /// <summary>
+    /// The size of the relative position/size coordinate space of children of this <see cref="Container"/>.
+    /// Children positioned at this size will appear as if they were positioned at <see cref="Drawable.Position"/> = <see cref="Vector2.One"/> in this <see cref="Container"/>.
+    /// </summary>
+    public Vector2 RelativeChildSize
+    {
+        get => relativeChildSize;
+        set
+        {
+            if (relativeChildSize == value) return;
+
+            if (value.X == 0 || value.Y == 0)
+                throw new ArgumentException($"{nameof(RelativeChildSize)} must be non-zero on both axes.", nameof(value));
+
+            relativeChildSize = value;
+
+            // The relative coordinate space changed, so every child's resolved geometry is stale.
+            Invalidate(InvalidationFlags.DrawInfo);
+        }
+    }
+
+    private Vector2 relativeChildOffset = Vector2.Zero;
+
+    /// <summary>
+    /// The offset of the relative position/size coordinate space of children of this <see cref="Container"/>.
+    /// Children positioned at this offset will appear as if they were positioned at <see cref="Drawable.Position"/> = <see cref="Vector2.Zero"/> in this <see cref="Container"/>.
+    /// </summary>
+    public Vector2 RelativeChildOffset
+    {
+        get => relativeChildOffset;
+        set
+        {
+            if (relativeChildOffset == value) return;
+
+            relativeChildOffset = value;
+
+            // The relative coordinate space changed, so every child's resolved geometry is stale.
+            Invalidate(InvalidationFlags.DrawInfo);
+        }
+    }
+
+    /// <summary>
+    /// Conversion multiplier that maps a child's relative coordinate (0..1 across <see cref="RelativeChildSize"/>)
+    /// into the container's pixel content space. Equal to <see cref="ChildSize"/> divided by <see cref="RelativeChildSize"/>.
+    /// </summary>
+    internal Vector2 RelativeToAbsoluteFactor
+    {
+        get
+        {
+            var childSize = ChildSize;
+            return new Vector2(childSize.X / relativeChildSize.X, childSize.Y / relativeChildSize.Y);
+        }
+    }
+
     public Container()
     {
         Texture = null;

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -514,6 +514,9 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
             Vector2 parentChildSize = Parent.ChildSize;
             Vector2 parentDrawSize = Parent.DrawSize;
 
+            Vector2 relativeToAbsolute = Parent.RelativeToAbsoluteFactor;
+            Vector2 relativeChildOffset = Parent.RelativeChildOffset;
+
             // prevent division by zero for drawables with no area.
             if (parentChildSize.X == 0)
                 parentChildSize.X = 1;
@@ -524,19 +527,24 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
             if (parentDrawSize.Y == 0)
                 parentDrawSize.Y = 1;
 
-            // Calculate scale relative to parent
+            if (relativeToAbsolute.X == 0)
+                relativeToAbsolute.X = 1;
+            if (relativeToAbsolute.Y == 0)
+                relativeToAbsolute.Y = 1;
+
             finalDrawSize = Size;
             if ((RelativeSizeAxes & Axes.X) != 0)
-                finalDrawSize.X = Math.Max(0, parentChildSize.X * Size.X - Margin.Total.X);
+                finalDrawSize.X = Math.Max(0, relativeToAbsolute.X * Size.X - Margin.Total.X);
             if ((RelativeSizeAxes & Axes.Y) != 0)
-                finalDrawSize.Y = Math.Max(0, parentChildSize.Y * Size.Y - Margin.Total.Y);
+                finalDrawSize.Y = Math.Max(0, relativeToAbsolute.Y * Size.Y - Margin.Total.Y);
 
-            // Calculate position relative to parent
+            // Calculate position relative to parent. The offset shifts the relative-space origin,
+            // so a child at Position == RelativeChildOffset resolves to pixel (0,0).
             Vector2 pixelPosition = Position;
             if ((RelativePositionAxes & Axes.X) != 0)
-                pixelPosition.X *= parentChildSize.X;
+                pixelPosition.X = (pixelPosition.X - relativeChildOffset.X) * relativeToAbsolute.X;
             if ((RelativePositionAxes & Axes.Y) != 0)
-                pixelPosition.Y *= parentChildSize.Y;
+                pixelPosition.Y = (pixelPosition.Y - relativeChildOffset.Y) * relativeToAbsolute.Y;
 
             Vector2 anchorOffset = GetAnchorOriginVector(Anchor);
             pixelPosition.X += anchorOffset.X * parentChildSize.X;

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -1152,6 +1152,14 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
     }
 
     /// <summary>
+    /// Removes a specific transform from this drawable, if present.
+    /// </summary>
+    internal void RemoveTransform(Transform transform)
+    {
+        transforms?.Remove(transform);
+    }
+
+    /// <summary>
     /// Number of transforms currently registered on this drawable.
     /// Used by <see cref="TransformSequence{T}"/> to detect newly added transforms.
     /// </summary>

--- a/Sakura.Framework/Graphics/Transforms/Transform.cs
+++ b/Sakura.Framework/Graphics/Transforms/Transform.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Sakura.Framework.Extensions.ColorExtensions;
+using Sakura.Framework.Extensions.DrawableExtensions;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Maths;

--- a/Sakura.Framework/Graphics/Transforms/Transform.cs
+++ b/Sakura.Framework/Graphics/Transforms/Transform.cs
@@ -243,6 +243,26 @@ public class SpinTransform : Transform
 }
 
 /// <summary>
+/// Animates a <see cref="Container"/>'s size toward an auto-size target computed from its children.
+/// Unlike <see cref="ResizeTransform"/>, the target can be re-pointed mid-flight (when children
+/// change) without restarting the animation from a hard snap — the start value is re-captured from
+/// the container's current size and the remaining duration is replayed toward the new target.
+/// </summary>
+public class AutoSizeTransform : Transform
+{
+    public Vector2 StartValue;
+    public Vector2 EndValue;
+
+    public override void Apply(Drawable drawable, double time)
+    {
+        if (drawable is not Container container)
+            return;
+
+        container.ApplyAutoSize(Vector2.Lerp(StartValue, EndValue, (float)GetEasedProgress(time)));
+    }
+}
+
+/// <summary>
 /// A zero-duration transform that fires completion/abort callbacks on behalf of a <see cref="TransformSequence{T}"/>.
 /// </summary>
 public class CallbackTransform<T> : Transform where T : Drawable

--- a/Sakura.Framework/Input/InputManager.cs
+++ b/Sakura.Framework/Input/InputManager.cs
@@ -151,26 +151,21 @@ public class InputManager : IFocusManager
     #region Non-positional dispatch
 
     /// <summary>
-    /// Dispatches a non-positional event down the current <see cref="NonPositionalInputQueue"/>
-    /// (front-to-back), invoking <paramref name="invoke"/> on each entry until one returns
-    /// <c>true</c>. Records the consuming entry in <see cref="LastNonPositionalHandler"/>.
+    /// Whether <paramref name="drawable"/> should be skipped during non-positional dispatch: not
+    /// loaded, or the queue root itself (the dispatcher, whose <c>OnX</c> *is* this dispatch entry
+    /// point — invoking it again would recurse infinitely).
     /// </summary>
-    /// <param name="invoke">Invokes the appropriate <c>OnX</c> handler on a queue entry.</param>
-    /// <returns><c>true</c> if a queue entry handled the event.</returns>
-    private bool dispatchNonPositional(System.Func<Drawable, bool> invoke)
+    private bool skipNonPositional(Drawable drawable) => !drawable.IsLoaded || ReferenceEquals(drawable, lastQueueRoot);
+
+    public bool DispatchKeyDown(KeyEvent e)
     {
-        // Snapshot count up front; handlers may mutate the tree, and entries are skipped if they
-        // were removed/unloaded mid-dispatch.
         for (int i = 0; i < nonPositionalQueue.Count; i++)
         {
             var drawable = nonPositionalQueue[i];
-
-            // The queue root is the dispatcher (App / ManualInputManager): its OnX *is* this dispatch
-            // entry point, so invoking it again would re-enter and recurse infinitely. Skip it.
-            if (!drawable.IsLoaded || ReferenceEquals(drawable, lastQueueRoot))
+            if (skipNonPositional(drawable))
                 continue;
 
-            if (invoke(drawable))
+            if (drawable.OnKeyDown(e))
             {
                 LastNonPositionalHandler = drawable;
                 return true;
@@ -181,19 +176,119 @@ public class InputManager : IFocusManager
         return false;
     }
 
-    public bool DispatchKeyDown(KeyEvent e) => dispatchNonPositional(d => d.OnKeyDown(e));
+    public bool DispatchKeyUp(KeyEvent e)
+    {
+        for (int i = 0; i < nonPositionalQueue.Count; i++)
+        {
+            var drawable = nonPositionalQueue[i];
+            if (skipNonPositional(drawable))
+                continue;
 
-    public bool DispatchKeyUp(KeyEvent e) => dispatchNonPositional(d => d.OnKeyUp(e));
+            if (drawable.OnKeyUp(e))
+            {
+                LastNonPositionalHandler = drawable;
+                return true;
+            }
+        }
 
-    public bool DispatchTextInput(TextInputEvent e) => dispatchNonPositional(d => d.OnTextInput(e));
+        LastNonPositionalHandler = null;
+        return false;
+    }
 
-    public bool DispatchTextEditing(TextEditingEvent e) => dispatchNonPositional(d => d.OnTextEditing(e));
+    public bool DispatchTextInput(TextInputEvent e)
+    {
+        for (int i = 0; i < nonPositionalQueue.Count; i++)
+        {
+            var drawable = nonPositionalQueue[i];
+            if (skipNonPositional(drawable))
+                continue;
 
-    public bool DispatchGamepadButtonDown(GamepadButtonEvent e) => dispatchNonPositional(d => d.OnGamepadButtonDown(e));
+            if (drawable.OnTextInput(e))
+            {
+                LastNonPositionalHandler = drawable;
+                return true;
+            }
+        }
 
-    public bool DispatchGamepadButtonUp(GamepadButtonEvent e) => dispatchNonPositional(d => d.OnGamepadButtonUp(e));
+        LastNonPositionalHandler = null;
+        return false;
+    }
 
-    public bool DispatchGamepadAxisMotion(GamepadAxisEvent e) => dispatchNonPositional(d => d.OnGamepadAxisMotion(e));
+    public bool DispatchTextEditing(TextEditingEvent e)
+    {
+        for (int i = 0; i < nonPositionalQueue.Count; i++)
+        {
+            var drawable = nonPositionalQueue[i];
+            if (skipNonPositional(drawable))
+                continue;
+
+            if (drawable.OnTextEditing(e))
+            {
+                LastNonPositionalHandler = drawable;
+                return true;
+            }
+        }
+
+        LastNonPositionalHandler = null;
+        return false;
+    }
+
+    public bool DispatchGamepadButtonDown(GamepadButtonEvent e)
+    {
+        for (int i = 0; i < nonPositionalQueue.Count; i++)
+        {
+            var drawable = nonPositionalQueue[i];
+            if (skipNonPositional(drawable))
+                continue;
+
+            if (drawable.OnGamepadButtonDown(e))
+            {
+                LastNonPositionalHandler = drawable;
+                return true;
+            }
+        }
+
+        LastNonPositionalHandler = null;
+        return false;
+    }
+
+    public bool DispatchGamepadButtonUp(GamepadButtonEvent e)
+    {
+        for (int i = 0; i < nonPositionalQueue.Count; i++)
+        {
+            var drawable = nonPositionalQueue[i];
+            if (skipNonPositional(drawable))
+                continue;
+
+            if (drawable.OnGamepadButtonUp(e))
+            {
+                LastNonPositionalHandler = drawable;
+                return true;
+            }
+        }
+
+        LastNonPositionalHandler = null;
+        return false;
+    }
+
+    public bool DispatchGamepadAxisMotion(GamepadAxisEvent e)
+    {
+        for (int i = 0; i < nonPositionalQueue.Count; i++)
+        {
+            var drawable = nonPositionalQueue[i];
+            if (skipNonPositional(drawable))
+                continue;
+
+            if (drawable.OnGamepadAxisMotion(e))
+            {
+                LastNonPositionalHandler = drawable;
+                return true;
+            }
+        }
+
+        LastNonPositionalHandler = null;
+        return false;
+    }
 
     /// <summary>
     /// Delivers a gamepad connected event to every entry in the non-positional queue (broadcast; no
@@ -245,6 +340,8 @@ public class InputManager : IFocusManager
     private readonly List<Drawable> hoveredDrawables = new List<Drawable>();
 
     private readonly HashSet<Drawable> hoverBlockers = new HashSet<Drawable>();
+
+    private readonly HashSet<Drawable> newlyHoveredScratch = new HashSet<Drawable>();
 
     public IReadOnlyList<Drawable> HoveredDrawables => hoveredDrawables;
 
@@ -378,7 +475,8 @@ public class InputManager : IFocusManager
         // returning true from OnHover (e.g. a visible OverlayContainer). Everything in front of and
         // including the blocker is hovered; everything behind it is treated as not hovered. This
         // mirrors the recursive path, where a child returning true from OnMouseMove broke the loop.
-        var newlyHovered = new HashSet<Drawable>();
+        var newlyHovered = newlyHoveredScratch;
+        newlyHovered.Clear();
         bool blocked = false;
 
         for (int i = 0; i < positionalQueue.Count && !blocked; i++)


### PR DESCRIPTION
Add a new API in container
- Auto size transform
- Relative child size

With just rewrite an input benchmark since we just refactor to use `InputManager` so there are performance inprovement there too.