### PR TITLE
Fix ESC keybind not work in lower container level

### DIFF
--- a/Sakura.Framework/Graphics/Performance/AudioMixerVisualiser.cs
+++ b/Sakura.Framework/Graphics/Performance/AudioMixerVisualiser.cs
@@ -13,6 +13,7 @@ using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Text;
 using Sakura.Framework.Graphics.Transforms;
+using Sakura.Framework.Input;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
@@ -163,6 +164,16 @@ public partial class AudioMixerVisualiser : FocusedOverlayContainer, IRemoveFrom
 
         currentTimeText.Text = $"{DateTime.Now:dd MMMM yyyy HH:mm:ss tt}";
         runningTimeText.Text = $"Has been running for {TimeSpan.FromSeconds(host.UpdateClock.CurrentTime / 1000):hh\\:mm\\:ss}";
+    }
+
+    public override bool OnKeyDown(KeyEvent e)
+    {
+        if (State == Visibility.Visible && e.Key == Key.Escape)
+        {
+            Hide();
+            return true;
+        }
+        return base.OnKeyDown(e);
     }
 
     protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);

--- a/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
+++ b/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
@@ -411,10 +411,19 @@ public partial class DrawVisualiser : FocusedOverlayContainer, IRemoveFromDrawVi
 
     public override bool OnKeyDown(KeyEvent e)
     {
-        if (isInspecting && e.Key == Key.Escape)
+        if (e.Key == Key.Escape)
         {
-            ToggleInspectMode();
-            return true;
+            if (isInspecting)
+            {
+                ToggleInspectMode();
+                return true;
+            }
+
+            if (State == Visibility.Visible)
+            {
+                Hide();
+                return true;
+            }
         }
 
         return base.OnKeyDown(e);

--- a/Sakura.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
@@ -228,7 +228,7 @@ public partial class GlobalStatisticsDisplay : FocusedOverlayContainer, IRemoveF
 
     public override bool OnKeyDown(KeyEvent e)
     {
-        if (e.Key == Key.Escape)
+        if (State == Visibility.Visible && e.Key == Key.Escape)
         {
             Hide();
             return true;

--- a/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
@@ -370,7 +370,7 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
 
     public override bool OnKeyDown(KeyEvent e)
     {
-        if (e.Key == Key.Escape)
+        if (State == Visibility.Visible && e.Key == Key.Escape)
         {
             Hide();
             return true;


### PR DESCRIPTION
TL;DR `FocusedOverlayContainer` debug overlay eat the keybind😡😡😡😡😡