### PR TITLE
Fix ancestor draw-node subtrees keep stale child references after input

### DIFF
--- a/Sakura.Framework.Tests/Rendering/ClearGhostDrawNodeTest.cs
+++ b/Sakura.Framework.Tests/Rendering/ClearGhostDrawNodeTest.cs
@@ -135,7 +135,7 @@ public class ClearGhostDrawNodeTest
     public void TestClearNeverGhostsAcrossManyRandomizedRepetitions()
     {
         const int repetitions = 5000;
-        var rng = new Random();
+        var rng = new Random(1234);
 
         for (int rep = 0; rep < repetitions; rep++)
         {

--- a/Sakura.Framework.Tests/Rendering/ClearGhostDrawNodeTest.cs
+++ b/Sakura.Framework.Tests/Rendering/ClearGhostDrawNodeTest.cs
@@ -1,0 +1,185 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Rendering;
+
+/// <summary>
+/// Regression tests for the "cleared drawables keep getting drawn" bug
+/// https://github.com/HelloYeew/sakura/pull/131
+/// </summary>
+[TestFixture]
+public class ClearGhostDrawNodeTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock
+        {
+            CurrentTime = 1000
+        };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+    }
+
+    /// <summary>
+    /// A drawable that invalidates itself every update
+    /// </summary>
+    private partial class AnimatedBox : Box
+    {
+        private int tick;
+
+        public override void Update()
+        {
+            base.Update();
+            // Small wrapped drift so the value genuinely changes each frame (a no-op assignment
+            // would not invalidate) without ever leaving the parent's bounds.
+            Position = new Vector2(10 + tick++ % 40, 10);
+        }
+    }
+
+    /// <summary>
+    /// Advances one update-thread frame in the same order as the real host: input/mutations first
+    /// (<paramref name="inputPhase"/>), then the update traversal, then draw-node generation for the
+    /// given buffer. Returns the freshly generated root draw node.
+    /// </summary>
+    private ContainerDrawNode step(int buffer, Action? inputPhase = null)
+    {
+        manual.CurrentTime += 16;
+        inputPhase?.Invoke();
+        root.UpdateSubTree();
+        return (ContainerDrawNode)root.GenerateDrawNodeSubtree(buffer);
+    }
+
+    /// <summary>
+    /// Counts leaf (non-container) draw nodes reachable from <paramref name="node"/> i.e. how many
+    /// concrete drawables would actually be drawn this frame. A ghost shows up as leftover leaves.
+    /// </summary>
+    private static int countDrawnLeaves(DrawNode node)
+    {
+        if (node is not ContainerDrawNode container)
+            return 1;
+
+        int total = 0;
+        foreach (var child in container.Children)
+            total += countDrawnLeaves(child);
+        return total;
+    }
+
+    /// <summary>
+    /// an active (animated) subtree is cleared during the
+    /// input phase, and every buffer must stop drawing the removed drawables.
+    /// </summary>
+    [Test]
+    public void TestClearingActiveSubtreeDuringInputStopsDrawingItInAllBuffers()
+    {
+        var outer = new Container { Size = new Vector2(600, 500) };
+        var target = new Container { Size = new Vector2(400, 400) };
+
+        for (int i = 0; i < 5; i++)
+            target.Add(new Box { Position = new Vector2(20 + i * 10, 20), Size = new Vector2(30) });
+
+        // The activity source that keeps the subtree-dirty flags set frame to frame.
+        target.Add(new AnimatedBox { Size = new Vector2(30) });
+
+        outer.Add(target);
+        root.Add(outer);
+
+        // Warm up so every buffer holds a populated, cached tree.
+        for (int f = 0; f < 9; f++)
+            step(f % 3);
+
+        Assert.That(countDrawnLeaves(step(0)), Is.EqualTo(6), "Sanity: all six drawables should be drawn before the clear.");
+
+        // Clear during the input phase — before the update traversal — exactly like a click on the
+        // "Clear test scene" step.
+        step(0, () => target.Clear());
+
+        // Let every buffer be regenerated at least once after the clear.
+        for (int f = 0; f < 9; f++)
+            step(f % 3);
+
+        Assert.Multiple(() =>
+        {
+            for (int buffer = 0; buffer < 3; buffer++)
+                Assert.That(countDrawnLeaves(step(buffer)), Is.Zero, $"Buffer {buffer} still draws removed drawables (ghosting).");
+        });
+    }
+
+    /// <summary>
+    /// Stress version
+    /// </summary>
+    [Test]
+    public void TestClearNeverGhostsAcrossManyRandomizedRepetitions()
+    {
+        const int repetitions = 5000;
+        var rng = new Random();
+
+        for (int rep = 0; rep < repetitions; rep++)
+        {
+            // Fresh scene each repetition.
+            root.Clear();
+
+            int depth = 1 + rng.Next(3);          // 1..3 nested containers above the target
+            int boxCount = rng.Next(6);           // 0..5 static boxes in the target
+            int warmup = 3 + rng.Next(9);         // frames to prime the buffers
+            int settle = 6 + rng.Next(9);         // frames to let all buffers regenerate after clear
+            int startBuffer = rng.Next(3);
+
+            Container parent = root;
+            for (int d = 0; d < depth; d++)
+            {
+                var c = new Container { Size = new Vector2(500 - d * 20, 480 - d * 20) };
+                parent.Add(c);
+                parent = c;
+            }
+
+            var target = parent;
+
+            for (int i = 0; i < boxCount; i++)
+                target.Add(new Box { Position = new Vector2(15 + i * 8, 15), Size = new Vector2(25) });
+
+            // Keep the flags hot so the pre-update clear hits the worst-case dedup state.
+            target.Add(new AnimatedBox { Size = new Vector2(25) });
+
+            for (int f = 0; f < warmup; f++)
+                step((startBuffer + f) % 3);
+
+            // Clear in the input phase.
+            step(startBuffer, () => target.Clear());
+
+            for (int f = 0; f < settle; f++)
+                step((startBuffer + f) % 3);
+
+            for (int buffer = 0; buffer < 3; buffer++)
+            {
+                int drawn = countDrawnLeaves(step(buffer));
+                Assert.That(drawn, Is.Zero,
+                    $"Repetition {rep} (depth={depth}, boxes={boxCount}, warmup={warmup}, settle={settle}, startBuffer={startBuffer}): "
+                    + $"buffer {buffer} still draws {drawn} removed drawable(s).");
+            }
+        }
+    }
+}

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -404,37 +404,42 @@ public partial class Container : Drawable
     // changes. Draw nodes store the version they were generated against, letting fully
     // clean subtrees skip draw-node regeneration entirely.
     private long subtreeDrawVersion = 1;
-    private bool subtreeDirtyNotified;
-
-    private const int draw_node_buffer_count = 3;
-    private int forceRebuildBuffers;
 
     /// <summary>
-    /// Marks this container's (and all ancestors') cached draw-node subtree as stale.
-    /// The walk up the parent chain short-circuits once per frame per container.
+    ///  True while this container has a subtree change that has not yet been flushed into a
+    /// rebuilt draw node. Used purely to dedup the walk up the parent chain: while it is set,
+    /// our ancestors have already been notified and their versions are already ahead of their
+    /// cached draw nodes, so re-walking is redundant.
+    ///
+    /// Crucially the flag is cleared when this container's draw-node subtree is actually
+    /// rebuilt (see GenerateDrawNodeSubtree) — NOT on a frame boundary. The previous design
+    /// reset it in Update(), but MarkSubtreeDrawStateDirty can run before the update traversal
+    /// (input is dispatched at the very start of the update frame, so a click that clears or
+    /// removes drawables fires here). At that point the flag still held its stale value from the
+    /// previous frame; if it was set, the walk short-circuited and the ancestors' versions were
+    /// never bumped, so they kept skipping regeneration and drawing removed drawables from their
+    /// cached child lists. Tying the reset to the rebuild removes that ordering dependency.
+    /// </summary>
+    private bool subtreeDirty;
+
+    /// <summary>
+    /// Marks this container's (and all ancestors') cached draw-node subtree as stale so it is
+    /// rebuilt on the next generation. Safe to call at any point in the frame, including before
+    /// the update traversal (e.g. from input handlers).
     /// </summary>
     internal void MarkSubtreeDrawStateDirty()
     {
         subtreeDrawVersion++;
 
-        // Every buffered draw node is now stale, not just the one written this frame. Force all of
-        // them to rebuild over the next few frames. Set before the short-circuit (like the version
-        // bump) so ancestors reached by the walk also force-rebuild their own buffers — otherwise an
-        // ancestor whose node still version-matches would keep a reference to a removed child's node.
-        forceRebuildBuffers = draw_node_buffer_count;
-
-        if (subtreeDirtyNotified)
+        if (subtreeDirty)
             return;
 
-        subtreeDirtyNotified = true;
+        subtreeDirty = true;
         Parent?.MarkSubtreeDrawStateDirty();
     }
 
     public override void Update()
     {
-        // Allow a fresh subtree-dirty notification walk this frame.
-        subtreeDirtyNotified = false;
-
         // Check whether our layout was dirty before base.Update() is called, as it will clear our invalidation flags.
         bool layoutWasInvalidated = (Invalidation & InvalidationFlags.DrawInfo) != 0;
         bool colourWasInvalidated = (Invalidation & InvalidationFlags.Colour) != 0;
@@ -658,18 +663,17 @@ public partial class Container : Drawable
     {
         var node = (ContainerDrawNode)base.GenerateDrawNodeSubtree(frameIndex);
 
-        // If nothing in this subtree changed since this buffer's node was last generated
-        // (no invalidations, topology, lifetime or masking transitions), the cached child
-        // node list is still valid and the entire subtree walk can be skipped.
-        // forceRebuildBuffers overrides the cache: after a subtree change the version bumps once but
-        // there are draw_node_buffer_count buffer slots, so each must be rebuilt at least once before
-        // the cache is trusted again. Without this, a buffer not yet rewritten since the change keeps
-        // its stale child list and "ghosts" removed drawables for a few frames.
-        if (forceRebuildBuffers == 0 && node.AppliedSubtreeVersion == subtreeDrawVersion)
+        // Per-buffer cache. Each of the buffered draw nodes tracks the subtree version it was
+        // built against. A change bumps subtreeDrawVersion, so every buffer's node becomes stale
+        // and rebuilds the next time that buffer index is generated — no separate multi-buffer
+        // force counter is needed, and no buffer can retain a stale child list once the version
+        // moves ahead of it.
+        if (node.AppliedSubtreeVersion == subtreeDrawVersion)
             return node;
 
-        if (forceRebuildBuffers > 0)
-            forceRebuildBuffers--;
+        // This buffer is stale and about to be rebuilt, flushing the pending change. Allow the
+        // next change to walk the parent chain again.
+        subtreeDirty = false;
 
         node.Children.Clear();
 


### PR DESCRIPTION
This happened sometime, especially if you are using visual test scene. When you click "clear test scene" sometime the drawable still got draw due to the "ghost draw-node" not clear properly.

How : Clearing marks the draw-node tree dirty by walking up the parent chain. That walk was deduped with a flag reset once per frame in `Update()`. But clicks are dispatched before the frame's update traversal, so the clear fired while the flag still held last frame's stale true -> the walk stopped early -> ancestor draw nodes were never invalidated -> they kept re-drawing the removed children from their cached child lists. It happened "only sometimes" because it depended on whether the flag happened to be stale at click time. So it's really rare to happen.

Fix : by Clear the dedup flag when the draw node is actually rebuilt, not on the frame boundary so the invalidation walk can't be suppressed by pre-update input. Also removed the `forceRebuildBuffers` band-aid since the per-buffer version check already covers all three buffers correctly once the walk is reliable.