### PR TITLE
Fix slider step and min/max is not using type's value

### DIFF
--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
@@ -1,6 +1,7 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System.Numerics;
 using NUnit.Framework;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Drawables;
@@ -8,9 +9,9 @@ using Sakura.Framework.Graphics.Primitives;
 using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Graphics.UserInterface;
 using Sakura.Framework.Input;
-using Sakura.Framework.Maths;
 using Sakura.Framework.Testing;
 using Sakura.Framework.Utilities;
+using Vector2 = Sakura.Framework.Maths.Vector2;
 
 namespace Sakura.Framework.Tests.Visuals.UserInterface;
 
@@ -131,8 +132,10 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         });
         AddStep("Set initial value to 50", () => slider.Current.Value = 50f);
 
+        // Default KeyboardStep is 1 (absolute unit), which happens to equal 1% of this
+        // slider's 0-100 range - that's a coincidence of the range width, not the mechanism.
         AddStep("Press Right arrow", () => InputManager.PressKey(Key.Right));
-        AddAssert("Value increased by 1%", () => Precision.AlmostEquals(slider.Current.Value, 51f, 0.1f));
+        AddAssert("Value increased by KeyboardStep (1)", () => Precision.AlmostEquals(slider.Current.Value, 51f, 0.1f));
 
         AddStep("Press Left arrow", () => InputManager.PressKey(Key.Left));
         AddAssert("Value decreased back to 50", () => Precision.AlmostEquals(slider.Current.Value, 50f, 0.1f));
@@ -154,11 +157,13 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         });
         AddStep("Set initial value to 50", () => slider.Current.Value = 50f);
 
+        // Ctrl multiplies KeyboardStep (1) by 10 -> 10, which again equals 10% only because
+        // this slider's range happens to be 100 wide.
         AddStep("Press Ctrl+Right", () => InputManager.PressKey(Key.Right, KeyModifiers.Control));
-        AddAssert("Value jumped by 10%", () => Precision.AlmostEquals(slider.Current.Value, 60f, 0.1f));
+        AddAssert("Value jumped by 10x KeyboardStep (10)", () => Precision.AlmostEquals(slider.Current.Value, 60f, 0.1f));
 
         AddStep("Press Ctrl+Left", () => InputManager.PressKey(Key.Left, KeyModifiers.Control));
-        AddAssert("Value jumped back by 10%", () => Precision.AlmostEquals(slider.Current.Value, 50f, 0.1f));
+        AddAssert("Value jumped back by 10x KeyboardStep (10)", () => Precision.AlmostEquals(slider.Current.Value, 50f, 0.1f));
     }
 
     [Test]
@@ -274,7 +279,7 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
 
             for (int i = 1; i <= 10; i++)
                 slider.Current.Value = i * 10f;
-            
+
             Assert.That(slider.CurrentFillWidth, Is.EqualTo(1f).Within(0.01f), "continuous drive should snap the fill");
         });
     }
@@ -298,5 +303,229 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         });
 
         AddUntilStep("Fill eventually reaches full", () => Precision.AlmostEquals(slider.CurrentFillWidth, 1f, 0.02f));
+    }
+
+    /// <summary>
+    /// Regression test for the reported bug: a 0-255 slider with <see cref="SliderBar{T}.KeyboardStep"/>
+    /// set to 1 (e.g. a "Green level" colour slider) used to jump across the entire range per key
+    /// press, because KeyboardStep was interpreted as a fraction of the range (1 = 100% of range)
+    /// rather than an absolute step. It must now move by exactly 1.
+    /// </summary>
+    [Test]
+    public void TestKeyboardStepIsAbsoluteNotFractionOfRange()
+    {
+        BasicSliderBar<double> levelSlider = null!;
+
+        AddStep("Add 0-255 slider with KeyboardStep = 1 (mirrors the Green level slider)", () =>
+        {
+            TestContent.Add(levelSlider = new BasicSliderBar<double>
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Position = new Vector2(0, 100),
+                Size = new Vector2(220, 18),
+                MinValue = 0,
+                MaxValue = 255,
+                KeyboardStep = 1
+            });
+        });
+
+        AddStep("Click slider to focus", () =>
+        {
+            InputManager.MoveMouseTo(levelSlider);
+            InputManager.Click(MouseButton.Left);
+        });
+
+        AddStep("Set value to 0", () => levelSlider.Current.Value = 0);
+        AddStep("Press Right arrow once", () => InputManager.PressKey(Key.Right));
+        AddAssert("Value moved by exactly 1, not by the whole 255-wide range", () => levelSlider.Current.Value == 1);
+
+        AddStep("Press Right arrow 9 more times", () =>
+        {
+            for (int i = 0; i < 9; i++)
+                InputManager.PressKey(Key.Right);
+        });
+        AddAssert("Value is 10 after 10 total presses of step 1", () => levelSlider.Current.Value == 10);
+
+        AddStep("Press Ctrl+Right once", () => InputManager.PressKey(Key.Right, KeyModifiers.Control));
+        AddAssert("Ctrl+Right moves by 10x KeyboardStep (10)", () => levelSlider.Current.Value == 20);
+    }
+
+    /// <summary>
+    /// Regression test for the reported clamping bug: assigning to <see cref="SliderBar{T}.Current"/>
+    /// directly (not through mouse or keyboard input) must still be clamped to [MinValue, MaxValue].
+    /// </summary>
+    [Test]
+    public void TestDirectAssignmentClampsToBounds()
+    {
+        AddStep("Set value far above MaxValue directly", () => slider.Current.Value = 9999f);
+        AddAssert("Value clamped to MaxValue", () => slider.Current.Value == slider.MaxValue);
+
+        AddStep("Set value far below MinValue directly", () => slider.Current.Value = -9999f);
+        AddAssert("Value clamped to MinValue", () => slider.Current.Value == slider.MinValue);
+    }
+
+    /// <summary>
+    /// Narrowing MinValue/MaxValue after the fact must re-clamp whatever value is currently held,
+    /// not just future input.
+    /// </summary>
+    [Test]
+    public void TestNarrowingBoundsReClampsCurrentValue()
+    {
+        AddStep("Set value to 80", () => slider.Current.Value = 80f);
+        AddStep("Lower MaxValue below the current value", () => slider.MaxValue = 50f);
+        AddAssert("Value re-clamped down to the new MaxValue", () => slider.Current.Value == 50f);
+
+        AddStep("Set value to 10 (still within [0, 50])", () => slider.Current.Value = 10f);
+        AddStep("Raise MinValue above the current value", () => slider.MinValue = 30f);
+        AddAssert("Value re-clamped up to the new MinValue", () => slider.Current.Value == 30f);
+
+        AddStep("Restore original bounds", () =>
+        {
+            slider.MinValue = 0f;
+            slider.MaxValue = 100f;
+        });
+    }
+
+    /// <summary>
+    /// Mirrors a real construction pattern (e.g. a "min area" slider with MinValue = 1): the
+    /// reactive's own default value (0) starts out below MinValue, and must be clamped up
+    /// immediately when MinValue is set - not left invalid until the user first interacts.
+    /// </summary>
+    [Test]
+    public void TestOutOfRangeDefaultValueClampsOnConstruction()
+    {
+        BasicSliderBar<double> areaSlider = null!;
+
+        AddStep("Add slider whose default value (0) starts below MinValue (1)", () =>
+        {
+            TestContent.Add(areaSlider = new BasicSliderBar<double>
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Position = new Vector2(0, 130),
+                Size = new Vector2(220, 18),
+                MinValue = 1,
+                MaxValue = 100
+            });
+        });
+
+        AddAssert("Current value was clamped up to MinValue immediately, not left at 0", () => Precision.AlmostEquals(areaSlider.Current.Value, 1));
+    }
+
+    private void runKeyboardStepAndClampingCase<T>(string typeLabel, T min, T max, T step, T outOfRangeLow, T outOfRangeHigh)
+        where T : struct, INumber<T>, IMinMaxValue<T>
+    {
+        BasicSliderBar<T> numSlider = null!;
+
+        AddStep($"Add {typeLabel} slider [{min}, {max}] with KeyboardStep = {step}", () =>
+        {
+            TestContent.Add(numSlider = new BasicSliderBar<T>
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Position = new Vector2(0, 160),
+                Size = new Vector2(220, 18),
+                MinValue = min,
+                MaxValue = max,
+                KeyboardStep = step
+            });
+        });
+
+        AddStep("Click slider to focus", () =>
+        {
+            InputManager.MoveMouseTo(numSlider);
+            InputManager.Click(MouseButton.Left);
+        });
+
+        AddStep("Set value to MinValue", () => numSlider.Current.Value = min);
+        AddStep("Press Right arrow once", () => InputManager.PressKey(Key.Right));
+        AddAssert("Value moved by exactly KeyboardStep", () => numSlider.Current.Value == min + step);
+
+        AddStep("Press Home", () => InputManager.PressKey(Key.Home));
+        AddStep("Press Left arrow at MinValue", () => InputManager.PressKey(Key.Left));
+        AddAssert("Value stays at MinValue (clamped, not wrapped/underflowed)", () => numSlider.Current.Value == min);
+
+        AddStep("Press End", () => InputManager.PressKey(Key.End));
+        AddStep("Press Right arrow at MaxValue", () => InputManager.PressKey(Key.Right));
+        AddAssert("Value stays at MaxValue (clamped, not overflowed)", () => numSlider.Current.Value == max);
+
+        AddStep("Directly assign a value below MinValue", () => numSlider.Current.Value = outOfRangeLow);
+        AddAssert("Out-of-range low assignment clamps to MinValue", () => numSlider.Current.Value == min);
+
+        AddStep("Directly assign a value above MaxValue", () => numSlider.Current.Value = outOfRangeHigh);
+        AddAssert("Out-of-range high assignment clamps to MaxValue", () => numSlider.Current.Value == max);
+    }
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithInt() =>
+        runKeyboardStepAndClampingCase("int", 0, 255, 1, -50, 500);
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithNarrowRangeInt() =>
+        runKeyboardStepAndClampingCase("int (narrow range)", 0, 10, 3, -5, 20);
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithFloat() =>
+        runKeyboardStepAndClampingCase("float", 0f, 1f, 0.1f, -5f, 5f);
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithSignedFloat() =>
+        runKeyboardStepAndClampingCase("float (signed range)", -80f, 80f, 5f, -500f, 500f);
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithDouble() =>
+        runKeyboardStepAndClampingCase("double", 0.0, 255.0, 1.0, -100.0, 1000.0);
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithLong() =>
+        runKeyboardStepAndClampingCase("long", 0L, 1000L, 25L, -500L, 5000L);
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithByte() =>
+        runKeyboardStepAndClampingCase("byte", (byte)10, (byte)200, (byte)5, (byte)0, (byte)255);
+
+    [Test]
+    public void TestKeyboardStepAndClampingWithUInt() =>
+        runKeyboardStepAndClampingCase("uint", (uint)10, (uint)200, (uint)5, (uint)0, (uint)9999);
+
+    /// <summary>
+    /// decimal can't be used as a [TestCase] attribute argument (not a valid C# attribute constant
+    /// type), so it gets its own dedicated test rather than a case in the generic test above.
+    /// </summary>
+    [Test]
+    public void TestKeyboardStepAndClampingWithDecimal()
+    {
+        BasicSliderBar<decimal> decimalSlider = null!;
+
+        AddStep("Add decimal slider [0, 255] with KeyboardStep = 1", () =>
+        {
+            TestContent.Add(decimalSlider = new BasicSliderBar<decimal>
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Position = new Vector2(0, 190),
+                Size = new Vector2(220, 18),
+                MinValue = 0m,
+                MaxValue = 255m,
+                KeyboardStep = 1m
+            });
+        });
+
+        AddStep("Click slider to focus", () =>
+        {
+            InputManager.MoveMouseTo(decimalSlider);
+            InputManager.Click(MouseButton.Left);
+        });
+
+        AddStep("Set value to 0", () => decimalSlider.Current.Value = 0m);
+        AddStep("Press Right arrow once", () => InputManager.PressKey(Key.Right));
+        AddAssert("Value moved by exactly 1, not the whole range", () => decimalSlider.Current.Value == 1m);
+
+        AddStep("Directly assign a value above range", () => decimalSlider.Current.Value = 9999m);
+        AddAssert("Assignment above range clamps to MaxValue", () => decimalSlider.Current.Value == decimalSlider.MaxValue);
+
+        AddStep("Directly assign a value below range", () => decimalSlider.Current.Value = -9999m);
+        AddAssert("Assignment below range clamps to MinValue", () => decimalSlider.Current.Value == decimalSlider.MinValue);
     }
 }

--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
@@ -305,12 +305,6 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         AddUntilStep("Fill eventually reaches full", () => Precision.AlmostEquals(slider.CurrentFillWidth, 1f, 0.02f));
     }
 
-    /// <summary>
-    /// Regression test for the reported bug: a 0-255 slider with <see cref="SliderBar{T}.KeyboardStep"/>
-    /// set to 1 (e.g. a "Green level" colour slider) used to jump across the entire range per key
-    /// press, because KeyboardStep was interpreted as a fraction of the range (1 = 100% of range)
-    /// rather than an absolute step. It must now move by exactly 1.
-    /// </summary>
     [Test]
     public void TestKeyboardStepIsAbsoluteNotFractionOfRange()
     {
@@ -351,10 +345,6 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         AddAssert("Ctrl+Right moves by 10x KeyboardStep (10)", () => levelSlider.Current.Value == 20);
     }
 
-    /// <summary>
-    /// Regression test for the reported clamping bug: assigning to <see cref="SliderBar{T}.Current"/>
-    /// directly (not through mouse or keyboard input) must still be clamped to [MinValue, MaxValue].
-    /// </summary>
     [Test]
     public void TestDirectAssignmentClampsToBounds()
     {
@@ -364,11 +354,7 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         AddStep("Set value far below MinValue directly", () => slider.Current.Value = -9999f);
         AddAssert("Value clamped to MinValue", () => slider.Current.Value == slider.MinValue);
     }
-
-    /// <summary>
-    /// Narrowing MinValue/MaxValue after the fact must re-clamp whatever value is currently held,
-    /// not just future input.
-    /// </summary>
+    
     [Test]
     public void TestNarrowingBoundsReClampsCurrentValue()
     {
@@ -387,11 +373,6 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         });
     }
 
-    /// <summary>
-    /// Mirrors a real construction pattern (e.g. a "min area" slider with MinValue = 1): the
-    /// reactive's own default value (0) starts out below MinValue, and must be clamped up
-    /// immediately when MinValue is set - not left invalid until the user first interacts.
-    /// </summary>
     [Test]
     public void TestOutOfRangeDefaultValueClampsOnConstruction()
     {

--- a/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
@@ -11,7 +11,7 @@ using Vector2 = Sakura.Framework.Maths.Vector2;
 
 namespace Sakura.Framework.Graphics.UserInterface;
 
-public partial class BasicSliderBar<T> : SliderBar<T> where T : struct, INumber<T>
+public partial class BasicSliderBar<T> : SliderBar<T> where T : struct, INumber<T>, IMinMaxValue<T>
 {
     public Color BackgroundColor { get; set; } = Color.DarkGreen;
     public Color SelectionColor { get; set; } = Color.LimeGreen;

--- a/Sakura.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/Sakura.Framework/Graphics/UserInterface/SliderBar.cs
@@ -12,21 +12,40 @@ namespace Sakura.Framework.Graphics.UserInterface;
 /// <summary>
 /// Abstract base for slider/scrubber controls.
 /// </summary>
-public abstract partial class SliderBar<T> : Container where T : struct, INumber<T>
+public abstract partial class SliderBar<T> : Container where T : struct, INumber<T>, IMinMaxValue<T>
 {
     /// <summary>
-    /// The current value, clamped between <see cref="MinValue"/> and <see cref="MaxValue"/>.
+    /// The current value. Assigning to <see cref="ReactiveNumber{T}.Value"/> (directly, via binding,
+    /// or via mouse/keyboard input) is always clamped between <see cref="MinValue"/> and <see cref="MaxValue"/>.
     /// </summary>
-    public Reactive<T> Current { get; } = new Reactive<T>(T.Zero);
-
-    public T MinValue { get; set; }
-    public T MaxValue { get; set; }
+    public ReactiveNumber<T> Current { get; } = new ReactiveNumber<T>(T.Zero);
 
     /// <summary>
-    /// How much one arrow-key press moves the value as a fraction of the total range.
-    /// Defaults to 1/100 (1 %). Ctrl+Arrow uses 10× this step.
+    /// The minimum value of the slider. Backed by <see cref="Current"/>'s own min bound, so the
+    /// current value is re-clamped automatically whenever this changes.
     /// </summary>
-    public float KeyboardStep { get; set; } = 0.01f;
+    public T MinValue
+    {
+        get => Current.MinValue;
+        set => Current.MinValue = value;
+    }
+
+    /// <summary>
+    /// The maximum value of the slider. Backed by <see cref="Current"/>'s own max bound, so the
+    /// current value is re-clamped automatically whenever this changes.
+    /// </summary>
+    public T MaxValue
+    {
+        get => Current.MaxValue;
+        set => Current.MaxValue = value;
+    }
+
+    /// <summary>
+    /// How much one arrow-key press moves the value, in the same units as <see cref="MinValue"/> /
+    /// <see cref="MaxValue"/> (i.e. an absolute step, not a fraction of the range).
+    /// Defaults to 1. Ctrl+Arrow moves 10× this amount.
+    /// </summary>
+    public T KeyboardStep { get; set; } = T.One;
 
     public override bool AcceptsFocus => true;
 
@@ -79,29 +98,32 @@ public abstract partial class SliderBar<T> : Container where T : struct, INumber
         if (!HasFocus) return false;
 
         bool ctrl = (e.Modifiers & KeyModifiers.Control) > 0;
-        float step = KeyboardStep * (ctrl ? 10f : 1f);
+        T step = ctrl ? KeyboardStep * T.CreateTruncating(10) : KeyboardStep;
 
-        float min = float.CreateTruncating(MinValue);
-        float max = float.CreateTruncating(MaxValue);
-        float cur = float.CreateTruncating(Current.Value);
-        float range = max - min;
+        T min = MinValue;
+        T max = MaxValue;
+        T cur = Current.Value;
 
-        if (range <= 0) return false;
+        if (max <= min) return false;
 
-        float delta = 0;
+        T newValue;
 
+        // Bounded via headroom (cur - min / max - cur, both always >= 0 since Current is kept
+        // within range) rather than a raw "cur ± step" followed by clamping, so unsigned numeric
+        // types (byte, uint, ulong, ...) never underflow/overflow when stepping near an edge.
         if (e.Key == Key.Left || e.Key == Key.Down)
-            delta = -step * range;
+            newValue = cur - T.Min(step, cur - min);
         else if (e.Key == Key.Right || e.Key == Key.Up)
-            delta = step * range;
+            newValue = cur + T.Min(step, max - cur);
         else if (e.Key == Key.Home)
-            delta = min - cur;
+            newValue = min;
         else if (e.Key == Key.End)
-            delta = max - cur;
+            newValue = max;
         else
             return false;
 
-        Current.Value = T.CreateTruncating(Math.Clamp(cur + delta, min, max));
+        // Current is a ReactiveNumber<T>, so this is clamped to [MinValue, MaxValue] as a safety net.
+        Current.Value = newValue;
         return true;
     }
 

--- a/Sakura.Framework/Testing/TestBrowserApp.cs
+++ b/Sakura.Framework/Testing/TestBrowserApp.cs
@@ -825,7 +825,7 @@ public partial class TestBrowserApp : App
         stepsFlow.Add(stepButton);
     }
 
-    private void generateStepVisual<T>(SliderStep<T> step) where T : struct, INumber<T>
+    private void generateStepVisual<T>(SliderStep<T> step) where T : struct, INumber<T>, IMinMaxValue<T>
     {
         stepsFlow.Add(new TestSliderStepControl<T>(step));
     }
@@ -1009,7 +1009,7 @@ public partial class TestBrowserApp : App
         }
     }
 
-    private partial class TestSliderStepControl<T> : Container where T : struct, INumber<T>
+    private partial class TestSliderStepControl<T> : Container where T : struct, INumber<T>, IMinMaxValue<T>
     {
         public TestSliderStepControl(SliderStep<T> step)
         {

--- a/Sakura.Framework/Testing/TestScene.cs
+++ b/Sakura.Framework/Testing/TestScene.cs
@@ -112,7 +112,7 @@ public abstract partial class TestScene : Container
         });
     }
 
-    public void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged) where T : struct, INumber<T>
+    public void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged) where T : struct, INumber<T>, IMinMaxValue<T>
     {
         steps.Add(new SliderStep<T>
         {

--- a/Sakura.Framework/Testing/TestStep.cs
+++ b/Sakura.Framework/Testing/TestStep.cs
@@ -27,7 +27,7 @@ public class WaitStep : TestStep
     public double Timeout { get; set; } = 10000;
 }
 
-public class SliderStep<T> : TestStep where T : struct, INumber<T>
+public class SliderStep<T> : TestStep where T : struct, INumber<T>, IMinMaxValue<T>
 {
     public T MinValue { get; set; }
     public T MaxValue { get; set; }


### PR DESCRIPTION
Now it's use the value from type itself since now it's required `IMinMaxValue`