### PR TITLE
Make color emoji glyph ignore drawable's color on draw

### DIFF
--- a/Sakura.Framework.Tests/Visuals/Text/TestSpriteText.cs
+++ b/Sakura.Framework.Tests/Visuals/Text/TestSpriteText.cs
@@ -1,11 +1,15 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System.Collections.Generic;
+using System.Reflection;
 using NUnit.Framework;
 using Sakura.Framework.Allocation;
+using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Rendering.Vertex;
 using Sakura.Framework.Graphics.Text;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Testing;
@@ -139,5 +143,75 @@ public partial class TestSpriteText : TestScene
             // The headless font store returns null and has no fonts
             return noto == null || noto.Name == "NotoColorEmoji";
         });
+    }
+
+    [Test]
+    public void TestColorEmojiIgnoresTint()
+    {
+        SpriteText tintedEmojiText = null!;
+
+        AddStep("Add red-tinted colour emoji text", () => Add(tintedEmojiText = new SpriteText
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Color = Color.Red,
+            Text = "Red 👍",
+            Font = new FontUsage(size: 48, weight: "Regular", italics: false)
+        }));
+
+        AddAssert("colour glyph vertices are untinted while text glyph vertices are tinted red", () =>
+        {
+            var glyphs = getShapedGlyphs(tintedEmojiText);
+            var vertices = getTextVertices(tintedEmojiText);
+
+            // The headless font store produces no glyphs at all - nothing to assert against.
+            if (glyphs == null || glyphs.Count == 0)
+                return true;
+
+            bool sawColorGlyph = false;
+            bool sawTextGlyph = false;
+
+            for (int i = 0; i < glyphs.Count; i++)
+            {
+                var glyph = glyphs[i];
+                if (glyph.Texture == null)
+                    continue;
+
+                var vertexColor = vertices[i * 4].Color;
+
+                if (glyph.IsColorGlyph)
+                {
+                    sawColorGlyph = true;
+
+                    // Color emoji glyphs must keep their native RGB (identity), only alpha follows the tint.
+                    if (vertexColor.X < 0.99f || vertexColor.Y < 0.99f || vertexColor.Z < 0.99f)
+                        return false;
+                }
+                else
+                {
+                    sawTextGlyph = true;
+
+                    // Ordinary glyphs must be tinted red: full red, no green/blue.
+                    if (vertexColor.X < 0.99f || vertexColor.Y > 0.01f || vertexColor.Z > 0.01f)
+                        return false;
+                }
+            }
+
+            // Both kinds of glyphs must actually have been exercised for this assertion to be meaningful.
+            return sawColorGlyph && sawTextGlyph;
+        });
+    }
+
+    private static IReadOnlyList<TextGlyph>? getShapedGlyphs(SpriteText spriteText)
+    {
+        var field = typeof(SpriteText).GetField("shapedText", BindingFlags.NonPublic | BindingFlags.Instance);
+        var shapedText = field?.GetValue(spriteText) as ShapedText;
+        return shapedText?.Glyphs;
+    }
+
+    private static Vertex[] getTextVertices(SpriteText spriteText)
+    {
+        var field = typeof(SpriteText).GetField("textVertices", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (Vertex[])field!.GetValue(spriteText)!;
     }
 }

--- a/Sakura.Framework/Graphics/Drawables/SpriteText.cs
+++ b/Sakura.Framework/Graphics/Drawables/SpriteText.cs
@@ -218,6 +218,10 @@ public partial class SpriteText : Drawable
             DrawAlpha
         );
 
+        // Color glyphs (e.g. color emoji bitmaps) carry their own native colors and must not be
+        // recolored by the drawable's tint, only alpha (for fades) should still apply to them.
+        var colorGlyphDrawColor = new Vector4(1f, 1f, 1f, DrawAlpha);
+
         Vector2 originRelative = GetAnchorOriginVector(Origin);
         Vector2 availableSpace = DrawSize - contentSize;
 
@@ -237,8 +241,11 @@ public partial class SpriteText : Drawable
         float maxX = float.MinValue;
         float maxY = float.MinValue;
 
-        foreach (var glyph in shapedText.Glyphs)
+        var glyphs = shapedText.Glyphs;
+
+        for (int glyphIndex = 0; glyphIndex < glyphs.Count; glyphIndex++)
         {
+            var glyph = glyphs[glyphIndex];
             var texture = glyph.Texture;
             var pos = glyph.Position;
             var size = glyph.Size;
@@ -249,8 +256,8 @@ public partial class SpriteText : Drawable
             // contribute to the bounding box.
             if (texture == null)
             {
-                var gx = (pos.X + textOffset.X) * normalizationScale.X;
-                var gy = (pos.Y + textOffset.Y) * normalizationScale.Y;
+                float gx = (pos.X + textOffset.X) * normalizationScale.X;
+                float gy = (pos.Y + textOffset.Y) * normalizationScale.Y;
                 var p = Vector2.Transform(new Vector2(gx, gy), ModelMatrix);
 
                 minX = Math.Min(minX, p.X);
@@ -288,11 +295,13 @@ public partial class SpriteText : Drawable
             var uvTopLeft = new Vector2(uv.X, uv.Y);
             var uvBottomRight = new Vector2(uv.X + uv.Width, uv.Y + uv.Height);
 
+            var glyphColor = glyph.IsColorGlyph ? colorGlyphDrawColor : drawColor;
+
             // One indexed quad per glyph (TL, TR, BR, BL).
-            vertices[vIndex++] = new Vertex { Position = new Vector2(vTopLeft.X, vTopLeft.Y), TexCoords = uvTopLeft, Color = drawColor };
-            vertices[vIndex++] = new Vertex { Position = new Vector2(vTopRight.X, vTopRight.Y), TexCoords = new Vector2(uvBottomRight.X, uvTopLeft.Y), Color = drawColor };
-            vertices[vIndex++] = new Vertex { Position = new Vector2(vBottomRight.X, vBottomRight.Y), TexCoords = uvBottomRight, Color = drawColor };
-            vertices[vIndex++] = new Vertex { Position = new Vector2(vBottomLeft.X, vBottomLeft.Y), TexCoords = new Vector2(uvTopLeft.X, uvBottomRight.Y), Color = drawColor };
+            vertices[vIndex++] = new Vertex { Position = new Vector2(vTopLeft.X, vTopLeft.Y), TexCoords = uvTopLeft, Color = glyphColor };
+            vertices[vIndex++] = new Vertex { Position = new Vector2(vTopRight.X, vTopRight.Y), TexCoords = new Vector2(uvBottomRight.X, uvTopLeft.Y), Color = glyphColor };
+            vertices[vIndex++] = new Vertex { Position = new Vector2(vBottomRight.X, vBottomRight.Y), TexCoords = uvBottomRight, Color = glyphColor };
+            vertices[vIndex++] = new Vertex { Position = new Vector2(vBottomLeft.X, vBottomLeft.Y), TexCoords = new Vector2(uvTopLeft.X, uvBottomRight.Y), Color = glyphColor };
         }
 
         DrawRectangle = new RectangleF(minX, minY, maxX - minX, maxY - minY);
@@ -319,8 +328,26 @@ public partial class SpriteText : Drawable
             DrawAlpha
         );
 
-        for (int i = 0; i < currentVertexCount; i++)
-            textVertices[i].Color = drawColor;
+        // Color glyphs keep their native colors, only alpha follows the drawable's fade/tint.
+        var colorGlyphDrawColor = new Vector4(1f, 1f, 1f, DrawAlpha);
+
+        if (shapedText == null || shapedText.Glyphs.Count == 0)
+        {
+            for (int i = 0; i < currentVertexCount; i++)
+                textVertices[i].Color = drawColor;
+            return;
+        }
+
+        var glyphs = shapedText.Glyphs;
+        int vIndex = 0;
+
+        for (int glyphIndex = 0; glyphIndex < glyphs.Count; glyphIndex++)
+        {
+            var glyphColor = glyphs[glyphIndex].IsColorGlyph ? colorGlyphDrawColor : drawColor;
+
+            for (int i = 0; i < 4 && vIndex < currentVertexCount; i++, vIndex++)
+                textVertices[vIndex].Color = glyphColor;
+        }
     }
 
     protected override DrawNode CreateDrawNode() => new SpriteTextDrawNode();

--- a/Sakura.Framework/Graphics/Text/Font.cs
+++ b/Sakura.Framework/Graphics/Text/Font.cs
@@ -98,6 +98,13 @@ public class Font : IDisposable
         public Texture Texture;
         public int BitmapLeft;
         public int BitmapTop;
+
+        /// <summary>
+        /// Whether this glyph carries its own native colors (e.g. a color emoji bitmap), as opposed
+        /// to a grayscale anti-aliased outline glyph. Color glyphs must not be tinted by the
+        /// drawable's color, since doing so would recolor the emoji artwork.
+        /// </summary>
+        public bool IsColorGlyph;
     }
 
     public Font(string name, byte[] fontData, TextureAtlas atlas)
@@ -534,7 +541,8 @@ public class Font : IDisposable
                             Texture = null,
                             Position = new Vector2(cursorX / dpiScale, baselineY / dpiScale),
                             Size = new Vector2(xAdvance / dpiScale, 0),
-                            StartIndex = startIndex
+                            StartIndex = startIndex,
+                            IsColorGlyph = false
                         });
                         cursorX += xAdvance;
                         continue;
@@ -557,7 +565,8 @@ public class Font : IDisposable
                     Texture = data.Texture,
                     Position = new Vector2(finalX / dpiScale, finalY / dpiScale),
                     Size = new Vector2(scaledWidth / dpiScale, scaledHeight / dpiScale),
-                    StartIndex = startIndex
+                    StartIndex = startIndex,
+                    IsColorGlyph = data.IsColorGlyph
                 });
 
                 cursorX += xAdvance;
@@ -655,7 +664,8 @@ public class Font : IDisposable
         {
             Texture = texture,
             BitmapLeft = glyphSlotPtr->bitmap_left,
-            BitmapTop = glyphSlotPtr->bitmap_top
+            BitmapTop = glyphSlotPtr->bitmap_top,
+            IsColorGlyph = bitmap.pixel_mode == FT_Pixel_Mode_.FT_PIXEL_MODE_BGRA
         };
     }
 
@@ -740,6 +750,12 @@ public struct TextGlyph
     /// emoji surrogate pair) or vice versa (ligatures).
     /// </summary>
     public int StartIndex;
+
+    /// <summary>
+    /// Whether this glyph is a natively-coloured bitmap (e.g. color emoji) rather than a grayscale
+    /// outline glyph. Colour glyphs should be drawn without applying the drawable's tint color.
+    /// </summary>
+    public bool IsColorGlyph;
 }
 
 public class ShapedText


### PR DESCRIPTION
If you use color emoji with custom `Color` in drawable (e.g. set `Color` in `SpriteText`, now before this PR it will got tinted. This PR fix it by when draw use only `DrawAlpha` that got effected from drawable properties