### PR TITLE
Improvement on Metal renderer behavior

### DIFF
--- a/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
@@ -116,6 +116,7 @@ public sealed class MetalRenderer : IMetalRenderer
         // sample this white texel so the result is white × v_Color. Bound to slot 0 each frame.
         var whiteTex = new MetalTexture(device, 1, 1);
         whiteTex.Upload(new byte[] { 255, 255, 255, 255 });
+        MetalTexture.WhitePixel = whiteTex; // shared fallback for un-uploaded textures (see MetalTexture.Bind)
         WhitePixel = new Texture(whiteTex);
 
         logDeviceInfo();

--- a/Sakura.Framework/Graphics/Textures/MetalTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/MetalTexture.cs
@@ -21,6 +21,14 @@ public sealed class MetalTexture : INativeTexture
     public int Height { get; }
     public bool Available { get; private set; }
 
+    /// <summary>
+    /// Shared 1×1 white fallback, set once by <see cref="Rendering.Metal.MetalRenderer"/> at startup.
+    /// Bound in place of any texture that isn't <see cref="Available"/> yet (or has been disposed), so
+    /// an un-uploaded texture samples white (mirroring <see cref="GLTexture"/>'s behavior instead of
+    /// sampling a freshly allocated MTLTexture whose contents are undefined).
+    /// </summary>
+    public static MetalTexture WhitePixel { get; internal set; }
+
     public MetalTexture(nint device, int width, int height)
     {
         this.device = device;
@@ -81,8 +89,19 @@ public sealed class MetalTexture : INativeTexture
 
     public void Bind(int slot = 0)
     {
-        if (handle != nint.Zero)
-            SakuraMetalNative.sakura_metal_set_fragment_texture(device, handle, slot);
+        nint h = handle;
+
+        // fallback to white pixel, matching GLTexture.Bind behavior
+        if (!Available || h == nint.Zero)
+        {
+            var white = WhitePixel;
+            if (white == null || ReferenceEquals(white, this))
+                return;
+            h = white.handle;
+        }
+
+        if (h != nint.Zero)
+            SakuraMetalNative.sakura_metal_set_fragment_texture(device, h, slot);
     }
 
     public void Dispose()

--- a/Sakura.Framework/Timing/Scheduler.cs
+++ b/Sakura.Framework/Timing/Scheduler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Sakura.Framework.Statistic;
 
 namespace Sakura.Framework.Timing;
@@ -17,6 +18,10 @@ public class Scheduler
     private readonly List<ScheduledTask> tasks = new List<ScheduledTask>();
     private readonly List<ScheduledTask> tasksToAdd = new List<ScheduledTask>();
     private IClock? clock;
+
+    private readonly Lock locker = new Lock();
+    
+    private readonly List<ScheduledTask> dueBuffer = new List<ScheduledTask>();
 
     public Scheduler(IClock? clock = null)
     {
@@ -35,11 +40,14 @@ public class Scheduler
         if (delta == 0)
             return;
 
-        foreach (var task in tasks)
-            task.ExecutionTime += delta;
+        lock (locker)
+        {
+            foreach (var task in tasks)
+                task.ExecutionTime += delta;
 
-        foreach (var task in tasksToAdd)
-            task.ExecutionTime += delta;
+            foreach (var task in tasksToAdd)
+                task.ExecutionTime += delta;
+        }
     }
 
     /// <summary>
@@ -61,7 +69,8 @@ public class Scheduler
             throw new InvalidOperationException("Scheduler requires a clock to be set before adding delayed tasks.");
 
         var task = new ScheduledTask(action, clock.CurrentTime + delay);
-        tasksToAdd.Add(task);
+        lock (locker)
+            tasksToAdd.Add(task);
         return task;
     }
 
@@ -80,7 +89,8 @@ public class Scheduler
             throw new ArgumentException("Repeat interval must be greater than zero.", nameof(repeatInterval));
 
         var task = new ScheduledTask(action, clock.CurrentTime + delay, repeatInterval);
-        tasksToAdd.Add(task);
+        lock (locker)
+            tasksToAdd.Add(task);
         return task;
     }
 
@@ -94,12 +104,15 @@ public class Scheduler
         if (task == null)
             return false;
 
-        bool removed = tasksToAdd.Remove(task);
+        lock (locker)
+        {
+            bool removed = tasksToAdd.Remove(task);
 
-        if (tasks.Remove(task))
-            removed = true;
+            if (tasks.Remove(task))
+                removed = true;
 
-        return removed;
+            return removed;
+        }
     }
 
     /// <summary>
@@ -107,8 +120,11 @@ public class Scheduler
     /// </summary>
     public void Clear()
     {
-        tasks.Clear();
-        tasksToAdd.Clear();
+        lock (locker)
+        {
+            tasks.Clear();
+            tasksToAdd.Clear();
+        }
     }
 
 
@@ -137,38 +153,51 @@ public class Scheduler
     {
         if (clock == null) return;
 
-        stat_pending_tasks.Value = tasks.Count + tasksToAdd.Count;
-
         double currentTime = clock.CurrentTime;
+        bool anyDue;
 
-        if (tasksToAdd.Count > 0)
+        lock (locker)
         {
-            for (int i = 0; i < tasksToAdd.Count; i++)
-                insertSorted(tasksToAdd[i]);
-            tasksToAdd.Clear();
-        }
+            stat_pending_tasks.Value = tasks.Count + tasksToAdd.Count;
 
-        // The list is sorted by execution time: run due tasks from the front, then remove
-        // them in one range operation. Index-based iteration tolerates a task action
-        // mutating the scheduler (e.g. cancelling another task) without throwing.
-        int executed = 0;
-
-        while (executed < tasks.Count && currentTime >= tasks[executed].ExecutionTime)
-        {
-            var task = tasks[executed];
-            executed++;
-
-            task.Action();
-
-            if (task.RepeatInterval > 0)
+            if (tasksToAdd.Count > 0)
             {
-                task.ExecutionTime += task.RepeatInterval;
-                tasksToAdd.Add(task);
+                for (int i = 0; i < tasksToAdd.Count; i++)
+                    insertSorted(tasksToAdd[i]);
+                tasksToAdd.Clear();
+            }
+
+            int executed = 0;
+            while (executed < tasks.Count && currentTime >= tasks[executed].ExecutionTime)
+                executed++;
+
+            anyDue = executed > 0;
+
+            if (anyDue)
+            {
+                dueBuffer.Clear();
+                for (int i = 0; i < executed; i++)
+                    dueBuffer.Add(tasks[i]);
+
+                tasks.RemoveRange(0, executed);
+
+                for (int i = 0; i < dueBuffer.Count; i++)
+                {
+                    var task = dueBuffer[i];
+                    if (task.RepeatInterval > 0)
+                    {
+                        task.ExecutionTime += task.RepeatInterval;
+                        tasksToAdd.Add(task);
+                    }
+                }
             }
         }
 
-        if (executed > 0)
-            tasks.RemoveRange(0, Math.Min(executed, tasks.Count));
+        if (!anyDue)
+            return;
+
+        for (int i = 0; i < dueBuffer.Count; i++)
+            dueBuffer[i].Action();
     }
 }
 

--- a/native/sakura-metal/SakuraMetal.m
+++ b/native/sakura-metal/SakuraMetal.m
@@ -217,6 +217,17 @@ void sakura_metal_destroy(SakuraMetalDevice* device)
     {
         for (int i = 0; i < SAKURA_METAL_MAX_FRAMES_IN_FLIGHT; i++)
             dispatch_semaphore_wait(device->frameSemaphore, DISPATCH_TIME_FOREVER);
+
+        // The drain above always leaves dsema_value at 0 (every slot re-acquired), regardless of how
+        // many frames were actually in flight when destroy was called. libdispatch requires
+        // dsema_value >= dsema_orig (the value passed to dispatch_semaphore_create) at the moment the
+        // semaphore is deallocated — see _dispatch_semaphore_dispose in libdispatch's semaphore.c —
+        // otherwise it raises "Semaphore object deallocated while in use" (a fatal trap). We've just
+        // drained every in-flight frame ourselves and no further begin_frame will run during teardown,
+        // so nothing can legitimately be blocked on this semaphore anymore; these signals only restore
+        // the bookkeeping value libdispatch expects before the CFRelease below frees it.
+        for (int i = 0; i < SAKURA_METAL_MAX_FRAMES_IN_FLIGHT; i++)
+            dispatch_semaphore_signal(device->frameSemaphore);
     }
 
     if (device->device) CFRelease((__bridge CFTypeRef)device->device);
@@ -885,6 +896,17 @@ void sakura_metal_upload_texture_region(SakuraMetalTexture* texture, int x, int 
 
     // Regenerate the mip chain so minified sampling stays crisp (mirrors GL's per-upload
     // glGenerateMipmap). Uploads are infrequent after warmup, so a one-shot blit here is fine.
+    //
+    // waitUntilCompleted is required, not optional: GL's glGenerateMipmap is synchronous within
+    // GL's single in-order command stream, so a subsequent draw call on the same thread is
+    // guaranteed to see the finished mips. This blit has no equivalent implicit ordering with the
+    // *next* frame's render pass from the caller's point of view, so without waiting here, a sprite
+    // sampled below 100% scale (Rem's fit-to-window zoom, mip level > 0) can read stale or (for a
+    // brand-new texture) uninitialized mip data for one or more frames after Upload() returns —
+    // visible as a flash on slower GPUs, where the blit takes longer relative to frame time, and
+    // invisible on fast ones (e.g. M3 Max) where it usually finishes before the next sample. Uploads
+    // are already infrequent (see above), so the CPU stall here is cheap and removes the race
+    // entirely instead of relying on timing luck.
     if (texture->hasMips && texture->queue != nil)
     {
         id<MTLCommandBuffer> cb = [texture->queue commandBuffer];
@@ -892,6 +914,7 @@ void sakura_metal_upload_texture_region(SakuraMetalTexture* texture, int x, int 
         [blit generateMipmapsForTexture:texture->texture];
         [blit endEncoding];
         [cb commit];
+        [cb waitUntilCompleted];
     }
 }
 
@@ -900,9 +923,9 @@ void sakura_metal_destroy_texture(SakuraMetalTexture* texture)
     if (texture == NULL)
         return;
 
-    if (texture->texture) 
+    if (texture->texture)
         CFRelease((__bridge CFTypeRef)texture->texture);
-    if (texture->queue)   
+    if (texture->queue)
         CFRelease((__bridge CFTypeRef)texture->queue);
     free(texture);
 }


### PR DESCRIPTION
Native side :

- Make native `sakura_metal_upload_texture_region` call `waitUntilCompleted` to make a sprite sampled below 100% could read stale or uninitialized mip level for a frame or more after `Upload()` returned (this is noticable in slower GPU)
- For my sanity : `sakura_metal_destroy`'s shutdown drained re-acquires all `MAX_FRAMES_IN_FLIGHT` semaphore  slots to wait out in-flight frames which always leaves the semaphore's count below its original creation value. `libdispatch` requires that count be restored before release or it just crashes ("Semaphore object deallocated while in use") Fixed by signaling the semaphore back up to its original count after the drain, before `CFRelease`. Noticing during debug when a lot of texture change.

C# side :

- Make `MetalTexture.Bind()` falls back to a shared white pixel when a texture isn't `Available` follow `GLTexture` that have this guard

Bonus :

- Make scheduler more thread-safe, a bit sacrificed on performance really a bit but for better thread handling in multi-thread execution mode after compare to #107 

| Method                         | Mean         | Error      | StdDev    | Ratio  | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------------------- |-------------:|-----------:|----------:|-------:|--------:|-------:|----------:|------------:|
| Update_Empty                   |     3.788 ns |  0.0195 ns | 0.0162 ns |   1.00 |    0.01 |      - |         - |          NA |
| Update_100PendingFutureTasks   |     3.985 ns |  0.0059 ns | 0.0052 ns |   1.05 |    0.00 |      - |         - |          NA |
| Add100Delayed_UpdateOnce_Clear | 2,512.125 ns | 11.1847 ns | 9.9150 ns | 663.25 |    3.73 | 0.4768 |    4000 B |          NA |
| Add10Immediate_UpdateExecutes  |   166.110 ns |  0.7543 ns | 0.7056 ns |  43.86 |    0.26 | 0.0477 |     400 B |          NA |

Required after this PR :

- [x] Update `libsakura-metal` native lib
- [x] Bump nativelib NuGet