### PR TITLE
Fix variable font weight unusable in Windows

### DIFF
--- a/Sakura.Framework/Graphics/Text/Font.cs
+++ b/Sakura.Framework/Graphics/Text/Font.cs
@@ -48,6 +48,14 @@ public class Font : IDisposable
     private readonly bool isVariable;
 
     /// <summary>
+    /// Native byte width of a FreeType <c>FT_Fixed</c> / <c>FT_ULong</c> (C <c>long</c>) for the loaded
+    /// native binary, detected at runtime from the axis records. The host ABI is not a reliable guide:
+    /// some bundled FreeType builds (observed under virtualized Windows) are LP64 (8-byte <c>long</c>)
+    /// even though 64-bit Windows itself is LLP64 (4-byte). Defaults to pointer width until probed.
+    /// </summary>
+    private int axisLongSize = IntPtr.Size;
+
+    /// <summary>
     /// Variation axes exposed by this face, in the face's native axis order (order matters for
     /// <see cref="FreeTypeVariations.FT_Set_Var_Design_Coordinates"/>). Empty for static fonts.
     /// </summary>
@@ -135,19 +143,24 @@ public class Font : IDisposable
             // FT_MM_Var has only uint/pointer fields, so it marshals correctly on every data model.
             var header = Marshal.PtrToStructure<FT_MM_Var>(mm);
 
+            if (header.num_axis == 0)
+                return;
+
             // FT_Var_Axis must *not* go through Marshal.PtrToStructure: its FT_Fixed/FT_ULong fields are
-            // C 'long' (8 bytes on macOS/Linux, 4 bytes on 64-bit Windows), and neither CLong/CULong
-            // nor a fixed-width struct reproduces that layout portably. Walk the records by hand using
-            // the platform C-long width. Native layout of each record:
+            // C 'long', whose width the native binary does not always match to the host ABI (some
+            // FreeType builds under virtualized Windows are LP64 with an 8-byte long even though Windows
+            // is normally LLP64). So detect the width from the first record, then walk the records by
+            // hand. Native layout of each record:
             //   name  : FT_String*     (pointer-sized)
-            //   min   : FT_Fixed 16.16 (CLongSize)
-            //   def   : FT_Fixed 16.16 (CLongSize)
-            //   max   : FT_Fixed 16.16 (CLongSize)
-            //   tag   : FT_ULong       (CLongSize) — packed 4-char axis tag
+            //   min   : FT_Fixed 16.16 (longSize)
+            //   def   : FT_Fixed 16.16 (longSize)
+            //   max   : FT_Fixed 16.16 (longSize)
+            //   tag   : FT_ULong       (longSize) — packed 4-char axis tag
             //   strid : FT_UInt        (4)
             // https://github.com/HelloYeew/sakura/pull/132
-            int longSize = FreeTypeVariations.CLongSize;
             int ptrSize = IntPtr.Size;
+            int longSize = detectAxisLongSize(header.axis);
+            axisLongSize = longSize;
             int recSize = alignUp(ptrSize + 4 * longSize + 4, ptrSize);
 
             for (int i = 0; i < header.num_axis; i++)
@@ -340,12 +353,12 @@ public class Font : IDisposable
         currentVariation = variation;
 
         int n = axisTable.Count;
-        int longSize = FreeTypeVariations.CLongSize;
+        int longSize = axisLongSize;
         var hbVariations = new HarfBuzzSharp.Variation[n];
 
         // FreeType wants an array of native FT_Fixed (C 'long', 16.16). Build it in unmanaged memory at
-        // the platform-correct element width instead of relying on CLong[] marshalling, which mis-sizes
-        // elements on 64-bit Windows.
+        // the native library's element width (detected in readVariationAxes) instead of relying on
+        // CLong[] marshalling, which mis-sizes elements.
         nint coords = Marshal.AllocHGlobal(n * longSize);
 
         try
@@ -392,6 +405,62 @@ public class Font : IDisposable
     /// Rounds <paramref name="value"/> up to the next multiple of <paramref name="alignment"/>
     /// </summary>
     private static int alignUp(int value, int alignment) => (value + alignment - 1) & ~(alignment - 1);
+
+    private static int? cachedAxisLongSize;
+
+    /// <summary>
+    /// Probes the native byte width of FreeType's <c>FT_Fixed</c> / <c>FT_ULong</c> (C <c>long</c>) by
+    /// reading the first axis record both ways and keeping the interpretation that yields a printable
+    /// 4-character axis tag together with a sane, in-range <c>min &lt;= default &lt;= max</c> ordering.
+    /// This tolerates native libraries whose <c>long</c> width disagrees with the host ABI (observed
+    /// with FreeType under virtualized Windows, which reported LP64 8-byte longs). The result is the
+    /// same for every face in a process, so it is cached after the first successful probe.
+    /// </summary>
+    private static int detectAxisLongSize(nint firstRecord)
+    {
+        if (cachedAxisLongSize is int cached)
+            return cached;
+
+        // Try pointer width first (8 on LP64), then 4 (LLP64). On 32-bit both are 4, so only probe once.
+        ReadOnlySpan<int> candidates = IntPtr.Size == 4 ? stackalloc[] { 4 } : stackalloc[] { IntPtr.Size, 4 };
+
+        foreach (int size in candidates)
+        {
+            nint fields = firstRecord + IntPtr.Size; // skip the FT_String* name
+
+            int min = Marshal.ReadInt32(fields, 0 * size);
+            int def = Marshal.ReadInt32(fields, 1 * size);
+            int max = Marshal.ReadInt32(fields, 2 * size);
+            uint tag = (uint)Marshal.ReadInt32(fields, 3 * size);
+
+            bool plausibleRange = min <= def && def <= max
+                                  && MathF.Abs(max / 65536f) < 100_000f
+                                  && MathF.Abs(min / 65536f) < 100_000f;
+
+            if (isPrintableTag(tag) && plausibleRange)
+            {
+                cachedAxisLongSize = size;
+                return size;
+            }
+        }
+
+        // Nothing validated; fall back to pointer width (correct for the common LP64 desktop case).
+        cachedAxisLongSize = IntPtr.Size;
+        return cachedAxisLongSize.Value;
+    }
+
+    /// <summary>True when all four bytes of a packed OpenType axis tag are printable ASCII.</summary>
+    private static bool isPrintableTag(uint tag)
+    {
+        for (int shift = 0; shift < 32; shift += 8)
+        {
+            byte b = (byte)(tag >> shift);
+            if (b < 0x20 || b > 0x7E)
+                return false;
+        }
+
+        return true;
+    }
 
     private List<TextGlyph> shapeRun(string text, float renderFontSize, float dpiScale, float baselineY, FontVariation variation, int runOffset, ref float cursorX)
     {

--- a/Sakura.Framework/Graphics/Text/Font.cs
+++ b/Sakura.Framework/Graphics/Text/Font.cs
@@ -132,19 +132,37 @@ public class Font : IDisposable
 
         try
         {
+            // FT_MM_Var has only uint/pointer fields, so it marshals correctly on every data model.
             var header = Marshal.PtrToStructure<FT_MM_Var>(mm);
-            int stride = Marshal.SizeOf<FT_Var_Axis>();
+
+            // FT_Var_Axis must *not* go through Marshal.PtrToStructure: its FT_Fixed/FT_ULong fields are
+            // C 'long' (8 bytes on macOS/Linux, 4 bytes on 64-bit Windows), and neither CLong/CULong
+            // nor a fixed-width struct reproduces that layout portably. Walk the records by hand using
+            // the platform C-long width. Native layout of each record:
+            //   name  : FT_String*     (pointer-sized)
+            //   min   : FT_Fixed 16.16 (CLongSize)
+            //   def   : FT_Fixed 16.16 (CLongSize)
+            //   max   : FT_Fixed 16.16 (CLongSize)
+            //   tag   : FT_ULong       (CLongSize) — packed 4-char axis tag
+            //   strid : FT_UInt        (4)
+            // https://github.com/HelloYeew/sakura/pull/132
+            int longSize = FreeTypeVariations.CLongSize;
+            int ptrSize = IntPtr.Size;
+            int recSize = alignUp(ptrSize + 4 * longSize + 4, ptrSize);
 
             for (int i = 0; i < header.num_axis; i++)
             {
-                var a = Marshal.PtrToStructure<FT_Var_Axis>(header.axis + i * stride);
+                nint fields = header.axis + i * recSize + ptrSize; // skip the FT_String* name
 
-                uint tag = (uint)a.tag.Value;
-                float min = (long)a.minimum.Value / 65536f;
-                float def = (long)a.def.Value / 65536f;
-                float max = (long)a.maximum.Value / 65536f;
+                // The 16.16 fixed values fit in 32 bits (including negatives, e.g. GRAD -50) and every
+                // supported target is little-endian, so reading the low Int32 of each field is correct
+                // regardless of the C-long width — only the field offsets depend on it.
+                int min = Marshal.ReadInt32(fields, 0 * longSize);
+                int def = Marshal.ReadInt32(fields, 1 * longSize);
+                int max = Marshal.ReadInt32(fields, 2 * longSize);
+                uint tag = (uint)Marshal.ReadInt32(fields, 3 * longSize);
 
-                axisTable.Add(new FontAxis(tag, min, def, max));
+                axisTable.Add(new FontAxis(tag, min / 65536f, def / 65536f, max / 65536f));
             }
         }
         catch (Exception ex)
@@ -322,31 +340,58 @@ public class Font : IDisposable
         currentVariation = variation;
 
         int n = axisTable.Count;
-        var coords = new CLong[n];
+        int longSize = FreeTypeVariations.CLongSize;
         var hbVariations = new HarfBuzzSharp.Variation[n];
 
-        for (int i = 0; i < n; i++)
+        // FreeType wants an array of native FT_Fixed (C 'long', 16.16). Build it in unmanaged memory at
+        // the platform-correct element width instead of relying on CLong[] marshalling, which mis-sizes
+        // elements on 64-bit Windows.
+        nint coords = Marshal.AllocHGlobal(n * longSize);
+
+        try
         {
-            var axis = axisTable[i];
+            for (int i = 0; i < n; i++)
+            {
+                var axis = axisTable[i];
 
-            // Use the requested value for this axis if present, else the axis default. Unknown axes in
-            // the request are simply never matched here, so they're ignored as intended.
-            float value = variation.Get(axis.Tag) ?? axis.Default;
-            value = Math.Clamp(value, axis.Minimum, axis.Maximum);
+                // Use the requested value for this axis if present, else the axis default. Unknown axes
+                // in the request are simply never matched here, so they're ignored as intended.
+                float value = variation.Get(axis.Tag) ?? axis.Default;
 
-            // FreeType wants 16.16 fixed point in the face's axis order. All axis values are small
-            // (< ~1000), so value * 65536 fits comfortably in int on both LP64 and LLP64.
-            coords[i] = new CLong((int)MathF.Round(value * 65536f));
-            hbVariations[i] = new HarfBuzzSharp.Variation { Tag = axis.Tag, Value = value };
+                // Guard against a degenerate axis range (min > max) so a bad axis read can never throw
+                // ArgumentException here; Math.Clamp requires min <= max.
+                float lo = MathF.Min(axis.Minimum, axis.Maximum);
+                float hi = MathF.Max(axis.Minimum, axis.Maximum);
+                value = Math.Clamp(value, lo, hi);
+
+                // All axis values are small (< ~1000), so value * 65536 fits comfortably in int.
+                int fixedValue = (int)MathF.Round(value * 65536f);
+
+                if (longSize == 4)
+                    Marshal.WriteInt32(coords, i * longSize, fixedValue);
+                else
+                    Marshal.WriteInt64(coords, i * longSize, fixedValue);
+
+                hbVariations[i] = new HarfBuzzSharp.Variation { Tag = axis.Tag, Value = value };
+            }
+
+            var err = FreeTypeVariations.FT_Set_Var_Design_Coordinates(faceHandle, (uint)n, coords);
+            if (err != FT_Error.FT_Err_Ok)
+                Logger.Error($"FT_Set_Var_Design_Coordinates failed for font '{Name}': {err}");
         }
-
-        var err = FreeTypeVariations.FT_Set_Var_Design_Coordinates(faceHandle, (uint)n, coords);
-        if (err != FT_Error.FT_Err_Ok)
-            Logger.Error($"FT_Set_Var_Design_Coordinates failed for font '{Name}': {err}");
+        finally
+        {
+            Marshal.FreeHGlobal(coords);
+        }
 
         // Keep HarfBuzz in sync so shaped advances match the rasterized weight.
         hbFont.SetVariations(hbVariations);
     }
+
+    /// <summary>
+    /// Rounds <paramref name="value"/> up to the next multiple of <paramref name="alignment"/>
+    /// </summary>
+    private static int alignUp(int value, int alignment) => (value + alignment - 1) & ~(alignment - 1);
 
     private List<TextGlyph> shapeRun(string text, float renderFontSize, float dpiScale, float baselineY, FontVariation variation, int runOffset, ref float cursorX)
     {

--- a/Sakura.Framework/Graphics/Text/FreeTypeVariations.cs
+++ b/Sakura.Framework/Graphics/Text/FreeTypeVariations.cs
@@ -19,11 +19,11 @@ namespace Sakura.Framework.Graphics.Text;
 /// <para>
 /// <b>Cross-platform integer widths.</b> <c>FT_Fixed</c> and <c>FT_ULong</c> are C
 /// <c>long</c>/<c>unsigned long</c>: 8 bytes on macOS/Linux (LP64) but 4 bytes on 64-bit Windows
-/// (LLP64). We marshal them with the runtime types <see cref="CLong"/>/<see cref="CULong"/>, which
-/// map to the platform-correct C <c>long</c> width automatically, and let
-/// <see cref="Marshal.SizeOf{T}()"/>/<see cref="Marshal.PtrToStructure{T}(nint)"/> compute the axis
-/// record stride. This keeps the struct layout correct on both data models without <c>#if</c>
-/// branches.
+/// (LLP64). The <see cref="CLong"/>/<see cref="CULong"/> runtime types do not reproduce that
+/// width when used as struct fields read via <see cref="Marshal.PtrToStructure{T}(nint)"/> (they are
+/// pointer-sized there), which silently corrupts the axis records on Windows. Instead we expose the
+/// platform C-long width via <see cref="CLongSize"/> and walk the <c>FT_Var_Axis</c> records by hand
+/// (see <c>Font.readVariationAxes</c>), and pass coordinates as a hand-built native buffer.
 /// </para>
 /// </remarks>
 internal static class FreeTypeVariations
@@ -34,6 +34,14 @@ internal static class FreeTypeVariations
     internal const long FT_FACE_FLAG_MULTIPLE_MASTERS = 1 << 8;
 
     /// <summary>
+    /// Width in bytes of a C <c>long</c>/<c>unsigned long</c> (i.e. <c>FT_Fixed</c>/<c>FT_ULong</c>)
+    /// on the current platform: 4 on Windows (LLP64), otherwise pointer-sized (8 on 64-bit LP64,
+    /// 4 on 32-bit ILP32). Used to compute native FreeType struct offsets and coordinate buffers.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    internal static readonly int CLongSize = RuntimeInfo.IsWindows ? 4 : IntPtr.Size;
+
+    /// <summary>
     /// Retrieves the variation axis and named-instance descriptors for a variable font. The returned
     /// <c>aMaster</c> pointer must be released with <see cref="FT_Done_MM_Var"/>.
     /// </summary>
@@ -41,11 +49,13 @@ internal static class FreeTypeVariations
     internal static extern FT_Error FT_Get_MM_Var(nint face, out nint aMaster);
 
     /// <summary>
-    /// Sets the design coordinates for the current variation instance. <paramref name="coords"/> are
-    /// 16.16 fixed-point values in the face's axis order.
+    /// Sets the design coordinates for the current variation instance. <paramref name="coords"/> points
+    /// at an array of <c>numCoords</c> native <c>FT_Fixed</c> (C <c>long</c>, 16.16 fixed-point) values
+    /// in the face's axis order. The caller owns the buffer and must size each element at
+    /// <see cref="CLongSize"/> bytes.
     /// </summary>
     [DllImport("freetype")]
-    internal static extern FT_Error FT_Set_Var_Design_Coordinates(nint face, uint numCoords, [In] CLong[] coords);
+    internal static extern FT_Error FT_Set_Var_Design_Coordinates(nint face, uint numCoords, nint coords);
 
     /// <summary>
     /// Frees an <c>FT_MM_Var</c> previously returned by <see cref="FT_Get_MM_Var"/>.
@@ -74,9 +84,11 @@ internal static class FreeTypeVariations
 }
 
 /// <summary>
-/// Managed mirror of FreeType's <c>FT_MM_Var</c> header. <see cref="LayoutKind.Sequential"/> with the
-/// <see cref="CLong"/>/<see cref="CULong"/> fields in <see cref="FT_Var_Axis"/> keeps it correct on
-/// both LP64 and LLP64.
+/// Managed mirror of FreeType's <c>FT_MM_Var</c> header. It contains only <c>uint</c> and pointer
+/// fields (no C <c>long</c>), so <see cref="Marshal.PtrToStructure{T}(nint)"/> lays it out correctly
+/// on both LP64 and LLP64. The <c>FT_Var_Axis</c> records it points at are read by hand (see
+/// <c>Font.readVariationAxes</c>) because their <c>FT_Fixed</c>/<c>FT_ULong</c> fields are C
+/// <c>long</c> and cannot be marshalled portably as struct fields.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
 [SuppressMessage("ReSharper", "InconsistentNaming")]
@@ -87,19 +99,4 @@ internal struct FT_MM_Var
     public uint num_namedstyles;
     public nint axis;        // FT_Var_Axis*
     public nint namedstyle;  // FT_Var_Named_Style*
-}
-
-/// <summary>
-/// Managed mirror of FreeType's <c>FT_Var_Axis</c>.
-/// </summary>
-[StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("ReSharper", "InconsistentNaming")]
-internal struct FT_Var_Axis
-{
-    public nint name;        // FT_String*
-    public CLong minimum;    // FT_Fixed (16.16)
-    public CLong def;        // FT_Fixed (16.16)
-    public CLong maximum;    // FT_Fixed (16.16)
-    public CULong tag;       // FT_ULong — packed 4-char axis tag
-    public uint strid;
 }

--- a/Sakura.Framework/Graphics/Text/FreeTypeVariations.cs
+++ b/Sakura.Framework/Graphics/Text/FreeTypeVariations.cs
@@ -18,12 +18,12 @@ namespace Sakura.Framework.Graphics.Text;
 /// <remarks>
 /// <para>
 /// <b>Cross-platform integer widths.</b> <c>FT_Fixed</c> and <c>FT_ULong</c> are C
-/// <c>long</c>/<c>unsigned long</c>: 8 bytes on macOS/Linux (LP64) but 4 bytes on 64-bit Windows
-/// (LLP64). The <see cref="CLong"/>/<see cref="CULong"/> runtime types do not reproduce that
-/// width when used as struct fields read via <see cref="Marshal.PtrToStructure{T}(nint)"/> (they are
-/// pointer-sized there), which silently corrupts the axis records on Windows. Instead we expose the
-/// platform C-long width via <see cref="CLongSize"/> and walk the <c>FT_Var_Axis</c> records by hand
-/// (see <c>Font.readVariationAxes</c>), and pass coordinates as a hand-built native buffer.
+/// <c>long</c>/<c>unsigned long</c>, whose byte width (4 or 8) depends on the native binary's data
+/// model and, as observed under virtualized Windows, does not always match the host ABI. The
+/// <see cref="CLong"/>/<see cref="CULong"/> runtime types also fail to reproduce that width when used
+/// as struct fields via <see cref="Marshal.PtrToStructure{T}(nint)"/>. So we neither marshal
+/// <c>FT_Var_Axis</c> as a struct nor assume a width: <c>Font.readVariationAxes</c> detects the width
+/// at runtime, walks the axis records by hand, and passes coordinates as a hand-built native buffer.
 /// </para>
 /// </remarks>
 internal static class FreeTypeVariations
@@ -32,14 +32,6 @@ internal static class FreeTypeVariations
     /// FreeType face flag indicating a variable ("Multiple Masters") font.
     /// </summary>
     internal const long FT_FACE_FLAG_MULTIPLE_MASTERS = 1 << 8;
-
-    /// <summary>
-    /// Width in bytes of a C <c>long</c>/<c>unsigned long</c> (i.e. <c>FT_Fixed</c>/<c>FT_ULong</c>)
-    /// on the current platform: 4 on Windows (LLP64), otherwise pointer-sized (8 on 64-bit LP64,
-    /// 4 on 32-bit ILP32). Used to compute native FreeType struct offsets and coordinate buffers.
-    /// </summary>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    internal static readonly int CLongSize = RuntimeInfo.IsWindows ? 4 : IntPtr.Size;
 
     /// <summary>
     /// Retrieves the variation axis and named-instance descriptors for a variable font. The returned
@@ -51,8 +43,8 @@ internal static class FreeTypeVariations
     /// <summary>
     /// Sets the design coordinates for the current variation instance. <paramref name="coords"/> points
     /// at an array of <c>numCoords</c> native <c>FT_Fixed</c> (C <c>long</c>, 16.16 fixed-point) values
-    /// in the face's axis order. The caller owns the buffer and must size each element at
-    /// <see cref="CLongSize"/> bytes.
+    /// in the face's axis order. The caller owns the buffer and sizes each element at the width detected
+    /// by <c>Font.readVariationAxes</c>.
     /// </summary>
     [DllImport("freetype")]
     internal static extern FT_Error FT_Set_Var_Design_Coordinates(nint face, uint numCoords, nint coords);

--- a/Sakura.Framework/Graphics/Text/RendererFontStore.cs
+++ b/Sakura.Framework/Graphics/Text/RendererFontStore.cs
@@ -215,7 +215,6 @@ public class RendererFontStore : IFontStore
             AddFont(resourceStorage, "NotoColorEmoji-Regular.ttf", alias: "NotoColorEmoji");
 
         Logger.Debug($"NotoColorEmoji.ttf is {(notoColorAvailable ? "available" : "not available")} in the resource storage.");
-        // TODO: Add but not rendered
 
         bool colorEmojiInChain = false;
 
@@ -244,7 +243,7 @@ public class RendererFontStore : IFontStore
         // NotoColorEmoji
         // Note for me in future: Still can't render COLRv1 version, please use normal bitmap version
         // https://github.com/googlefonts/noto-emoji/blob/main/fonts/NotoColorEmoji.ttf
-        if (!colorEmojiInChain && notoColorAvailable)
+        if (notoColorAvailable)
         {
             AddFallbackFamily("NotoColorEmoji");
             colorEmojiInChain = true;


### PR DESCRIPTION
At first we use C#'s [CLong](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.clong?view=net-10.0) to receive the byte but it turned out that it's unusable so just walk the byte manually instead. (Windows FreeType turned out to be LP64 with an 8-byte long sooooo.......🤷)