### PR TITLE
Fix LOH POH FOH memory issues from long run

### DIFF
--- a/Sakura.Framework.Tests/Graphics/InvalidationCascadeTest.cs
+++ b/Sakura.Framework.Tests/Graphics/InvalidationCascadeTest.cs
@@ -444,6 +444,37 @@ public class InvalidationCascadeTest
     }
 
     [Test]
+    public void TestContainerFadeOutCascadesZeroAlphaToChildren()
+    {
+        // a container (without AlwaysPresent) fading itself out to exactly zero alpha
+        // must still tell its children their effective alpha dropped to zero. Container.Update()
+        // previously returned early as soon as its own Alpha reached zero, before ever reaching the
+        // Colour-invalidation cascade so a child's cached DrawAlpha stayed stuck at its last
+        // nonzero value forever (until the parent faded back in, which isn't affected by the same
+        // early return).
+        var screen = new Container { Size = new Vector2(400, 300) };
+        var content = new Box { Size = new Vector2(100) };
+        screen.Add(content);
+        root.Add(screen);
+        settle();
+
+        Assert.That(content.DrawAlpha, Is.EqualTo(1f).Within(0.001f));
+
+        screen.FadeOut(100);
+
+        manual.CurrentTime += 150;
+        root.UpdateSubTree();
+        root.UpdateSubTree();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(screen.Alpha, Is.EqualTo(0f).Within(0.001f));
+            Assert.That(content.DrawAlpha, Is.EqualTo(0f).Within(0.001f),
+                "Child DrawAlpha must reach 0 when a (non-AlwaysPresent) parent fades itself out to invisible.");
+        });
+    }
+
+    [Test]
     public void TestContainerMoveTransformCascadesToChildren()
     {
         var screen = new Container { Position = new Vector2(0, 300), Size = new Vector2(400, 300) };

--- a/Sakura.Framework/Audio/BassEngine/BassTrack.cs
+++ b/Sakura.Framework/Audio/BassEngine/BassTrack.cs
@@ -35,11 +35,26 @@ internal class BassTrack : ITrack
         this.manager = manager;
         filePath = null;
 
-        using (var ms = new MemoryStream())
+        int initialCapacity = 0;
+        if (stream.CanSeek)
+        {
+            try
+            {
+                long length = stream.Length;
+                initialCapacity = length > 0 && length <= int.MaxValue ? (int)length : 0;
+            }
+            catch (NotSupportedException)
+            {
+                initialCapacity = 0;
+            }
+        }
+
+        using (var ms = initialCapacity > 0 ? new MemoryStream(initialCapacity) : new MemoryStream())
         {
             stream.CopyTo(ms);
-            byte[] data = ms.ToArray();
-            dataLength = data.Length;
+
+            byte[] data = ms.GetBuffer();
+            dataLength = ms.Length;
             dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             dataPtr = dataHandle.AddrOfPinnedObject();
 

--- a/Sakura.Framework/Graphics/Colors/KnownColorTable.cs
+++ b/Sakura.Framework/Graphics/Colors/KnownColorTable.cs
@@ -16,7 +16,7 @@ internal static class KnownColorTable
     public const byte KnownColorKindUnknown = 2;
 
     // All known color values (in order of definition in the KnownColor enum).
-    public static ReadOnlySpan<uint> ColorValueTable =>
+    private static readonly uint[] s_colorValueTable =
     [
         // "not a known color"
         0,
@@ -241,8 +241,9 @@ internal static class KnownColorTable
         0xFF663399,     // RebeccaPurple
     ];
 
-    // All known color kinds (in order of definition in the KnownColor enum).
-    public static ReadOnlySpan<byte> ColorKindTable =>
+    public static ReadOnlySpan<uint> ColorValueTable => s_colorValueTable;
+
+    private static readonly byte[] s_colorKindTable =
     [
         // "not a known color"
         KnownColorKindUnknown,
@@ -431,12 +432,14 @@ internal static class KnownColorTable
         KnownColorKindWeb,      // RebeccaPurple
     ];
 
+    public static ReadOnlySpan<byte> ColorKindTable => s_colorKindTable;
+
     // These values were based on manual investigation of dark mode themes in the
     // Win32 Common Controls and WinUI. There aren't direct mappings published by
     // Windows, these may change slightly when this feature is finalized to make
     // sure we have the best experience in hybrid dark mode scenarios (mixing
     // WPF, WinForms, and WinUI).
-    private static ReadOnlySpan<uint> AlternateSystemColors =>
+    private static readonly uint[] s_alternateSystemColors =
     [
         0,          // To align with KnownColor.ActiveBorder = 1
 
@@ -475,6 +478,8 @@ internal static class KnownColorTable
         0xFF373737, // FFF0F0F0 - FF373737: MenuBar - Same as Normal Menu Background
         0xFF2A80D2  // FF3399FF - FF2A80D2: MenuHighlight - Same as Highlighted Menu Background
     ];
+
+    private static ReadOnlySpan<uint> AlternateSystemColors => s_alternateSystemColors;
 
     internal static Color ArgbToKnownColor(uint argb)
     {

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -456,6 +456,14 @@ public partial class Container : Drawable
 
         base.Update();
 
+        if (colourWasInvalidated)
+        {
+            foreach (var child in children)
+            {
+                child.Invalidate(InvalidationFlags.Colour, false);
+            }
+        }
+
         if (!AlwaysPresent && Precision.AlmostEqualZero(Alpha))
             return;
 
@@ -483,14 +491,6 @@ public partial class Container : Drawable
             foreach (var child in children)
             {
                 child.Invalidate(InvalidationFlags.DrawInfo, false);
-            }
-        }
-
-        if (colourWasInvalidated)
-        {
-            foreach (var child in children)
-            {
-                child.Invalidate(InvalidationFlags.Colour, false);
             }
         }
     }

--- a/Sakura.Framework/Sakura.Framework.csproj
+++ b/Sakura.Framework/Sakura.Framework.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="ManagedBass.Mix" Version="4.0.2" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="Sakura.Framework.NativeLibraries" Version="2026.625.0" />
-    <PackageReference Include="Sakura.Framework.SourceGenerators" Version="2026.622.0">
+    <PackageReference Include="Sakura.Framework.SourceGenerators" Version="2026.708.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Sakura.Framework/Statistic/GlobalStatistics.cs
+++ b/Sakura.Framework/Statistic/GlobalStatistics.cs
@@ -12,8 +12,11 @@ public static class GlobalStatistics
 
     public static GlobalStatistic<T> Get<T>(string group, string name)
     {
-        var groupStats = statistics.GetOrAdd(group, _ => new ConcurrentDictionary<string, IGlobalStatistic>());
-        var stat = groupStats.GetOrAdd(name, _ => new GlobalStatistic<T>(group, name));
+        if (statistics.TryGetValue(group, out var existingGroupStats) && existingGroupStats.TryGetValue(name, out var existingStat))
+            return (GlobalStatistic<T>)existingStat;
+
+        var groupStats = statistics.GetOrAdd(group, static _ => new ConcurrentDictionary<string, IGlobalStatistic>());
+        var stat = groupStats.GetOrAdd(name, static (n, g) => new GlobalStatistic<T>(g, n), group);
 
         return (GlobalStatistic<T>)stat;
     }


### PR DESCRIPTION
- Make `KnownColorTable` that's bind with `Color` readonly since we don't use it much and it's allocate a lot when long run
- Decrease allocation of `Get<T>` in `GlobalStatistics`
- Improve memory stream reliability in `BASSTrack`
- Fix color invalidation at wrong level lead to wrong `DrawAlpha` report

Before :
<img width="2178" height="963" alt="Screenshot 2026-07-07 at 17 29 35" src="https://github.com/user-attachments/assets/05bba5ff-d729-481a-ac15-499e7fb734d9" />
<img width="2172" height="702" alt="Screenshot 2026-07-07 at 17 29 53" src="https://github.com/user-attachments/assets/25381fcf-911c-40cd-bd76-84618a5b669b" />

After :
<img width="2185" height="596" alt="Screenshot 2026-07-08 at 10 34 07" src="https://github.com/user-attachments/assets/89301462-99fd-41be-8724-9f274b80be8c" />
<img width="2178" height="548" alt="Screenshot 2026-07-08 at 10 34 36" src="https://github.com/user-attachments/assets/e1541bab-09ff-41e4-9e1e-9dcb79df6439" />

