### PR TITLE
Raise multi-texture batch slots from 8 to 16 in all backend

### DIFF
--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
@@ -64,10 +64,14 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     private static readonly Color4 clear_colour = new Color4(0f, 0f, 0f, 1f);
 
     // Register mapping from the sakura-spirv HLSL cross-compile (resources ordered by (set,binding),
-    // per-kind counters): ProjectionBlock -> VS b0, MaskBlock -> PS b1, u_Textures[8] -> PS t0..t7 / s0.
+    // per-kind counters): ProjectionBlock -> VS b0, MaskBlock -> PS b1, u_Textures[16] -> PS t0..t15 / s0.
     private const int projection_cb_slot = 0;
     private const int mask_cb_slot = 1;
-    private const int texture_slot_count = 8;
+
+    // Matches u_Textures[] in shader.frag. D3D11 still draws one texture at slot 0 and forces
+    // TexIndex 0; the remaining slots are padded with the white SRV purely so the shader's declared
+    // array is fully bound.
+    private const int texture_slot_count = 16;
 
     private D3D11Shader mainShader;
     private D3D11Shader currentShader;

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -106,8 +106,22 @@ public class GLRenderer : IGLRenderer, IDisposable
     private int viewportHeight;
     private readonly Stack<Vector4> scissorStack = new Stack<Vector4>();
 
-    private readonly uint[] boundTextureHandles = new uint[8];
+    /// <summary>
+    /// Maximum number of textures the shader can sample in one draw. Matches the size of
+    /// <c>u_Textures[]</c> in shader.frag. The effective count used at runtime is clamped to
+    /// <c>GL_MAX_TEXTURE_IMAGE_UNITS</c> in <see cref="textureSlotCount"/>.
+    /// </summary>
+    private const int max_texture_slots = 16;
+
+    private readonly uint[] boundTextureHandles = new uint[max_texture_slots];
     private int boundTextureCount;
+
+    /// <summary>
+    /// Effective number of batch texture slots: <c>min(<see cref="max_texture_slots"/>,
+    /// GL_MAX_TEXTURE_IMAGE_UNITS)</c>. Set at initialization so the renderer never assigns a slot
+    /// index the driver cannot sample. Drives the slot-exhaustion check and the prefill loop.
+    /// </summary>
+    private int textureSlotCount = max_texture_slots;
 
     private float renderScaleX = 1.0f;
     private float renderScaleY = 1.0f;
@@ -137,7 +151,11 @@ public class GLRenderer : IGLRenderer, IDisposable
         public ClipState Clip;
     }
 
-    private static readonly int[] texture_samplers = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    /// <summary>
+    /// Sampler-to-texture-unit mapping for <c>u_Textures[]</c>, sized to <see cref="textureSlotCount"/>
+    /// and populated with <c>0..textureSlotCount-1</c> at initialization.
+    /// </summary>
+    private int[] textureSamplers = { 0, 1, 2, 3, 4, 5, 6, 7 };
 
     private struct ClipState
     {
@@ -170,6 +188,18 @@ public class GLRenderer : IGLRenderer, IDisposable
 
         Logger.Verbose("🚅 Hardware Acceleration Information");
         Logger.Verbose($"JIT intrinsic support: {RuntimeInfo.IsIntrinsicSupported}");
+
+        // Clamp the batch texture-slot count to what the driver can actually sample. The shader's
+        // u_Textures[] array is fixed at max_texture_slots (16, the GL spec minimum for
+        // GL_MAX_TEXTURE_IMAGE_UNITS), but a driver may expose exactly 16 or — defensively — fewer;
+        // never hand the shader a slot index the hardware can't sample.
+        gl.GetInteger(GetPName.MaxTextureImageUnits, out int maxTextureImageUnits);
+        textureSlotCount = Math.Clamp(maxTextureImageUnits, 1, max_texture_slots);
+        Logger.Verbose($"GL Max Texture Image Units: {maxTextureImageUnits} (using {textureSlotCount} batch slots)");
+
+        textureSamplers = new int[textureSlotCount];
+        for (int i = 0; i < textureSlotCount; i++)
+            textureSamplers[i] = i;
 
         tryEnableDebugOutput(extensions);
 
@@ -206,7 +236,7 @@ public class GLRenderer : IGLRenderer, IDisposable
             Logger.Error("GLRenderer: main shader is missing expected uniform block 'MaskBlock'.");
 
         shader.Use();
-        shader.SetUniformIntArray("u_Textures", texture_samplers);
+        shader.SetUniformIntArray("u_Textures", textureSamplers);
 
         maskState = default;
 
@@ -499,7 +529,7 @@ public class GLRenderer : IGLRenderer, IDisposable
                 return i;
         }
 
-        if (boundTextureCount < 8)
+        if (boundTextureCount < textureSlotCount)
         {
             int slot = boundTextureCount;
             glTexture.Bind(slot);
@@ -742,7 +772,7 @@ public class GLRenderer : IGLRenderer, IDisposable
         // to fix some strict drivers that complain about "unloadable texture".
         if (WhitePixel?.BackendTexture != null)
         {
-            for (int i = 0; i < 8; i++)
+            for (int i = 0; i < textureSlotCount; i++)
             {
                 whiteGLTexture.Bind(i);
             }

--- a/Sakura.Framework/Platform/DesktopAppHost.cs
+++ b/Sakura.Framework/Platform/DesktopAppHost.cs
@@ -47,16 +47,7 @@ public class DesktopAppHost : AppHost
     /// Returns the preferred renderer types in priority order for this platform.
     /// Override to change backend preference.
     /// </summary>
-    protected virtual IEnumerable<RendererType> GetPreferredRenderers()
-    {
-        if (RuntimeInfo.IsApple)
-            return [RendererType.Metal, RendererType.OpenGL];
-
-        if (RuntimeInfo.IsWindows)
-            return [RendererType.Direct3D11, RendererType.OpenGL];
-
-        return [RendererType.OpenGL];
-    }
+    protected virtual IEnumerable<RendererType> GetPreferredRenderers() => RendererTypes.GetPlatformRenderers();
 
     /// <summary>
     /// Creates a renderer instance for the given type. Return null to skip that type.

--- a/Sakura.Framework/Platform/RendererType.cs
+++ b/Sakura.Framework/Platform/RendererType.cs
@@ -1,6 +1,7 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Sakura.Framework.Platform;
@@ -13,4 +14,40 @@ public enum RendererType
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     OpenGL
+}
+
+/// <summary>
+/// Helpers for determining which <see cref="RendererType"/> values make sense on the current platform.
+/// </summary>
+public static class RendererTypes
+{
+    /// <summary>
+    /// The platform-native renderer types in fallback priority order (most preferred first),
+    /// excluding <see cref="RendererType.Automatic"/>. <see cref="RendererType.OpenGL"/> is always the
+    /// universal fallback, so it is the last entry on every platform. This is the order the automatic
+    /// selection walks when picking a backend.
+    /// </summary>
+    public static IReadOnlyList<RendererType> GetPlatformRenderers()
+    {
+        if (RuntimeInfo.IsApple)
+            return [RendererType.Metal, RendererType.OpenGL];
+
+        if (RuntimeInfo.IsWindows)
+            return [RendererType.Direct3D11, RendererType.OpenGL];
+
+        return [RendererType.OpenGL];
+    }
+
+    /// <summary>
+    /// The renderer types a user can select on the current platform, in display order:
+    /// <see cref="RendererType.Automatic"/> first, followed by each platform-native backend from
+    /// <see cref="GetPlatformRenderers"/>. Suitable for populating a settings dropdown — e.g. on macOS
+    /// this returns <c>[Automatic, Metal, OpenGL]</c>.
+    /// </summary>
+    public static IReadOnlyList<RendererType> GetSuitableRenderers()
+    {
+        var result = new List<RendererType> { RendererType.Automatic };
+        result.AddRange(GetPlatformRenderers());
+        return result;
+    }
 }

--- a/Sakura.Framework/Resources/Shaders/shader.frag
+++ b/Sakura.Framework/Resources/Shaders/shader.frag
@@ -12,7 +12,7 @@ layout(location = 6) in float v_ClipRadius;
 
 layout(location = 0) out vec4 FragColor;
 
-layout(set = 1, binding = 0) uniform sampler2D u_Textures[8];
+layout(set = 1, binding = 0) uniform sampler2D u_Textures[16];
 
 // Masking + border state. Field order matches the std140 layout in MaskBlock in C#
 //   vec4 u_BorderColor (offset 0)
@@ -109,6 +109,14 @@ void main()
     else if (index == 5) texColor = texture(u_Textures[5], v_TexCoords);
     else if (index == 6) texColor = texture(u_Textures[6], v_TexCoords);
     else if (index == 7) texColor = texture(u_Textures[7], v_TexCoords);
+    else if (index == 8) texColor = texture(u_Textures[8], v_TexCoords);
+    else if (index == 9) texColor = texture(u_Textures[9], v_TexCoords);
+    else if (index == 10) texColor = texture(u_Textures[10], v_TexCoords);
+    else if (index == 11) texColor = texture(u_Textures[11], v_TexCoords);
+    else if (index == 12) texColor = texture(u_Textures[12], v_TexCoords);
+    else if (index == 13) texColor = texture(u_Textures[13], v_TexCoords);
+    else if (index == 14) texColor = texture(u_Textures[14], v_TexCoords);
+    else if (index == 15) texColor = texture(u_Textures[15], v_TexCoords);
     else texColor = vec4(1.0);
 
     texColor *= v_Color;


### PR DESCRIPTION
Notice during D3D renderer implementation.

The only backend that "actually" batches multiple textures is OpenGL. Metal and D3D11 draw one texture at slot 0 and force TexIndex = 0, so for them this is purely about keeping the shared shader's u_Textures[] array fully bound.

## Changed by renderer

- OpenGL (`GLRenderer`) : Add max_texture_slots and query `GL_MAX_TEXTURE_IMAGE_UNITS` for check
- Direct3D11 (`D3D11Renderer`) : Increase texture_slot_count from 8 to 16
- Metal : Nothing change since it bind slot 0 and forces TexIndex 0 and handled by GPU (within the >=16 fragment-texture limit)