### PR TITLE
Add spring and CSS cubic bezier transform support for transformation

### DIFF
--- a/Sakura.Framework.Tests/Graphics/EasingFunctionTest.cs
+++ b/Sakura.Framework.Tests/Graphics/EasingFunctionTest.cs
@@ -1,0 +1,107 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Transforms;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+[TestFixture]
+public class EasingFunctionTest
+{
+    private const double tolerance = 1e-6;
+
+    [Test]
+    public void TestDefaultIsLinear()
+    {
+        EasingFunction easing = default;
+        Assert.That(easing.Apply(0), Is.EqualTo(0).Within(tolerance));
+        Assert.That(easing.Apply(0.5), Is.EqualTo(0.5).Within(tolerance));
+        Assert.That(easing.Apply(1), Is.EqualTo(1).Within(tolerance));
+    }
+
+    [Test]
+    public void TestImplicitConversionFromEasing()
+    {
+        EasingFunction easing = Easing.OutQuad;
+        // OutQuad: t * (2 - t)
+        Assert.That(easing.Apply(0.5), Is.EqualTo(0.75).Within(tolerance));
+        Assert.That(easing.Apply(0), Is.EqualTo(0).Within(tolerance));
+        Assert.That(easing.Apply(1), Is.EqualTo(1).Within(tolerance));
+    }
+
+    [Test]
+    public void TestCubicBezierEndpoints()
+    {
+        var easing = EasingFunction.CubicBezier(0.42, 0, 0.58, 1);
+        Assert.That(easing.Apply(0), Is.EqualTo(0).Within(tolerance));
+        Assert.That(easing.Apply(1), Is.EqualTo(1).Within(tolerance));
+    }
+
+    [Test]
+    public void TestCubicBezierLinearWhenControlPointsOnDiagonal()
+    {
+        // Control points on the y=x diagonal reproduce the linear curve.
+        var easing = EasingFunction.CubicBezier(0.25, 0.25, 0.75, 0.75);
+
+        for (double t = 0; t <= 1.0; t += 0.1)
+            Assert.That(easing.Apply(t), Is.EqualTo(t).Within(1e-4), $"at t={t}");
+    }
+
+    [Test]
+    public void TestCubicBezierIsMonotonicForStandardEase()
+    {
+        var easing = EasingFunction.CubicBezier(0.25, 0.1, 0.25, 1.0); // CSS "ease"
+        double previous = double.NegativeInfinity;
+
+        for (double t = 0; t <= 1.0; t += 0.05)
+        {
+            double value = easing.Apply(t);
+            Assert.That(value, Is.GreaterThanOrEqualTo(previous - 1e-9), $"non-monotonic at t={t}");
+            previous = value;
+        }
+    }
+
+    [Test]
+    public void TestSpringEndpointsPinned()
+    {
+        var easing = EasingFunction.Spring();
+        Assert.That(easing.Apply(0), Is.EqualTo(0).Within(tolerance));
+        Assert.That(easing.Apply(1), Is.EqualTo(1).Within(tolerance));
+    }
+
+    [Test]
+    public void TestSpringUnderdampedOvershoots()
+    {
+        var easing = EasingFunction.Spring(dampingRatio: 0.3, frequency: 1.5);
+        bool overshot = false;
+
+        for (double t = 0; t < 1.0; t += 0.01)
+        {
+            if (easing.Apply(t) > 1.0 + 1e-3)
+            {
+                overshot = true;
+                break;
+            }
+        }
+
+        Assert.That(overshot, Is.True, "under-damped spring should overshoot its target");
+    }
+
+    [Test]
+    public void TestSpringCriticallyDampedDoesNotOvershoot()
+    {
+        var easing = EasingFunction.Spring(dampingRatio: 1.0, frequency: 1.5);
+
+        for (double t = 0; t <= 1.0; t += 0.01)
+            Assert.That(easing.Apply(t), Is.LessThanOrEqualTo(1.0 + 1e-6), $"overshoot at t={t}");
+    }
+
+    [Test]
+    public void TestSpringSettlesNearTargetBeforeEnd()
+    {
+        var easing = EasingFunction.Spring(dampingRatio: 0.5, frequency: 1.5);
+        // With this decay the value should be within a couple percent of the target well before the end.
+        Assert.That(easing.Apply(0.95), Is.EqualTo(1.0).Within(0.05));
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestTransforms.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestTransforms.cs
@@ -265,6 +265,212 @@ public partial class TestTransforms : TestScene
         });
     }
 
+    [Test]
+    public void TestCubicBezierMove()
+    {
+        // CSS "ease-in-out" curve.
+        AddStep("Move with cubic-bezier(0.42,0,0.58,1)", () =>
+            subject.MoveTo(new Vector2(180, 0), 700, EasingFunction.CubicBezier(0.42, 0, 0.58, 1)));
+        AddWaitStep("Wait", 700);
+        AddStep("Move back with cubic-bezier ease-in-out", () =>
+            subject.MoveTo(Vector2.Zero, 700, EasingFunction.CubicBezier(0.42, 0, 0.58, 1)));
+        AddWaitStep("Wait", 700);
+        AddAssert("Back at centre", () => Precision.AlmostEquals(subject.Position, Vector2.Zero));
+    }
+
+    [Test]
+    public void TestSpringScale()
+    {
+        AddStep("Scale to 2x with spring", () =>
+            subject.ScaleTo(2f, 800, EasingFunction.Spring()));
+        AddWaitStep("Wait", 800);
+        AddAssert("Rests exactly at 2x", () => Precision.AlmostEquals(subject.Scale, new Vector2(2f)));
+        AddStep("Scale back to 1x with bouncy spring", () =>
+            subject.ScaleTo(1f, 800, EasingFunction.Spring(dampingRatio: 0.35, frequency: 2.5)));
+        AddWaitStep("Wait", 800);
+        AddAssert("Rests exactly at 1x", () => Precision.AlmostEquals(subject.Scale, Vector2.One));
+    }
+
+    [Test]
+    public void TestSpringMoveSequence()
+    {
+        AddStep("Sequence: spring right → spring back", () =>
+            subject.TransformSequence()
+                   .MoveTo(new Vector2(200, 0), 700, EasingFunction.Spring(0.4, 2f))
+                   .Then()
+                   .MoveTo(Vector2.Zero, 700, EasingFunction.Spring(0.4, 2f)));
+        AddWaitStep("Watch sequence", 1600);
+        AddAssert("Back at centre", () => Precision.AlmostEquals(subject.Position, Vector2.Zero));
+    }
+
+    [Test]
+    public void TestEasingComparisonCubicVsSpring()
+    {
+        Box boxA = null!, boxB = null!;
+
+        AddStep("Setup two boxes (CubicBezier vs Spring)", () =>
+        {
+            Clear();
+            Add(boxA = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(80),
+                Color = Color.CornflowerBlue,
+                Position = new Vector2(-100, 0)
+            });
+            Add(boxB = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(80),
+                Color = Color.LightPink,
+                Position = new Vector2(100, 0)
+            });
+        });
+
+        AddSliderStep("Scale amount", 0.5f, 3f, 1.5f, v =>
+        {
+            boxA?.ClearTransforms();
+            boxB?.ClearTransforms();
+            boxA?.ScaleTo(v, 700, EasingFunction.CubicBezier(0.42, 0, 0.58, 1));
+            boxB?.ScaleTo(v, 700, EasingFunction.Spring());
+        });
+    }
+
+    [Test]
+    public void TestSpringDampingComparison()
+    {
+        // Several boxes stacked vertically, each with a different damping ratio, all launched
+        // together so the effect of damping (bouncy → critical → over-damped) is visible side by side.
+        (double damping, Color colour)[] rows =
+        {
+            (0.2, Color.Tomato),
+            (0.4, Color.Orange),
+            (0.6, Color.MediumSeaGreen),
+            (1.0, Color.CornflowerBlue),
+            (1.6, Color.MediumPurple),
+        };
+
+        var boxes = new Box[rows.Length];
+
+        AddStep("Setup boxes (damping 0.2 → 1.6)", () =>
+        {
+            Clear();
+            for (int i = 0; i < rows.Length; i++)
+            {
+                float y = (i - (rows.Length - 1) / 2f) * 70f;
+                Add(boxes[i] = new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(50),
+                    Color = rows[i].colour,
+                    Position = new Vector2(-220, y)
+                });
+            }
+        });
+
+        AddStep("Spring all to the right", () =>
+        {
+            for (int i = 0; i < rows.Length; i++)
+                boxes[i].MoveToX(220, 900, EasingFunction.Spring(dampingRatio: rows[i].damping, frequency: 2f));
+        });
+        AddWaitStep("Watch settle", 1000);
+        AddAssert("All rested at target X", () =>
+        {
+            for (int i = 0; i < boxes.Length; i++)
+                if (!Precision.AlmostEquals(boxes[i].Position.X, 220f))
+                    return false;
+            return true;
+        });
+
+        AddStep("Spring all back", () =>
+        {
+            for (int i = 0; i < rows.Length; i++)
+                boxes[i].MoveToX(-220, 900, EasingFunction.Spring(dampingRatio: rows[i].damping, frequency: 2f));
+        });
+        AddWaitStep("Watch settle", 1000);
+    }
+
+    [Test]
+    public void TestSpringInteractive()
+    {
+        double damping = SpringEasing.DEFAULT_DAMPING_RATIO;
+        double frequency = SpringEasing.DEFAULT_FREQUENCY;
+        bool toRight = true;
+
+        AddStep("Reset subject to left", () => subject.MoveToX(-200));
+
+        AddSliderStep("Damping ratio", 0.1f, 2f, (float)SpringEasing.DEFAULT_DAMPING_RATIO, v => damping = v);
+        AddSliderStep("Frequency", 0.5f, 5f, (float)SpringEasing.DEFAULT_FREQUENCY, v => frequency = v);
+
+        AddStep("Spring to other side", () =>
+        {
+            float targetX = toRight ? 200 : -200;
+            toRight = !toRight;
+            subject.MoveToX(targetX, 900, EasingFunction.Spring(damping, frequency));
+        });
+    }
+
+    [Test]
+    public void TestCubicBezierPresets()
+    {
+        // Compares common CSS cubic-bezier presets driven off the same trigger.
+        Box ease = null!, easeIn = null!, easeOut = null!, easeInOut = null!;
+
+        AddStep("Setup preset boxes", () =>
+        {
+            Clear();
+            Add(ease = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(45),
+                Color = Color.CornflowerBlue,
+                Position = new Vector2(-220, -90)
+            });
+            Add(easeIn = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(45),
+                Color = Color.MediumSeaGreen,
+                Position = new Vector2(-220, -30)
+            });
+            Add(easeOut = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(45),
+                Color = Color.Orange,
+                Position = new Vector2(-220, 30)
+            });
+            Add(easeInOut = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(45),
+                Color = Color.MediumPurple,
+                Position = new Vector2(-220, 90)
+            });
+        });
+
+        AddStep("Run all presets", () =>
+        {
+            ease.MoveToX(220, 900, EasingFunction.CubicBezier(0.25, 0.1, 0.25, 1.0));   // ease
+            easeIn.MoveToX(220, 900, EasingFunction.CubicBezier(0.42, 0, 1, 1));         // ease-in
+            easeOut.MoveToX(220, 900, EasingFunction.CubicBezier(0, 0, 0.58, 1));        // ease-out
+            easeInOut.MoveToX(220, 900, EasingFunction.CubicBezier(0.42, 0, 0.58, 1));   // ease-in-out
+        });
+        AddWaitStep("Watch", 1000);
+        AddAssert("All reached target", () =>
+            Precision.AlmostEquals(ease.Position.X, 220f)
+            && Precision.AlmostEquals(easeIn.Position.X, 220f)
+            && Precision.AlmostEquals(easeOut.Position.X, 220f)
+            && Precision.AlmostEquals(easeInOut.Position.X, 220f));
+    }
+
     [TearDown]
     public void TearDown()
     {

--- a/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
+++ b/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
@@ -36,7 +36,7 @@ public static class TransformExtensions
     /// <summary>
     /// Moves the drawable to a specific position over a duration.
     /// </summary>
-    public static Drawable MoveTo(this Drawable drawable, Vector2 newPosition, double duration = 0, Easing easing = Easing.None)
+    public static Drawable MoveTo(this Drawable drawable, Vector2 newPosition, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new MoveTransform
         {
@@ -50,7 +50,7 @@ public static class TransformExtensions
     /// <summary>
     /// Moves the drawable to a specific X position over a duration.
     /// </summary>
-    public static Drawable MoveToX(this Drawable drawable, float newX, double duration = 0, Easing easing = Easing.None)
+    public static Drawable MoveToX(this Drawable drawable, float newX, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new MoveTransform
         {
@@ -64,7 +64,7 @@ public static class TransformExtensions
     /// <summary>
     /// Moves the drawable to a specific Y position over a duration.
     /// </summary>
-    public static Drawable MoveToY(this Drawable drawable, float newY, double duration = 0, Easing easing = Easing.None)
+    public static Drawable MoveToY(this Drawable drawable, float newY, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new MoveTransform
         {
@@ -78,13 +78,13 @@ public static class TransformExtensions
     /// <summary>
     /// Moves the drawable by an offset relative to its current position over a duration.
     /// </summary>
-    public static Drawable MoveToOffset(this Drawable drawable, Vector2 offset, double duration = 0, Easing easing = Easing.None)
+    public static Drawable MoveToOffset(this Drawable drawable, Vector2 offset, double duration = 0, EasingFunction easing = default)
         => drawable.MoveTo(drawable.Position + offset, duration, easing);
 
     /// <summary>
     /// Resizes the drawable to a specific size over a duration.
     /// </summary>
-    public static Drawable ResizeTo(this Drawable drawable, Vector2 newSize, double duration = 0, Easing easing = Easing.None)
+    public static Drawable ResizeTo(this Drawable drawable, Vector2 newSize, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new ResizeTransform
         {
@@ -98,13 +98,13 @@ public static class TransformExtensions
     /// <summary>
     /// Resizes the drawable to a uniform size over a duration.
     /// </summary>
-    public static Drawable ResizeTo(this Drawable drawable, float newSize, double duration = 0, Easing easing = Easing.None)
+    public static Drawable ResizeTo(this Drawable drawable, float newSize, double duration = 0, EasingFunction easing = default)
         => drawable.ResizeTo(new Vector2(newSize), duration, easing);
 
     /// <summary>
     /// Adjusts the drawable's scale to a specific value over a duration.
     /// </summary>
-    public static Drawable ScaleTo(this Drawable drawable, Vector2 newScale, double duration = 0, Easing easing = Easing.None)
+    public static Drawable ScaleTo(this Drawable drawable, Vector2 newScale, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new ScaleTransform
         {
@@ -118,13 +118,13 @@ public static class TransformExtensions
     /// <summary>
     /// Adjusts the drawable's scale uniformly to a specific value over a duration.
     /// </summary>
-    public static Drawable ScaleTo(this Drawable drawable, float newScale, double duration = 0, Easing easing = Easing.None)
+    public static Drawable ScaleTo(this Drawable drawable, float newScale, double duration = 0, EasingFunction easing = default)
         => drawable.ScaleTo(new Vector2(newScale), duration, easing);
 
     /// <summary>
     /// Rotates the drawable to a specific angle over a duration.
     /// </summary>
-    public static Drawable RotateTo(this Drawable drawable, float newRotation, double duration = 0, Easing easing = Easing.None)
+    public static Drawable RotateTo(this Drawable drawable, float newRotation, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new RotateTransform
         {
@@ -157,7 +157,7 @@ public static class TransformExtensions
     /// <summary>
     /// Fades the drawable to a specific alpha over a duration.
     /// </summary>
-    public static Drawable FadeTo(this Drawable drawable, float newAlpha, double duration = 0, Easing easing = Easing.None)
+    public static Drawable FadeTo(this Drawable drawable, float newAlpha, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new AlphaTransform
         {
@@ -171,17 +171,17 @@ public static class TransformExtensions
     /// <summary>
     /// Fades the drawable to full alpha over a duration.
     /// </summary>
-    public static Drawable FadeIn(this Drawable drawable, double duration = 0, Easing easing = Easing.None) => drawable.FadeTo(1, duration, easing);
+    public static Drawable FadeIn(this Drawable drawable, double duration = 0, EasingFunction easing = default) => drawable.FadeTo(1, duration, easing);
 
     /// <summary>
     /// Fades the drawable to zero alpha over a duration.
     /// </summary>
-    public static Drawable FadeOut(this Drawable drawable, double duration = 0, Easing easing = Easing.None) => drawable.FadeTo(0, duration, easing);
+    public static Drawable FadeOut(this Drawable drawable, double duration = 0, EasingFunction easing = default) => drawable.FadeTo(0, duration, easing);
 
     /// <summary>
     /// Sets alpha to 0 then fades to full alpha over a duration.
     /// </summary>
-    public static Drawable FadeInFromZero(this Drawable drawable, double duration = 0, Easing easing = Easing.None)
+    public static Drawable FadeInFromZero(this Drawable drawable, double duration = 0, EasingFunction easing = default)
     {
         drawable.Alpha = 0;
         return drawable.FadeTo(1, duration, easing);
@@ -190,19 +190,19 @@ public static class TransformExtensions
     /// <summary>
     /// Sets alpha to 0 then fades to full alpha over a duration. Alias for <see cref="FadeInFromZero"/>.
     /// </summary>
-    public static Drawable FadeFromZero(this Drawable drawable, double duration = 0, Easing easing = Easing.None)
+    public static Drawable FadeFromZero(this Drawable drawable, double duration = 0, EasingFunction easing = default)
         => drawable.FadeInFromZero(duration, easing);
 
     /// <summary>
     /// Fades the drawable to zero alpha over a duration.
     /// </summary>
-    public static Drawable FadeToZero(this Drawable drawable, double duration = 0, Easing easing = Easing.None)
+    public static Drawable FadeToZero(this Drawable drawable, double duration = 0, EasingFunction easing = default)
         => drawable.FadeTo(0, duration, easing);
 
     /// <summary>
     /// Instantly flashes the drawable to a specific colour, then fades back to its original colour over a duration.
     /// </summary>
-    public static Drawable FlashColour(this Drawable drawable, Color flashColour, double duration, Easing easing = Easing.None)
+    public static Drawable FlashColour(this Drawable drawable, Color flashColour, double duration, EasingFunction easing = default)
     {
         drawable.addTransform(new FlashColorTransform
         {
@@ -215,7 +215,7 @@ public static class TransformExtensions
     /// <summary>
     /// Fades the drawable's colour to a specific colour over a duration.
     /// </summary>
-    public static Drawable FadeToColour(this Drawable drawable, Color newColour, double duration = 0, Easing easing = Easing.None)
+    public static Drawable FadeToColour(this Drawable drawable, Color newColour, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new ColorTransform
         {
@@ -228,7 +228,7 @@ public static class TransformExtensions
     /// <summary>
     /// Animates the container's edge-effect color to a specific color over a duration.
     /// </summary>
-    public static T FadeEdgeEffectTo<T>(this T container, Color newColour, double duration = 0, Easing easing = Easing.None) where T : Container
+    public static T FadeEdgeEffectTo<T>(this T container, Color newColour, double duration = 0, EasingFunction easing = default) where T : Container
     {
         container.addTransform(new EdgeEffectColourTransform
         {
@@ -242,7 +242,7 @@ public static class TransformExtensions
     /// Animates the alpha of the container's edge-effect color to a specific value over a duration,
     /// keeping the current RGB.
     /// </summary>
-    public static T FadeEdgeEffectTo<T>(this T container, float newAlpha, double duration = 0, Easing easing = Easing.None) where T : Container
+    public static T FadeEdgeEffectTo<T>(this T container, float newAlpha, double duration = 0, EasingFunction easing = default) where T : Container
     {
         var current = container.EdgeEffect.Colour;
         var target = Color.FromArgb((int)Math.Clamp(newAlpha * 255f, 0f, 255f), current);
@@ -252,7 +252,7 @@ public static class TransformExtensions
     /// <summary>
     /// Animates the container's edge-effect blur radius to a specific value over a duration.
     /// </summary>
-    public static T TweenEdgeEffectRadiusTo<T>(this T container, float newRadius, double duration = 0, Easing easing = Easing.None) where T : Container
+    public static T TweenEdgeEffectRadiusTo<T>(this T container, float newRadius, double duration = 0, EasingFunction easing = default) where T : Container
     {
         container.addTransform(new EdgeEffectRadiusTransform
         {

--- a/Sakura.Framework/Extensions/TransformSequenceExtensions/TransformSequenceExtensions.cs
+++ b/Sakura.Framework/Extensions/TransformSequenceExtensions/TransformSequenceExtensions.cs
@@ -31,51 +31,51 @@ namespace Sakura.Framework.Extensions.TransformSequenceExtensions;
 /// </summary>
 public static class TransformSequenceExtensions
 {
-    public static TransformSequence<T> MoveTo<T>(this TransformSequence<T> seq, Vector2 position, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> MoveTo<T>(this TransformSequence<T> seq, Vector2 position, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.MoveTo(position, duration, easing));
 
-    public static TransformSequence<T> MoveToX<T>(this TransformSequence<T> seq, float x, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> MoveToX<T>(this TransformSequence<T> seq, float x, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.MoveToX(x, duration, easing));
 
-    public static TransformSequence<T> MoveToY<T>(this TransformSequence<T> seq, float y, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> MoveToY<T>(this TransformSequence<T> seq, float y, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.MoveToY(y, duration, easing));
 
-    public static TransformSequence<T> MoveToOffset<T>(this TransformSequence<T> seq, Vector2 offset, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> MoveToOffset<T>(this TransformSequence<T> seq, Vector2 offset, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.MoveToOffset(offset, duration, easing));
 
-    public static TransformSequence<T> ResizeTo<T>(this TransformSequence<T> seq, Vector2 size, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> ResizeTo<T>(this TransformSequence<T> seq, Vector2 size, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.ResizeTo(size, duration, easing));
 
-    public static TransformSequence<T> ResizeTo<T>(this TransformSequence<T> seq, float size, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> ResizeTo<T>(this TransformSequence<T> seq, float size, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.ResizeTo(size, duration, easing));
 
-    public static TransformSequence<T> ScaleTo<T>(this TransformSequence<T> seq, Vector2 scale, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> ScaleTo<T>(this TransformSequence<T> seq, Vector2 scale, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.ScaleTo(scale, duration, easing));
 
-    public static TransformSequence<T> ScaleTo<T>(this TransformSequence<T> seq, float scale, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> ScaleTo<T>(this TransformSequence<T> seq, float scale, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.ScaleTo(scale, duration, easing));
 
-    public static TransformSequence<T> RotateTo<T>(this TransformSequence<T> seq, float rotation, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> RotateTo<T>(this TransformSequence<T> seq, float rotation, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.RotateTo(rotation, duration, easing));
 
     public static TransformSequence<T> Spin<T>(this TransformSequence<T> seq, double revolutionDuration, RotationDirection direction = RotationDirection.Clockwise) where T : Drawable
         => seq.Append(d => d.Spin(revolutionDuration, direction));
 
-    public static TransformSequence<T> FadeTo<T>(this TransformSequence<T> seq, float alpha, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> FadeTo<T>(this TransformSequence<T> seq, float alpha, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.FadeTo(alpha, duration, easing));
 
-    public static TransformSequence<T> FadeIn<T>(this TransformSequence<T> seq, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> FadeIn<T>(this TransformSequence<T> seq, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.FadeIn(duration, easing));
 
-    public static TransformSequence<T> FadeOut<T>(this TransformSequence<T> seq, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> FadeOut<T>(this TransformSequence<T> seq, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.FadeOut(duration, easing));
 
-    public static TransformSequence<T> FadeInFromZero<T>(this TransformSequence<T> seq, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> FadeInFromZero<T>(this TransformSequence<T> seq, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.FadeInFromZero(duration, easing));
 
-    public static TransformSequence<T> FadeToColour<T>(this TransformSequence<T> seq, Color colour, double duration = 0, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> FadeToColour<T>(this TransformSequence<T> seq, Color colour, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.FadeToColour(colour, duration, easing));
 
-    public static TransformSequence<T> FlashColour<T>(this TransformSequence<T> seq, Color flashColour, double duration, Easing easing = Easing.None) where T : Drawable
+    public static TransformSequence<T> FlashColour<T>(this TransformSequence<T> seq, Color flashColour, double duration, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.FlashColour(flashColour, duration, easing));
 }

--- a/Sakura.Framework/Graphics/Transforms/CubicBezierEasing.cs
+++ b/Sakura.Framework/Graphics/Transforms/CubicBezierEasing.cs
@@ -1,0 +1,103 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.Graphics.Transforms;
+
+/// <summary>
+/// A cubic bezier easing curve equivalent to CSS's <c>cubic-bezier(x1, y1, x2, y2)</c>.
+/// The curve runs from a fixed start point (0, 0) to a fixed end point (1, 1) via the two
+/// user-supplied control points (<c>x1</c>, <c>y1</c>) and (<c>x2</c>, <c>y2</c>).
+/// </summary>
+/// <remarks>
+/// Given an input <c>x</c> (normalised time), the curve is solved for the parametric value
+/// <c>t</c> such that the bezier's x-component equals <c>x</c>, then the y-component at that
+/// <c>t</c> is returned. This mirrors the well-known WebKit <c>UnitBezier</c> implementation:
+/// a fast Newton-Raphson search that falls back to bisection when convergence is poor.
+/// </remarks>
+public sealed class CubicBezierEasing : IEasingFunction
+{
+    // Polynomial coefficients for the x and y components, expanded from the bezier basis with
+    // P0 = (0,0) and P3 = (1,1). x(t) = ((ax*t + bx)*t + cx)*t (and likewise for y).
+    private readonly double ax, bx, cx;
+    private readonly double ay, by, cy;
+
+    private const int newton_iterations = 8;
+    private const double newton_min_slope = 0.001;
+    private const double subdivision_precision = 0.0000001;
+    private const int subdivision_max_iterations = 12;
+
+    /// <param name="x1">X of the first control point. CSS clamps this to [0, 1]; values outside are allowed but may be non-monotonic.</param>
+    /// <param name="y1">Y of the first control point.</param>
+    /// <param name="x2">X of the second control point.</param>
+    /// <param name="y2">Y of the second control point.</param>
+    public CubicBezierEasing(double x1, double y1, double x2, double y2)
+    {
+        // Control-point X must stay within [0, 1] for the curve to represent a valid time function.
+        x1 = Math.Clamp(x1, 0, 1);
+        x2 = Math.Clamp(x2, 0, 1);
+
+        cx = 3.0 * x1;
+        bx = 3.0 * (x2 - x1) - cx;
+        ax = 1.0 - cx - bx;
+
+        cy = 3.0 * y1;
+        by = 3.0 * (y2 - y1) - cy;
+        ay = 1.0 - cy - by;
+    }
+
+    public double Apply(double progress)
+    {
+        if (progress <= 0) return 0;
+        if (progress >= 1) return 1;
+
+        return sampleCurveY(solveCurveX(progress));
+    }
+
+    private double sampleCurveX(double t) => ((ax * t + bx) * t + cx) * t;
+
+    private double sampleCurveY(double t) => ((ay * t + by) * t + cy) * t;
+
+    private double sampleCurveDerivativeX(double t) => (3.0 * ax * t + 2.0 * bx) * t + cx;
+
+    private double solveCurveX(double x)
+    {
+        double t2 = x;
+
+        // First try Newton-Raphson — it converges very quickly for well-behaved curves.
+        for (int i = 0; i < newton_iterations; i++)
+        {
+            double x2 = sampleCurveX(t2) - x;
+            if (Math.Abs(x2) < subdivision_precision)
+                return t2;
+
+            double d2 = sampleCurveDerivativeX(t2);
+            if (Math.Abs(d2) < newton_min_slope)
+                break;
+
+            t2 -= x2 / d2;
+        }
+
+        // Fall back to bisection to guarantee a result within the valid range.
+        double tLower = 0.0;
+        double tUpper = 1.0;
+        t2 = x;
+
+        for (int i = 0; i < subdivision_max_iterations; i++)
+        {
+            double x2 = sampleCurveX(t2);
+            if (Math.Abs(x2 - x) < subdivision_precision)
+                return t2;
+
+            if (x > x2)
+                tLower = t2;
+            else
+                tUpper = t2;
+
+            t2 = (tUpper + tLower) * 0.5;
+        }
+
+        return t2;
+    }
+}

--- a/Sakura.Framework/Graphics/Transforms/EasingFunction.cs
+++ b/Sakura.Framework/Graphics/Transforms/EasingFunction.cs
@@ -1,0 +1,82 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Graphics.Transforms;
+
+/// <summary>
+/// Describes how a transform interpolates between its start and end values over time.
+/// </summary>
+public readonly struct EasingFunction
+{
+    private readonly Easing standard;
+    private readonly IEasingFunction? custom;
+
+    /// <summary>
+    /// Creates an <see cref="EasingFunction"/> backed by one of the built-in <see cref="Easing"/> curves.
+    /// </summary>
+    public EasingFunction(Easing easing)
+    {
+        standard = easing;
+        custom = null;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="EasingFunction"/> backed by a custom <see cref="IEasingFunction"/>.
+    /// </summary>
+    public EasingFunction(IEasingFunction easingFunction)
+    {
+        standard = Easing.None;
+        custom = easingFunction;
+    }
+
+    /// <summary>
+    /// Evaluates the easing at the given normalised <paramref name="progress"/> in [0, 1].
+    /// </summary>
+    public double Apply(double progress) => custom?.Apply(progress) ?? EasingFunctions.Apply(standard, progress);
+
+    /// <summary>
+    /// Implicitly promotes an <see cref="Easing"/> to an <see cref="EasingFunction"/>, preserving
+    /// backward compatibility with every API that previously took an <see cref="Easing"/>.
+    /// </summary>
+    public static implicit operator EasingFunction(Easing easing) => new EasingFunction(easing);
+
+    /// <summary>
+    /// Implicitly wraps a custom <see cref="IEasingFunction"/> (e.g. <see cref="CubicBezierEasing"/>
+    /// or <see cref="SpringEasing"/>) into an <see cref="EasingFunction"/>.
+    /// </summary>
+    public static implicit operator EasingFunction(CubicBezierEasing bezier) => new EasingFunction(bezier);
+
+    /// <summary>
+    /// Implicitly wraps a <see cref="SpringEasing"/> into an <see cref="EasingFunction"/>.
+    /// </summary>
+    public static implicit operator EasingFunction(SpringEasing spring) => new EasingFunction(spring);
+
+    /// <summary>
+    /// Creates a CSS-style cubic bezier easing through control points (<paramref name="x1"/>, <paramref name="y1"/>)
+    /// and (<paramref name="x2"/>, <paramref name="y2"/>), with fixed endpoints (0, 0) and (1, 1).
+    /// </summary>
+    /// <example><code>
+    /// // The CSS "ease-in-out" curve.
+    /// drawable.MoveTo(target, 400, EasingFunction.CubicBezier(0.42, 0, 0.58, 1));
+    /// </code></example>
+    public static EasingFunction CubicBezier(double x1, double y1, double x2, double y2)
+        => new EasingFunction(new CubicBezierEasing(x1, y1, x2, y2));
+
+    /// <summary>
+    /// Creates a physically-based spring easing that overshoots and settles at its target.
+    /// </summary>
+    /// <param name="dampingRatio">
+    /// How quickly oscillations decay. Less than 1 is under-damped (bouncy overshoot), 1 is critically
+    /// damped (no overshoot, fastest settle), greater than 1 is over-damped (slow, no overshoot).
+    /// </param>
+    /// <param name="frequency">
+    /// The natural frequency of the spring, expressed as the number of oscillations that would occur
+    /// across the transform's duration. Higher values feel stiffer.
+    /// </param>
+    /// <example><code>
+    /// drawable.ScaleTo(1.5f, 600, EasingFunction.Spring());              // pleasant default bounce
+    /// drawable.MoveTo(target, 800, EasingFunction.Spring(0.35, 2.5));    // looser, bouncier
+    /// </code></example>
+    public static EasingFunction Spring(double dampingRatio = SpringEasing.DEFAULT_DAMPING_RATIO, double frequency = SpringEasing.DEFAULT_FREQUENCY)
+        => new EasingFunction(new SpringEasing(dampingRatio, frequency));
+}

--- a/Sakura.Framework/Graphics/Transforms/IEasingFunction.cs
+++ b/Sakura.Framework/Graphics/Transforms/IEasingFunction.cs
@@ -1,0 +1,18 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Graphics.Transforms;
+
+/// <summary>
+/// A parameterised easing curve that maps a normalised progress value in the range [0, 1]
+/// to an eased value (usually, but not necessarily, also in [0, 1]).
+/// </summary>
+public interface IEasingFunction
+{
+    /// <summary>
+    /// Evaluates the easing curve at the given normalised <paramref name="progress"/>.
+    /// </summary>
+    /// <param name="progress">Normalised progress, expected in the range [0, 1].</param>
+    /// <returns>The eased value.</returns>
+    double Apply(double progress);
+}

--- a/Sakura.Framework/Graphics/Transforms/SpringEasing.cs
+++ b/Sakura.Framework/Graphics/Transforms/SpringEasing.cs
@@ -1,0 +1,97 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.Graphics.Transforms;
+
+/// <summary>
+/// A physically-based spring easing modelled as the step response of a damped harmonic oscillator.
+/// The value starts at 0, is pulled toward its target of 1, and — depending on the damping —
+/// may overshoot and oscillate before settling.
+/// </summary>
+/// <remarks>
+/// The spring's behaviour is controlled by two parameters:
+/// <list type="bullet">
+/// <item><description>
+/// <c>dampingRatio</c> (ζ): below 1 the spring is under-damped and bounces past the target;
+/// exactly 1 is critically damped (the fastest settle with no overshoot); above 1 is over-damped
+/// (a slow approach with no overshoot).
+/// </description></item>
+/// <item><description>
+/// <c>frequency</c>: the natural frequency of the spring expressed as the number of oscillations
+/// that a completely undamped spring would perform across the transform's whole duration. Higher
+/// values feel stiffer and settle faster.
+/// </description></item>
+/// </list>
+/// The curve is evaluated over normalised progress <c>t ∈ [0, 1]</c>, where <c>t = 1</c> corresponds
+/// to the end of the transform. The endpoints are pinned so the transform always comes to rest
+/// exactly on its target value.
+/// </remarks>
+public sealed class SpringEasing : IEasingFunction
+{
+    /// <summary>
+    /// A gently bouncy default that overshoots once before settling.
+    /// </summary>
+    public const double DEFAULT_DAMPING_RATIO = 0.5;
+
+    /// <summary>
+    /// A default natural frequency of 1.5 oscillations across the duration.
+    /// </summary>
+    public const double DEFAULT_FREQUENCY = 1.5;
+
+    private readonly double dampingRatio;
+
+    /// <summary>
+    /// Natural angular frequency (rad over the normalised [0, 1] duration)
+    /// </summary>
+    private readonly double omega0;
+
+    /// <param name="dampingRatio">
+    /// The damping ratio ζ. Clamped to a small positive minimum. Values in (0, 1) bounce,
+    /// 1 is critically damped, and values above 1 are over-damped.
+    /// </param>
+    /// <param name="frequency">
+    /// Natural frequency as the number of oscillations across the duration. Clamped to a small
+    /// positive minimum.
+    /// </param>
+    public SpringEasing(double dampingRatio = DEFAULT_DAMPING_RATIO, double frequency = DEFAULT_FREQUENCY)
+    {
+        this.dampingRatio = Math.Max(dampingRatio, 0.0001);
+        omega0 = 2.0 * Math.PI * Math.Max(frequency, 0.0001);
+    }
+
+    public double Apply(double progress)
+    {
+        // Pin the endpoints so transforms always start and finish exactly on their target value.
+        if (progress <= 0) return 0;
+        if (progress >= 1) return 1;
+
+        double t = progress;
+        double envelope = Math.Exp(-dampingRatio * omega0 * t);
+
+        double displacement;
+
+        if (dampingRatio < 1.0)
+        {
+            // Under-damped: decaying oscillation.
+            double omegaD = omega0 * Math.Sqrt(1.0 - dampingRatio * dampingRatio);
+            displacement = envelope * (Math.Cos(omegaD * t) + dampingRatio * omega0 / omegaD * Math.Sin(omegaD * t));
+        }
+        else if (Math.Abs(dampingRatio - 1.0) < 1e-6)
+        {
+            // Critically damped.
+            displacement = envelope * (1.0 + omega0 * t);
+        }
+        else
+        {
+            // Over-damped: hyperbolic, non-oscillating approach.
+            double omegaD = omega0 * Math.Sqrt(dampingRatio * dampingRatio - 1.0);
+            displacement = envelope * (Math.Cosh(omegaD * t) + dampingRatio * omega0 / omegaD * Math.Sinh(omegaD * t));
+        }
+
+        // "displacement" is the remaining distance to the target (1 at t=0, ~0 as it settles),
+        // so the eased value is 1 minus that.
+        return 1.0 - displacement;
+    }
+}

--- a/Sakura.Framework/Graphics/Transforms/Transform.cs
+++ b/Sakura.Framework/Graphics/Transforms/Transform.cs
@@ -16,7 +16,14 @@ public abstract class Transform : ITransform
 {
     public double StartTime { get; set; }
     public double EndTime { get; set; }
-    public Easing Easing { get; set; }
+
+    /// <summary>
+    /// The easing applied to this transform's progress. Accepts any built-in easing curve
+    /// (via implicit conversion from the <c>Easing</c> enum) as well as parameterised curves such as
+    /// <see cref="CubicBezierEasing"/> and <see cref="SpringEasing"/>.
+    /// </summary>
+    public EasingFunction Easing { get; set; }
+
     public bool IsLooping { get; set; }
 
     /// <summary>
@@ -95,7 +102,7 @@ public abstract class Transform : ITransform
             progress = (time - StartTime) / duration;
         }
 
-        return EasingFunctions.Apply(Easing, progress);
+        return Easing.Apply(progress);
     }
 }
 


### PR DESCRIPTION
Got this opportunity by expand the transform parameter to also support custom function by `EasingFunction` so you can implement the `IEasingFunction` yourself and applied it to the drawable transformation than just normal `Easing` that framework give you. Note that old code that's use `Easing` is usable with implicit conversion. Still recommend to use normal `Easing` like before if you don't need anything special.