### PR TITLE
Add support for multi-color info on drawable (gradient support) and color picker

### DIFF
--- a/Sakura.Framework.Tests/Graphics/ColorInfoTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ColorInfoTest.cs
@@ -1,0 +1,143 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Colors;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+public class ColorInfoTest
+{
+    [Test]
+    public void TestImplicitConversionFromColorIsSolid()
+    {
+        ColorInfo info = Color.Red;
+
+        Assert.That(info.HasSingleColour, Is.True);
+        Assert.That(info.TopLeft, Is.EqualTo(Color.Red));
+        Assert.That(info.TopRight, Is.EqualTo(Color.Red));
+        Assert.That(info.BottomLeft, Is.EqualTo(Color.Red));
+        Assert.That(info.BottomRight, Is.EqualTo(Color.Red));
+    }
+
+    [Test]
+    public void TestSolid()
+    {
+        var info = ColorInfo.Solid(Color.Lime);
+
+        Assert.That(info.HasSingleColour, Is.True);
+        Assert.That(info.TopLeft, Is.EqualTo(Color.Lime));
+    }
+
+    [Test]
+    public void TestGradientHorizontal()
+    {
+        var info = ColorInfo.GradientHorizontal(Color.Red, Color.Blue);
+
+        Assert.That(info.HasSingleColour, Is.False);
+        // Left edge (TL, BL) = left colour; right edge (TR, BR) = right colour.
+        Assert.That(info.TopLeft, Is.EqualTo(Color.Red));
+        Assert.That(info.BottomLeft, Is.EqualTo(Color.Red));
+        Assert.That(info.TopRight, Is.EqualTo(Color.Blue));
+        Assert.That(info.BottomRight, Is.EqualTo(Color.Blue));
+    }
+
+    [Test]
+    public void TestGradientVertical()
+    {
+        var info = ColorInfo.GradientVertical(Color.Red, Color.Blue);
+
+        Assert.That(info.HasSingleColour, Is.False);
+        // Top edge (TL, TR) = top colour; bottom edge (BL, BR) = bottom colour.
+        Assert.That(info.TopLeft, Is.EqualTo(Color.Red));
+        Assert.That(info.TopRight, Is.EqualTo(Color.Red));
+        Assert.That(info.BottomLeft, Is.EqualTo(Color.Blue));
+        Assert.That(info.BottomRight, Is.EqualTo(Color.Blue));
+    }
+
+    [Test]
+    public void TestValueEquality()
+    {
+        var a = ColorInfo.GradientHorizontal(Color.Red, Color.Blue);
+        var b = ColorInfo.GradientHorizontal(Color.Red, Color.Blue);
+        var c = ColorInfo.GradientHorizontal(Color.Red, Color.Green);
+
+        Assert.That(a, Is.EqualTo(b));
+        Assert.That(a == b, Is.True);
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+
+        Assert.That(a, Is.Not.EqualTo(c));
+        Assert.That(a != c, Is.True);
+    }
+
+    [Test]
+    public void TestSolidColorEqualsImplicitConversion()
+    {
+        ColorInfo fromColor = Color.White;
+        var solid = ColorInfo.Solid(Color.White);
+
+        Assert.That(fromColor, Is.EqualTo(solid));
+    }
+
+    [Test]
+    public void TestMultiplyAlpha()
+    {
+        var info = ColorInfo.Solid(Color.FromArgb(200, 10, 20, 30)).MultiplyAlpha(0.5f);
+
+        Assert.That(info.TopLeft.A, Is.EqualTo(100));
+        // RGB is untouched.
+        Assert.That(info.TopLeft.R, Is.EqualTo(10));
+        Assert.That(info.TopLeft.G, Is.EqualTo(20));
+        Assert.That(info.TopLeft.B, Is.EqualTo(30));
+    }
+
+    [Test]
+    public void TestMultiplyAlphaClampsToByteRange()
+    {
+        var info = ColorInfo.Solid(Color.FromArgb(200, 255, 255, 255)).MultiplyAlpha(2f);
+
+        Assert.That(info.TopLeft.A, Is.EqualTo(255));
+    }
+
+    [Test]
+    public void TestMultiplyAlphaPerCorner()
+    {
+        var info = new ColorInfo(
+            Color.FromArgb(100, 0, 0, 0),
+            Color.FromArgb(200, 0, 0, 0),
+            Color.FromArgb(50, 0, 0, 0),
+            Color.FromArgb(255, 0, 0, 0)).MultiplyAlpha(0.5f);
+
+        Assert.That(info.TopLeft.A, Is.EqualTo(50));
+        Assert.That(info.TopRight.A, Is.EqualTo(100));
+        Assert.That(info.BottomLeft.A, Is.EqualTo(25));
+        Assert.That(info.BottomRight.A, Is.EqualTo(127));
+    }
+
+    [Test]
+    public void TestLerpEndpoints()
+    {
+        // Build endpoints via FromArgb so they compare equal to Lerp's FromArgb-reconstructed
+        // corners (Color equality is identity-sensitive: a named colour != its ARGB twin).
+        var red = Color.FromArgb(255, 255, 0, 0);
+        var blue = Color.FromArgb(255, 0, 0, 255);
+        var a = ColorInfo.GradientHorizontal(red, blue);
+        var b = ColorInfo.GradientHorizontal(blue, red);
+
+        Assert.That(ColorInfo.Lerp(a, b, 0f), Is.EqualTo(a));
+        Assert.That(ColorInfo.Lerp(a, b, 1f), Is.EqualTo(b));
+    }
+
+    [Test]
+    public void TestLerpMidpointIsCornerWise()
+    {
+        var a = ColorInfo.Solid(Color.FromArgb(255, 0, 0, 0));
+        var b = ColorInfo.Solid(Color.FromArgb(255, 100, 100, 100));
+
+        var mid = ColorInfo.Lerp(a, b, 0.5f);
+
+        Assert.That(mid.TopLeft.R, Is.EqualTo(50));
+        Assert.That(mid.TopLeft.G, Is.EqualTo(50));
+        Assert.That(mid.TopLeft.B, Is.EqualTo(50));
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestColorInfo.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestColorInfo.cs
@@ -1,0 +1,119 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Extensions.ColorExtensions;
+using Sakura.Framework.Extensions.DrawableExtensions;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Testing;
+
+namespace Sakura.Framework.Tests.Visuals.Drawables;
+
+public partial class TestColorInfo : TestScene
+{
+    [SetUp]
+    public void SetUp() => AddStep("Clear", Clear);
+
+    private static Box centredBox() => new Box
+    {
+        Anchor = Anchor.Centre,
+        Origin = Anchor.Centre,
+        Size = new Vector2(400, 300),
+    };
+
+    [Test]
+    public void TestHorizontal()
+    {
+        AddStep("Add horizontal gradient", () => Add(new Box
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(400, 300),
+            ColorInfo = ColorInfo.GradientHorizontal(Color.Red, Color.Blue),
+        }));
+    }
+
+    [Test]
+    public void TestVertical()
+    {
+        AddStep("Add vertical gradient", () => Add(new Box
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(400, 300),
+            ColorInfo = ColorInfo.GradientVertical(Color.Yellow, Color.Purple),
+        }));
+    }
+
+    [Test]
+    public void TestFourCorners()
+    {
+        AddStep("Add four-corner gradient", () => Add(new Box
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(400, 300),
+            ColorInfo = new ColorInfo(Color.Red, Color.Lime, Color.Blue, Color.Yellow),
+        }));
+    }
+
+    [Test]
+    public void TestAlphaGradient()
+    {
+        AddStep("Add background", () => Add(new Box
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(400, 300),
+            Color = Color.White,
+        }));
+
+        AddStep("Add opaque→transparent overlay", () => Add(new Box
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(400, 300),
+            ColorInfo = ColorInfo.GradientHorizontal(Color.Red, Color.Red.WithAlpha((byte)0)),
+        }));
+    }
+
+    [Test]
+    public void TestGradientSurvivesFade()
+    {
+        Box box = null!;
+
+        AddStep("Add gradient box", () => Add(box = new Box
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(400, 300),
+            ColorInfo = ColorInfo.GradientHorizontal(Color.Cyan, Color.Magenta),
+        }));
+
+        AddStep("Loop fade out/in", () => box.FadeOut(1000).Then().FadeIn(1000).Loop());
+        AddStep("Fade out (instant check)", () => box.FadeTo(0.4f, 500));
+        AddStep("Fade in (instant check)", () => box.FadeTo(1f, 500));
+    }
+
+    [Test]
+    public void TestInteractive()
+    {
+        Box box = null!;
+
+        AddStep("Add box", () => Add(box = centredBox()));
+
+        AddStep("Solid red", () => box.ColorInfo = Color.Red);
+        AddStep("Horizontal (red -> blue)", () => box.ColorInfo = ColorInfo.GradientHorizontal(Color.Red, Color.Blue));
+        AddStep("Vertical (yellow -> purple)", () => box.ColorInfo = ColorInfo.GradientVertical(Color.Yellow, Color.Purple));
+        AddStep("Four corners", () => box.ColorInfo = new ColorInfo(Color.Red, Color.Lime, Color.Blue, Color.Yellow));
+
+        AddSliderStep("Alpha", 0f, 1f, 1f, alpha =>
+        {
+            if (box != null)
+                box.Alpha = alpha;
+        });
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestColorPicker.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestColorPicker.cs
@@ -1,0 +1,210 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Extensions.ColorExtensions;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.UserInterface;
+using Sakura.Framework.Input;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Reactive;
+using Sakura.Framework.Testing;
+
+namespace Sakura.Framework.Tests.Visuals.UserInterface;
+
+public partial class TestColorPicker : ManualInputManagerTestScene
+{
+    private BasicColorPicker picker = null!;
+    private SpriteText stateText = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        AddStep("Add picker", () =>
+        {
+            TestContent.Add(stateText = new SpriteText
+            {
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopLeft,
+                Margin = new MarginPadding(8),
+                Text = "Current: (none)",
+                Color = Color.White
+            });
+
+            picker = new BasicColorPicker
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            };
+
+            picker.Current.ValueChanged += e => stateText.Text = $"Current: {e.NewValue.ToHex()}";
+
+            TestContent.Add(picker);
+        });
+
+        AddUntilStep("wait for layout", () => picker.HueSlider.DrawRectangle.Width > 0);
+    }
+
+    private void clickAt(Drawable target, float fx, float fy)
+    {
+        var rect = target.DrawRectangle;
+        InputManager.MoveMouseTo(new Vector2(rect.X + fx * rect.Width, rect.Y + fy * rect.Height));
+        InputManager.Click(MouseButton.Left);
+    }
+
+    [Test]
+    public void TestDragSaturationValue()
+    {
+        // Start pinned to white (top-left of the square = zero saturation, full value).
+        AddStep("Reset to white", () => picker.Current.Value = Color.White);
+        AddAssert("Is white", () => picker.Current.Value == Color.White);
+
+        // Click the centre of the square: saturation ~0.5, value ~0.5.
+        AddStep("Click square centre", () => clickAt(picker.SaturationValueArea, 0.5f, 0.5f));
+        AddAssert("No longer white", () => picker.Current.Value != Color.White);
+        AddAssert("Value darkened below full", () =>
+        {
+            ColorExtensions.ToHSV(picker.Current.Value, out _, out _, out float v);
+            return v < 0.95f;
+        });
+    }
+
+    [Test]
+    public void TestDragHue()
+    {
+        // Pick a saturated, bright color first so hue is meaningful.
+        AddStep("Pick a saturated color", () => clickAt(picker.SaturationValueArea, 0.9f, 0.1f));
+
+        AddStep("Click hue far-left (red)", () => clickAt(picker.HueSlider, 0.02f, 0.5f));
+        AddAssert("Hue near red", () =>
+        {
+            ColorExtensions.ToHSV(picker.Current.Value, out float h, out _, out _);
+            return h < 0.1f || h > 0.9f;
+        });
+
+        AddStep("Click hue middle (cyan)", () => clickAt(picker.HueSlider, 0.5f, 0.5f));
+        AddAssert("Hue near cyan (0.5)", () =>
+        {
+            ColorExtensions.ToHSV(picker.Current.Value, out float h, out _, out _);
+            return h > 0.4f && h < 0.6f;
+        });
+    }
+
+    [Test]
+    public void TestDragUpdatesContinuously()
+    {
+        AddStep("Choose saturated color", () => clickAt(picker.SaturationValueArea, 0.9f, 0.1f));
+
+        Color afterLeft = default;
+        Color afterRight = default;
+
+        // Drag across the hue bar, the color must change while dragging (not just on release).
+        AddStep("Drag hue left→right", () =>
+        {
+            var rect = picker.HueSlider.DrawRectangle;
+            float y = rect.Y + rect.Height / 2f;
+            InputManager.MoveMouseTo(new Vector2(rect.X + rect.Width * 0.05f, y));
+            InputManager.PressButton(MouseButton.Left);
+            InputManager.MoveMouseTo(new Vector2(rect.X + rect.Width * 0.2f, y));
+            afterLeft = picker.Current.Value;
+            InputManager.MoveMouseTo(new Vector2(rect.X + rect.Width * 0.8f, y));
+            afterRight = picker.Current.Value;
+            InputManager.ReleaseButton(MouseButton.Left);
+        });
+
+        AddAssert("color changed mid-drag", () => afterLeft != afterRight);
+        AddAssert("Hue tracked toward the right", () =>
+        {
+            ColorExtensions.ToHSV(afterLeft, out float hl, out _, out _);
+            ColorExtensions.ToHSV(afterRight, out float hr, out _, out _);
+            return hr > hl;
+        });
+    }
+
+    [Test]
+    public void TestInteractingReleasesHexFocus()
+    {
+        // Focus the hex field, then interact with the square: focus must drop and the hex text must
+        // reflect the new color immediately (even on a single click, no drag).
+        AddStep("Focus hex input", () =>
+        {
+            InputManager.MoveMouseTo(picker.HexInput);
+            InputManager.Click(MouseButton.Left);
+        });
+        AddAssert("Hex focused", () => picker.HexInput!.HasFocus);
+
+        AddStep("Single click square", () => clickAt(picker.SaturationValueArea, 0.6f, 0.4f));
+        AddAssert("Hex no longer focused", () => !picker.HexInput!.HasFocus);
+        AddAssert("Hex text matches color", () => picker.HexInput!.Text.Value == picker.Current.Value.ToHex());
+    }
+
+    [Test]
+    public void TestExternalValue()
+    {
+        AddStep("Set to blue", () => picker.Current.Value = Color.Blue);
+        AddAssert("Current is blue", () => picker.Current.Value == Color.Blue);
+
+        AddStep("Set to green", () => picker.Current.Value = Color.Green);
+        AddAssert("Current is green", () => picker.Current.Value == Color.Green);
+    }
+
+    [Test]
+    public void TestHexInputUpdatesLive()
+    {
+        AddStep("Focus hex input + clear", () =>
+        {
+            InputManager.MoveMouseTo(picker.HexInput);
+            InputManager.Click(MouseButton.Left);
+            picker.HexInput.Text.Value = "";
+        });
+
+        // Type a full hex, the color should track the moment the value becomes valid.
+        AddStep("Type 00FF00", () => InputManager.TypeText("00FF00"));
+        AddAssert("Current is green", () => picker.Current.Value == ColorExtensions.FromHex("00FF00"));
+    }
+
+    [Test]
+    public void TestHexInputLengthLimited()
+    {
+        AddAssert("Length limit is 9", () => picker.HexInput.LengthLimit == 9);
+
+        AddStep("Focus + clear", () =>
+        {
+            InputManager.MoveMouseTo(picker.HexInput);
+            InputManager.Click(MouseButton.Left);
+            picker.HexInput.Text.Value = "";
+        });
+
+        AddStep("Type overly long text", () => InputManager.TypeText("0123456789ABCDEF"));
+        AddAssert("Truncated to limit", () => picker.HexInput.Text.Value.Length <= 9);
+    }
+
+    [Test]
+    public void TestBindExternalReactive()
+    {
+        var external = new Reactive<Color>(Color.White);
+
+        AddStep("Bind external reactive", () => picker.Current.BindTo(external));
+
+        AddStep("Set external to magenta", () => external.Value = Color.Magenta);
+        AddAssert("Picker follows external", () => picker.Current.Value == Color.Magenta);
+    }
+
+    [Test]
+    public void TestHueThenSaturationKeepsHue()
+    {
+        // dragging the value/saturation down to black must not lose the chosen hue,
+        // because HSV is kept authoritative independently of the (hue-less) black color.
+        AddStep("Choose green hue", () => clickAt(picker.HueSlider, 1f / 3f, 0.5f));
+        AddStep("Drag square to black corner", () => clickAt(picker.SaturationValueArea, 0f, 1f));
+
+        AddStep("Return square to full color", () => clickAt(picker.SaturationValueArea, 1f, 0f));
+        AddAssert("Hue is still green-ish", () =>
+        {
+            ColorExtensions.ToHSV(picker.Current.Value, out float h, out _, out _);
+            return h > 0.25f && h < 0.42f;
+        });
+    }
+}

--- a/Sakura.Framework/Extensions/ColorExtensions/ColorExtensions.cs
+++ b/Sakura.Framework/Extensions/ColorExtensions/ColorExtensions.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file for full license text.
 
 using System;
+using System.Collections.Generic;
 using Sakura.Framework.Graphics.Colors;
 
 namespace Sakura.Framework.Extensions.ColorExtensions;
@@ -313,6 +314,83 @@ public static class ColorExtensions
     }
 
     /// <summary>
+    /// Decomposes a <see cref="Color"/> into HSV (Hue, Saturation, Value/Brightness) components,
+    /// each in the range 0 to 1. This is the model used by the classic saturation/value square +
+    /// hue slider colour picker, and is distinct from the HSL model used by <see cref="ToHSL"/>.
+    /// </summary>
+    /// <param name="color">The color to decompose.</param>
+    /// <param name="h">Hue component (0 to 1).</param>
+    /// <param name="s">Saturation component (0 to 1).</param>
+    /// <param name="v">Value/brightness component (0 to 1).</param>
+    public static void ToHSV(Color color, out float h, out float s, out float v)
+    {
+        float r = color.R / 255f;
+        float g = color.G / 255f;
+        float b = color.B / 255f;
+
+        float max = Math.Max(r, Math.Max(g, b));
+        float min = Math.Min(r, Math.Min(g, b));
+        float delta = max - min;
+
+        v = max;
+        s = max <= 0f ? 0f : delta / max;
+
+        if (delta <= 0f)
+        {
+            h = 0f; // achromatic (grey) — hue is undefined, report 0
+            return;
+        }
+
+        if (max == r)
+            h = (g - b) / delta + (g < b ? 6f : 0f);
+        else if (max == g)
+            h = (b - r) / delta + 2f;
+        else
+            h = (r - g) / delta + 4f;
+
+        h /= 6f;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Color"/> from HSV (Hue, Saturation, Value/Brightness) values, each in
+    /// the range 0 to 1. Companion to <see cref="ToHSV"/>.
+    /// </summary>
+    /// <param name="h">Hue component (0 to 1).</param>
+    /// <param name="s">Saturation component (0 to 1).</param>
+    /// <param name="v">Value/brightness component (0 to 1).</param>
+    /// <param name="alpha">Alpha component (0 to 255), default is 255 (opaque).</param>
+    /// <returns>The corresponding <see cref="Color"/>.</returns>
+    public static Color FromHSV(float h, float s, float v, byte alpha = 255)
+    {
+        h = ((h % 1f) + 1f) % 1f; // wrap hue into [0, 1)
+        s = Math.Clamp(s, 0f, 1f);
+        v = Math.Clamp(v, 0f, 1f);
+
+        float chroma = v * s;
+        float hPrime = h * 6f;
+        float x = chroma * (1f - Math.Abs(hPrime % 2f - 1f));
+        float m = v - chroma;
+
+        float r1, g1, b1;
+
+        switch ((int)hPrime % 6)
+        {
+            case 0: (r1, g1, b1) = (chroma, x, 0f); break;
+            case 1: (r1, g1, b1) = (x, chroma, 0f); break;
+            case 2: (r1, g1, b1) = (0f, chroma, x); break;
+            case 3: (r1, g1, b1) = (0f, x, chroma); break;
+            case 4: (r1, g1, b1) = (x, 0f, chroma); break;
+            default: (r1, g1, b1) = (chroma, 0f, x); break;
+        }
+
+        return Color.FromArgb(
+            alpha,
+            (byte)Math.Round((r1 + m) * 255f),
+            (byte)Math.Round((g1 + m) * 255f),
+            (byte)Math.Round((b1 + m) * 255f));
+    }
+
+    /// <summary>
     /// Returns a new <see cref="Color"/> with the specified hue (0 to 1) while preserving saturation and lightness.
     /// </summary>
     /// <param name="color">The original color.</param>
@@ -394,5 +472,31 @@ public static class ColorExtensions
             (byte)Random.Shared.Next(256),
             (byte)Random.Shared.Next(256)
         );
+    }
+
+    /// <summary>
+    /// Samples from a given linear gradient at a certain specified point.
+    /// </summary>
+    /// <param name="gradient">The gradient, defining the color stops and their positions (in [0-1] range) in the gradient.</param>
+    /// <param name="point">The point to sample the color at.</param>
+    /// <returns>A <see cref="Color"/> sampled from the linear gradient.</returns>
+    public static Color SampleFromLinearGradient(IReadOnlyList<(float position, Color color)> gradient, float point)
+    {
+        if (point < gradient[0].position)
+            return gradient[0].color;
+
+        for (int i = 0; i < gradient.Count - 1; i++)
+        {
+            var startStop = gradient[i];
+            var endStop = gradient[i + 1];
+
+            if (point >= endStop.position)
+                continue;
+
+            float t = (point - startStop.position) / (endStop.position - startStop.position);
+            return Lerp(startStop.color, endStop.color, t);
+        }
+
+        return gradient[^1].color;
     }
 }

--- a/Sakura.Framework/Graphics/Colors/ColorInfo.cs
+++ b/Sakura.Framework/Graphics/Colors/ColorInfo.cs
@@ -1,0 +1,104 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Sakura.Framework.Extensions.ColorExtensions;
+
+namespace Sakura.Framework.Graphics.Colors;
+
+/// <summary>
+/// A per-corner color for a quad. A solid color sets all four corners equal; gradients set them
+/// differently and let the renderer interpolate across the quad (blending happens in linear space
+/// on the GPU, since vertex colors are uploaded linear).
+/// </summary>
+/// <remarks>
+/// The corner names match the quad vertex order used by
+/// <see cref="Drawables.Drawable.GenerateVertices"/>
+/// (0 = TopLeft, 1 = TopRight, 2 = BottomRight, 3 = BottomLeft).
+/// </remarks>
+public readonly struct ColorInfo : IEquatable<ColorInfo>
+{
+    public readonly Color TopLeft;
+    public readonly Color TopRight;
+    public readonly Color BottomLeft;
+    public readonly Color BottomRight;
+
+    public ColorInfo(Color topLeft, Color topRight, Color bottomLeft, Color bottomRight)
+    {
+        TopLeft = topLeft;
+        TopRight = topRight;
+        BottomLeft = bottomLeft;
+        BottomRight = bottomRight;
+    }
+
+    /// <summary>
+    /// Implicitly treats a single <see cref="Color"/> as a solid <see cref="ColorInfo"/> so existing
+    /// <c>drawable.Color = someColour</c> call sites keep working.
+    /// </summary>
+    public static implicit operator ColorInfo(Color color) => Solid(color);
+
+    /// <summary>
+    /// A uniform color applied to all four corners.
+    /// </summary>
+    public static ColorInfo Solid(Color c) => new ColorInfo(c, c, c, c);
+
+    /// <summary>
+    /// A gradient interpolating from <paramref name="left"/> to <paramref name="right"/> along the X axis.
+    /// </summary>
+    public static ColorInfo GradientHorizontal(Color left, Color right) => new ColorInfo(left, right, left, right);
+
+    /// <summary>
+    /// A gradient interpolating from <paramref name="top"/> to <paramref name="bottom"/> along the Y axis.
+    /// </summary>
+    public static ColorInfo GradientVertical(Color top, Color bottom) => new ColorInfo(top, top, bottom, bottom);
+
+    /// <summary>
+    /// Whether all four corners are the same color (i.e. this is effectively a solid color).
+    /// </summary>
+    public bool HasSingleColour => TopLeft == TopRight && TopLeft == BottomLeft && TopLeft == BottomRight;
+
+    /// <summary>
+    /// Scales every corner's alpha by <paramref name="factor"/>, returning a new <see cref="ColorInfo"/>.
+    /// </summary>
+    public ColorInfo MultiplyAlpha(float factor)
+    {
+        if (factor < 0)
+            throw new ArgumentOutOfRangeException(nameof(factor), factor, "Cannot multiply alpha by a negative value.");
+
+        return new ColorInfo(
+            multiplyAlpha(TopLeft, factor),
+            multiplyAlpha(TopRight, factor),
+            multiplyAlpha(BottomLeft, factor),
+            multiplyAlpha(BottomRight, factor));
+    }
+
+    private static Color multiplyAlpha(Color c, float factor) => c.WithAlpha((byte)Math.Clamp(c.A * factor, 0, 255));
+
+    /// <summary>
+    /// Corner-wise linear interpolation between <paramref name="a"/> and <paramref name="b"/>, for
+    /// animating between two <see cref="ColorInfo"/>s.
+    /// </summary>
+    public static ColorInfo Lerp(ColorInfo a, ColorInfo b, float t) => new ColorInfo(
+        ColorExtensions.Lerp(a.TopLeft, b.TopLeft, t),
+        ColorExtensions.Lerp(a.TopRight, b.TopRight, t),
+        ColorExtensions.Lerp(a.BottomLeft, b.BottomLeft, t),
+        ColorExtensions.Lerp(a.BottomRight, b.BottomRight, t));
+
+    public bool Equals(ColorInfo other) =>
+        TopLeft == other.TopLeft
+        && TopRight == other.TopRight
+        && BottomLeft == other.BottomLeft
+        && BottomRight == other.BottomRight;
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is ColorInfo other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(TopLeft, TopRight, BottomLeft, BottomRight);
+
+    public static bool operator ==(ColorInfo left, ColorInfo right) => left.Equals(right);
+
+    public static bool operator !=(ColorInfo left, ColorInfo right) => !left.Equals(right);
+
+    public override string ToString() =>
+        HasSingleColour ? $"Solid({TopLeft})" : $"Gradient(TL={TopLeft}, TR={TopRight}, BL={BottomLeft}, BR={BottomRight})";
+}

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -100,7 +100,7 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
     private float rotation;
     private Axes relativeSizeAxes = Axes.None;
     private Axes relativePositionAxes = Axes.None;
-    private Color color = Color.White;
+    private ColorInfo colorInfo = Color.White;
     private float alpha = 1f;
     private MarginPadding margin;
     private MarginPadding padding;
@@ -309,15 +309,32 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
         }
     }
 
-    public Color Color
+    /// <summary>
+    /// The per-corner colour of this drawable. Set a <see cref="Colors.ColorInfo"/> gradient (e.g.
+    /// <see cref="Colors.ColorInfo.GradientHorizontal"/>) to have the renderer interpolate colour
+    /// across the quad, or a single <see cref="Colors.Color"/> (implicitly converted to a solid
+    /// <see cref="Colors.ColorInfo"/>) for a flat colour.
+    /// </summary>
+    public ColorInfo ColorInfo
     {
-        get => color;
+        get => colorInfo;
         set
         {
-            if (color == value) return;
-            color = value;
+            if (colorInfo.Equals(value)) return;
+            colorInfo = value;
             Invalidate(InvalidationFlags.Colour);
         }
+    }
+
+    /// <summary>
+    /// The flat colour of this drawable. This is a back-compat shim over <see cref="ColorInfo"/>:
+    /// the getter returns the top-left corner, and the setter collapses the whole drawable to a
+    /// solid colour. Use <see cref="ColorInfo"/> directly for gradients.
+    /// </summary>
+    public Color Color
+    {
+        get => colorInfo.TopLeft;
+        set => ColorInfo = value;
     }
 
     public float Alpha
@@ -587,16 +604,33 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
         GenerateVertices();
     }
 
+    /// <summary>
+    /// Converts an sRGB corner <see cref="Color"/> to a linear-space vertex colour, folding
+    /// <see cref="DrawAlpha"/> and the colour's own alpha into the <c>W</c> component (RGB is not
+    /// premultiplied). Shared by <see cref="GenerateVertices"/> and <see cref="UpdateDrawColour"/>
+    /// so both stay in sync.
+    /// </summary>
+    private Vector4 toLinear(Color c) => new Vector4(
+        ColorExtensions.SrgbToLinear(c.R),
+        ColorExtensions.SrgbToLinear(c.G),
+        ColorExtensions.SrgbToLinear(c.B),
+        DrawAlpha * (c.A / 255f));
+
+    /// <summary>
+    /// Writes the four corner colours of <see cref="colorInfo"/> into the existing quad vertices.
+    /// The corner→index mapping must match <see cref="GenerateVertices"/>
+    /// (0 = TopLeft, 1 = TopRight, 2 = BottomRight, 3 = BottomLeft).
+    /// </summary>
+    private void writeCornerColours()
+    {
+        Vertices[0].Color = toLinear(colorInfo.TopLeft);
+        Vertices[1].Color = toLinear(colorInfo.TopRight);
+        Vertices[2].Color = toLinear(colorInfo.BottomRight);
+        Vertices[3].Color = toLinear(colorInfo.BottomLeft);
+    }
+
     protected virtual void GenerateVertices()
     {
-        float rLinear = ColorExtensions.SrgbToLinear(Color.R);
-        float gLinear = ColorExtensions.SrgbToLinear(Color.G);
-        float bLinear = ColorExtensions.SrgbToLinear(Color.B);
-
-        float colorAlpha = Color.A / 255f;
-
-        var calculatedColor = new Vector4(rLinear, gLinear, bLinear, DrawAlpha * colorAlpha);
-
         // Default UVs (0 to 1)
         var uvRect = Texture?.UvRect ?? new RectangleF(0, 0, 1, 1);
         Vector2 uvTopLeft = new Vector2(uvRect.X, uvRect.Y);
@@ -673,10 +707,14 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
         var vBottomLeft = Vector2.Transform(new Vector2(drawTopLeft.X, drawBottomRight.Y), ModelMatrix);
         var vBottomRight = Vector2.Transform(new Vector2(drawBottomRight.X, drawBottomRight.Y), ModelMatrix);
 
-        Vertices[0] = new Vertex { Position = new Vector2(vTopLeft.X, vTopLeft.Y), TexCoords = uvTopLeft, Color = calculatedColor };
-        Vertices[1] = new Vertex { Position = new Vector2(vTopRight.X, vTopRight.Y), TexCoords = new Vector2(uvBottomRight.X, uvTopLeft.Y), Color = calculatedColor };
-        Vertices[2] = new Vertex { Position = new Vector2(vBottomRight.X, vBottomRight.Y), TexCoords = uvBottomRight, Color = calculatedColor };
-        Vertices[3] = new Vertex { Position = new Vector2(vBottomLeft.X, vBottomLeft.Y), TexCoords = new Vector2(uvTopLeft.X, uvBottomRight.Y), Color = calculatedColor };
+        Vertices[0] = new Vertex { Position = new Vector2(vTopLeft.X, vTopLeft.Y), TexCoords = uvTopLeft };
+        Vertices[1] = new Vertex { Position = new Vector2(vTopRight.X, vTopRight.Y), TexCoords = new Vector2(uvBottomRight.X, uvTopLeft.Y) };
+        Vertices[2] = new Vertex { Position = new Vector2(vBottomRight.X, vBottomRight.Y), TexCoords = uvBottomRight };
+        Vertices[3] = new Vertex { Position = new Vector2(vBottomLeft.X, vBottomLeft.Y), TexCoords = new Vector2(uvTopLeft.X, uvBottomRight.Y) };
+
+        // Per-corner colour (solid or gradient), converted to linear space. Must run after the
+        // vertices exist and match the corner→index mapping above.
+        writeCornerColours();
 
         // Calculate DrawRectangle in screen space
         float minX = Math.Min(vTopLeft.X, Math.Min(vTopRight.X, Math.Min(vBottomLeft.X, vBottomRight.X)));
@@ -1095,21 +1133,18 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
 
     /// <summary>
     /// Recomputes <see cref="DrawAlpha"/> and rewrites the color of the existing vertices
-    /// without regenerating geometry. Called for color-only invalidations.
-    /// Drawables whose vertices carry non-uniform colors must override this
+    /// without regenerating geometry. Called for color-only invalidations. Handles both solid
+    /// colours and per-corner gradients (via <see cref="ColorInfo"/>) for the default quad.
+    /// Drawables whose vertices don't follow the default quad layout must override this
     /// (falling back to <see cref="UpdateTransforms"/> is always correct).
     /// </summary>
     protected virtual void UpdateDrawColour()
     {
         DrawAlpha = (Parent?.DrawAlpha ?? 1f) * Alpha;
 
-        float rLinear = ColorExtensions.SrgbToLinear(Color.R);
-        float gLinear = ColorExtensions.SrgbToLinear(Color.G);
-        float bLinear = ColorExtensions.SrgbToLinear(Color.B);
-        var calculatedColor = new Vector4(rLinear, gLinear, bLinear, DrawAlpha * (Color.A / 255f));
-
-        for (int i = 0; i < Vertices.Length; i++)
-            Vertices[i].Color = calculatedColor;
+        // Rewrite per-corner colours so gradients survive the colour-only fast path (used by fades);
+        // toLinear folds the freshly-computed DrawAlpha into every corner.
+        writeCornerColours();
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/UserInterface/BasicColorPicker.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicColorPicker.cs
@@ -1,0 +1,77 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Maths;
+
+namespace Sakura.Framework.Graphics.UserInterface;
+
+/// <summary>
+/// A basic implementation of <see cref="ColorPicker"/>
+/// </summary>
+public partial class BasicColorPicker : ColorPicker
+{
+    public Color PanelColor { get; init; } = Color.FromArgb(255, 30, 30, 30);
+
+    public BasicColorPicker()
+    {
+        Masking = true;
+        CornerRadius = 8;
+    }
+
+    protected override Drawable CreateBackground() => new Box
+    {
+        RelativeSizeAxes = Axes.Both,
+        Color = PanelColor
+    };
+
+    protected override Drawable CreateSaturationValueMarker() => new CircularContainer
+    {
+        Size = new Vector2(18),
+        BorderThickness = 3,
+        BorderColor = Color.White,
+        Child = new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            Color = Color.Transparent
+        }
+    };
+
+    protected override Drawable CreateHueMarker() => new Container
+    {
+        Size = new Vector2(10, HueBarHeight + 8),
+        Masking = true,
+        CornerRadius = 4,
+        BorderThickness = 3,
+        BorderColor = Color.White,
+        Child = new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            Color = Color.Transparent
+        }
+    };
+
+    protected override TextBox? CreateHexInput() => new BasicTextBox
+    {
+        Size = new Vector2(0, HueBarHeight + 8)
+    };
+
+    private Box? previewFill;
+
+    protected override Drawable CreatePreview() => new Container
+    {
+        Size = new Vector2(64, HueBarHeight + 8),
+        Masking = true,
+        CornerRadius = 6,
+        Child = previewFill = new Box { RelativeSizeAxes = Axes.Both }
+    };
+
+    protected override void UpdatePreview(Drawable previewDrawable, Color color)
+    {
+        if (previewFill != null)
+            previewFill.Color = color;
+    }
+}

--- a/Sakura.Framework/Graphics/UserInterface/ColorPicker.cs
+++ b/Sakura.Framework/Graphics/UserInterface/ColorPicker.cs
@@ -1,0 +1,438 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using Sakura.Framework.Extensions.ColorExtensions;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Input;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Reactive;
+
+namespace Sakura.Framework.Graphics.UserInterface;
+
+/// <summary>
+/// Abstract base for a color picker
+/// </summary>
+public abstract partial class ColorPicker : Container
+{
+    /// <summary>
+    /// The currently selected color. Assigning to it (directly, via binding, or via UI input)
+    /// updates the whole picker, the alpha channel is preserved through HSV round-trips.
+    /// </summary>
+    public Reactive<Color> Current { get; } = new Reactive<Color>(Color.White);
+
+    /// <summary>
+    /// Pixel size of the saturation/value square
+    /// </summary>
+    public Vector2 SaturationValueAreaSize { get; init; } = new Vector2(300, 220);
+
+    /// <summary>
+    /// Pixel height of the hue slider bar.
+    /// </summary>
+    public float HueBarHeight { get; init; } = 24;
+
+    /// <summary>
+    /// Vertical spacing between the square, the hue bar, and the hex/preview row.
+    /// </summary>
+    public float Spacing { get; init; } = 10;
+
+    /// <summary>
+    /// The saturation/value square region. Exposed so tests and consumers can target it.
+    /// </summary>
+    public Drawable SaturationValueArea => svArea;
+
+    /// <summary>
+    /// The hue slider region. Exposed so tests and consumers can target it.
+    /// </summary>
+    public Drawable HueSlider => hueBar;
+
+    /// <summary>
+    /// The hex text input, or null if the picker was built without one.
+    /// </summary>
+    public TextBox? HexInput => hexInput;
+
+    // Authoritative HSV state, each in [0, 1].
+    private float hue;
+    private float saturation;
+    private float brightness = 1f;
+
+    // Guards the Current change handler from re-deriving HSV while we are the ones writing Current.
+    private bool applyingHsv;
+
+    private readonly SaturationValueSelector svArea;
+    private readonly HueSelector hueBar;
+    private readonly Box svHueLayer;
+    private readonly Drawable svMarker;
+    private readonly Drawable hueMarker;
+
+    private readonly TextBox? hexInput;
+    private readonly Drawable? preview;
+
+    protected ColorPicker()
+    {
+        AutoSizeAxes = Axes.Both;
+
+        float width = SaturationValueAreaSize.X;
+
+        svMarker = CreateSaturationValueMarker();
+        svMarker.Anchor = Anchor.TopLeft;
+        svMarker.Origin = Anchor.Centre;
+        svMarker.RelativePositionAxes = Axes.Both;
+
+        hueMarker = CreateHueMarker();
+        hueMarker.Anchor = Anchor.CentreLeft;
+        hueMarker.Origin = Anchor.Centre;
+        hueMarker.RelativePositionAxes = Axes.X;
+
+        svArea = new SaturationValueSelector
+        {
+            Size = SaturationValueAreaSize,
+            Masking = true,
+            PositionChanged = onSaturationValueChanged,
+            Children = new Drawable[]
+            {
+                svHueLayer = new Box { RelativeSizeAxes = Axes.Both },
+                // White (full saturation reveal) on the left fading to transparent on the right
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    ColorInfo = ColorInfo.GradientHorizontal(Color.White, Color.White.WithAlpha((byte)0))
+                },
+                // Transparent at the top fading to black at the bottom (value falls off downward).
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    ColorInfo = ColorInfo.GradientVertical(Color.Black.WithAlpha((byte)0), Color.Black)
+                },
+                new NonPositionalContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = svMarker
+                }
+            }
+        };
+
+        hueBar = new HueSelector
+        {
+            Size = new Vector2(width, HueBarHeight),
+            Masking = true,
+            HueChanged = onHueChanged,
+        };
+
+        hueBar.Add(new NonPositionalContainer
+        {
+            RelativeSizeAxes = Axes.Both,
+            Child = hueMarker
+        });
+
+        var layout = new FlowContainer
+        {
+            Direction = FlowDirection.Vertical,
+            AutoSizeAxes = Axes.Both,
+            Spacing = new Vector2(0, Spacing),
+        };
+
+        layout.Add(svArea);
+        layout.Add(hueBar);
+
+        hexInput = CreateHexInput();
+        preview = CreatePreview();
+
+        if (hexInput != null || preview != null)
+        {
+            var bottomRow = new FlowContainer
+            {
+                Direction = FlowDirection.Horizontal,
+                AutoSizeAxes = Axes.Both,
+                Spacing = new Vector2(Spacing, 0),
+            };
+
+            if (hexInput != null)
+            {
+                if (hexInput.Size.X <= 0)
+                    hexInput.Size = new Vector2(width - (preview?.Size.X ?? 0) - Spacing, HueBarHeight + 8);
+
+                // "#AARRGGBB" is the longest accepted form.
+                hexInput.LengthLimit = 9;
+                hexInput.OnCommit += onHexCommitted;
+                hexInput.Text.ValueChanged += onHexTextChanged;
+                bottomRow.Add(hexInput);
+            }
+
+            if (preview != null)
+                bottomRow.Add(preview);
+
+            layout.Add(bottomRow);
+        }
+
+        var background = CreateBackground();
+        if (background != null)
+        {
+            background.RelativeSizeAxes = Axes.Both;
+            AddInternal(background);
+        }
+
+        AddInternal(layout);
+
+        Current.ValueChanged += onCurrentChanged;
+    }
+
+    public override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        // Derive the initial HSV from Current and paint everything once.
+        deriveHsvFromCurrent(Current.Value);
+        updateVisuals();
+    }
+
+    /// <summary>Create the draggable marker shown over the saturation/value square.</summary>
+    protected abstract Drawable CreateSaturationValueMarker();
+
+    /// <summary>Create the draggable marker shown over the hue slider.</summary>
+    protected abstract Drawable CreateHueMarker();
+
+    /// <summary>Create the background drawn behind the whole picker. Return null for none.</summary>
+    protected virtual Drawable? CreateBackground() => null;
+
+    /// <summary>
+    /// Create the hex text input. Return null to omit the hex row. Its color is not managed by the
+    /// base; only its <see cref="TextBox.Text"/> is kept in sync with <see cref="Current"/>.
+    /// </summary>
+    protected virtual TextBox? CreateHexInput() => null;
+
+    /// <summary>
+    /// Create the preview swatch kept in sync with <see cref="Current"/>. Return null to omit it.
+    /// The base updates it via <see cref="UpdatePreview"/>, which defaults to setting
+    /// <see cref="Drawable.Color"/> — override that if the preview renders its color indirectly
+    /// (e.g. through a child).
+    /// </summary>
+    protected virtual Drawable? CreatePreview() => null;
+
+    /// <summary>
+    /// Applies <paramref name="color"/> to the drawable returned by <see cref="CreatePreview"/>.
+    /// Defaults to setting <see cref="Drawable.Color"/>.
+    /// </summary>
+    protected virtual void UpdatePreview(Drawable previewDrawable, Color color) => previewDrawable.Color = color;
+
+    private void onSaturationValueChanged(Vector2 normalised)
+    {
+        releaseHexFocus();
+        saturation = Math.Clamp(normalised.X, 0f, 1f);
+        brightness = Math.Clamp(1f - normalised.Y, 0f, 1f);
+        applyHsvToCurrent();
+    }
+
+    private void onHueChanged(float normalisedHue)
+    {
+        releaseHexFocus();
+        hue = Math.Clamp(normalisedHue, 0f, 1f);
+        applyHsvToCurrent();
+    }
+
+    /// <summary>
+    /// Drops focus off the hex input when the user starts interacting with the square/hue bar, so the
+    /// live-updating hex text is no longer suppressed (<see cref="updateVisuals"/> skips the field
+    /// while it has focus) and the field reflects the dragged color immediately.
+    /// </summary>
+    private void releaseHexFocus()
+    {
+        if (hexInput != null && hexInput.HasFocus)
+            GetContainingFocusManager()?.ChangeFocus(null);
+    }
+
+    private void onHexTextChanged(ValueChangedEvent<string> e)
+    {
+        // Only react to the user's own typing; programmatic syncs (from updateVisuals) happen while
+        // the field is unfocused, and must not feed back into Current.
+        if (hexInput == null || !hexInput.HasFocus)
+            return;
+
+        // Update live while typing, but silently ignore partial/invalid input until it parses.
+        if (tryParseHex(e.NewValue, out var parsed))
+            Current.Value = parsed;
+    }
+
+    private void onHexCommitted(string text)
+    {
+        if (tryParseHex(text, out var parsed))
+            Current.Value = parsed;
+        else if (hexInput != null)
+            // Invalid input on commit: revert the field to the current color.
+            hexInput.Text.Value = Current.Value.ToHex();
+    }
+
+    private static bool tryParseHex(string text, out Color color)
+    {
+        try
+        {
+            color = ColorExtensions.FromHex(text.Trim());
+            return true;
+        }
+        catch (Exception)
+        {
+            color = Color.Empty;
+            return false;
+        }
+    }
+
+    private void applyHsvToCurrent()
+    {
+        applyingHsv = true;
+        Current.Value = ColorExtensions.FromHSV(hue, saturation, brightness, Current.Value.A);
+        applyingHsv = false;
+
+        updateVisuals();
+    }
+
+    private void onCurrentChanged(ValueChangedEvent<Color> e)
+    {
+        // A UI drag already set the HSV state; only re-derive when the change came from elsewhere.
+        if (!applyingHsv)
+            deriveHsvFromCurrent(e.NewValue);
+
+        updateVisuals();
+    }
+
+    private void deriveHsvFromCurrent(Color color)
+    {
+        ColorExtensions.ToHSV(color, out float h, out float s, out float v);
+
+        // Hue is undefined for greyscale/black; keep the previous hue so the UI does not jump.
+        if (s > 0f && v > 0f)
+            hue = h;
+
+        saturation = s;
+        brightness = v;
+    }
+
+    private void updateVisuals()
+    {
+        svMarker.Position = new Vector2(saturation, 1f - brightness);
+        hueMarker.X = hue;
+
+        // The square's base layer is the fully-saturated, full-value form of the current hue.
+        svHueLayer.Color = ColorExtensions.FromHSV(hue, 1f, 1f);
+
+        if (preview != null)
+            UpdatePreview(preview, Current.Value);
+
+        // Don't stomp on the field while the user is typing in it.
+        if (hexInput != null && !hexInput.HasFocus)
+            hexInput.Text.Value = Current.Value.ToHex();
+    }
+
+    /// <summary>
+    /// The saturation/value square. Reports the drag position as a normalised (x, y) in [0, 1],
+    /// where x is saturation and y grows downward (so value = 1 - y).
+    /// </summary>
+    private partial class SaturationValueSelector : Container
+    {
+        public Action<Vector2>? PositionChanged;
+
+        public override bool OnMouseDown(MouseButtonEvent e)
+        {
+            if (e.Button != MouseButton.Left)
+                return false;
+
+            report(e.ScreenSpaceMousePosition);
+
+            // Let the base set IsDragged / invoke OnDragStart so the input manager captures us as the
+            // drag target then claim the event so we become that target.
+            base.OnMouseDown(e);
+            return true;
+        }
+
+        public override bool OnDragStart(MouseButtonEvent e) => e.Button == MouseButton.Left;
+
+        public override bool OnDrag(MouseEvent e)
+        {
+            report(e.ScreenSpaceMousePosition);
+            return true;
+        }
+
+        private void report(Vector2 screenSpacePos)
+        {
+            if (DrawSize.X <= 0 || DrawSize.Y <= 0)
+                return;
+
+            var local = ToLocalSpace(screenSpacePos);
+            PositionChanged?.Invoke(new Vector2(
+                Math.Clamp(local.X / DrawSize.X, 0f, 1f),
+                Math.Clamp(local.Y / DrawSize.Y, 0f, 1f)));
+        }
+    }
+
+    /// <summary>
+    /// The hue slider. Built from segments so a full 0..1 rainbow is expressed with the framework's
+    /// per-quad two-color gradients. Reports the drag position as a normalised hue in [0, 1].
+    /// </summary>
+    private partial class HueSelector : Container
+    {
+        public Action<float>? HueChanged;
+
+        private const int segments = 6;
+
+        public HueSelector()
+        {
+            for (int i = 0; i < segments; i++)
+            {
+                float start = (float)i / segments;
+                float end = (float)(i + 1) / segments;
+
+                AddInternal(new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    RelativePositionAxes = Axes.X,
+                    Width = 1f / segments,
+                    X = start,
+                    ColorInfo = ColorInfo.GradientHorizontal(
+                        ColorExtensions.FromHSV(start, 1f, 1f),
+                        ColorExtensions.FromHSV(end, 1f, 1f))
+                });
+            }
+        }
+
+        public override bool OnMouseDown(MouseButtonEvent e)
+        {
+            if (e.Button != MouseButton.Left)
+                return false;
+
+            report(e.ScreenSpaceMousePosition);
+
+            // Let the base set IsDragged / invoke OnDragStart so the input manager captures us as the
+            // drag target then claim the event so we become that target.
+            base.OnMouseDown(e);
+            return true;
+        }
+
+        public override bool OnDragStart(MouseButtonEvent e) => e.Button == MouseButton.Left;
+
+        public override bool OnDrag(MouseEvent e)
+        {
+            report(e.ScreenSpaceMousePosition);
+            return true;
+        }
+
+        private void report(Vector2 screenSpacePos)
+        {
+            if (DrawSize.X <= 0)
+                return;
+
+            float localX = ToLocalSpace(screenSpacePos).X;
+            HueChanged?.Invoke(Math.Clamp(localX / DrawSize.X, 0f, 1f));
+        }
+    }
+
+    /// <summary>
+    /// A pass-through container that never receives positional input, so the markers it holds never
+    /// steal mouse-down/drag from the interactive area beneath them.
+    /// </summary>
+    private partial class NonPositionalContainer : Container
+    {
+        public override bool HandlePositionalInput => false;
+    }
+}


### PR DESCRIPTION
Add `ColorInfo` that can store color up to 4 color (for each vertices corner). The normal `Color` still be usable in `Drawable` so no changed required. Also add color picker input UI component since now we can draw gradient box without override `GenerateVertices`