### PR TITLE
Fix transform got discarded when update thread stutter

### DIFF
--- a/Sakura.Framework.Benchmarks/Benchmarks/TransformBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/TransformBenchmarks.cs
@@ -57,8 +57,11 @@ public class TransformBenchmarks
     }
 
     /// <summary>
-    /// Scheduling cost: queue 10 transforms on one drawable, then clear them.
-    /// Tracks allocation per scheduled transform.
+    /// Scheduling cost check by queue 10 transforms on one drawable, then clear them.
+    /// Tracks allocation per scheduled transform. Note: with retarget-in-place the consecutive
+    /// same-member immediate calls here (three <c>MoveTo*</c> → Position, three fades → Alpha) redirect
+    /// the in-flight transform instead of accumulating, so the drawable holds ~5 transforms rather than
+    /// 10 - the transient objects are still built by the fluent helpers, so allocation is unchanged.
     /// </summary>
     [Benchmark]
     public void Schedule10Transforms_ThenClear()
@@ -73,6 +76,24 @@ public class TransformBenchmarks
         scheduleTarget.ResizeTo(new Vector2(32, 32), 300);
         scheduleTarget.MoveTo(new Vector2(0, 0), 100);
         scheduleTarget.FadeOut(100);
+
+        scheduleTarget.ClearTransforms();
+    }
+
+    /// <summary>
+    /// Replicate SliderBar: one property retargeted every frame. With retarget-in-place each subsequent
+    /// <c>ResizeTo</c> redirects the single in-flight transform rather than clearing and re-adding,
+    /// so the transform list stays bounded at one. Tracks the per-retarget cost (the same-member scan
+    /// plus the transient transform the fluent helper builds), which is the real cost of animating a
+    /// slider fill / scrubber that follows continuous input.
+    /// </summary>
+    [Benchmark]
+    public void RetargetChurn_SliderDrag()
+    {
+        // First call has nothing in flight and adds; the rest redirect it in place. A long duration
+        // keeps it in flight for the whole churn so every call after the first hits the retarget path.
+        for (int i = 0; i < 60; i++)
+            scheduleTarget.ResizeTo(new Vector2(16 + i % 40, 16), 1_000);
 
         scheduleTarget.ClearTransforms();
     }

--- a/Sakura.Framework.Tests/Graphics/BasicSliderBarFillTest.cs
+++ b/Sakura.Framework.Tests/Graphics/BasicSliderBarFillTest.cs
@@ -1,0 +1,108 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.UserInterface;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Regression test on the bug that slider bar transformation got stuck when update clock got stutter.
+/// </summary>
+[TestFixture]
+public class BasicSliderBarFillTest
+{
+    private ManualClock manual = null!;
+    private FramedClock rootClock = null!;
+    private Container root = null!;
+    private BasicSliderBar<float> slider = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock
+        {
+            CurrentTime = 1000
+        };
+        rootClock = new FramedClock(manual);
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = rootClock
+        };
+        slider = new BasicSliderBar<float>
+        {
+            MinValue = 0f,
+            MaxValue = 1f,
+            Size = new Vector2(200, 20),
+        };
+        root.Add(slider);
+
+        root.Load();
+        root.LoadComplete();
+
+        // Settle past the initial fill animation (LoadComplete fires one ResizeTo over
+        // FillAnimationDuration) so it can't clobber a later instant set.
+        for (int i = 0; i < 14; i++)
+            frame(null);
+    }
+
+    private void frame(Action? atFrameStart, double advance = 16)
+    {
+        manual.CurrentTime += advance;
+        rootClock.ProcessFrame();
+        atFrameStart?.Invoke();
+        root.UpdateSubTree();
+    }
+
+    [Test]
+    public void TestDragEveryFrameDoesNotFreezeFill()
+    {
+        float[] widths = new float[10];
+        for (int i = 0; i < 10; i++)
+        {
+            float value = (i + 1) / 10f;
+            frame(() => slider.Current.Value = value);
+            widths[i] = slider.CurrentFillWidth;
+        }
+
+        Assert.Multiple(() =>
+        {
+            for (int i = 1; i < widths.Length; i++)
+                Assert.That(widths[i], Is.GreaterThanOrEqualTo(widths[i - 1] - 0.001f), $"fill regressed at frame {i}: {string.Join(",", widths)}");
+
+            Assert.That(widths[^1], Is.GreaterThan(0.2f), $"fill froze during drag: {string.Join(",", widths)}");
+        });
+    }
+
+    [Test]
+    public void TestFillSettlesOnValue()
+    {
+        frame(() => slider.Current.Value = 0.8f);
+
+        // let the animation (150ms default) finish
+        for (int i = 0; i < 20; i++) frame(null, 20);
+
+        Assert.That(slider.CurrentFillWidth, Is.EqualTo(0.8f).Within(0.001f), "fill must settle exactly on the value");
+    }
+
+    [Test]
+    public void TestZeroDurationSnaps()
+    {
+        slider.FillAnimationDuration = 0;
+        frame(() => slider.Current.Value = 0.6f);
+
+        Assert.That(slider.CurrentFillWidth, Is.EqualTo(0.6f).Within(0.001f), "with no animation window the fill snaps immediately");
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/TransformRetargetTest.cs
+++ b/Sakura.Framework.Tests/Graphics/TransformRetargetTest.cs
@@ -1,0 +1,197 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using Sakura.Framework.Extensions.DrawableExtensions;
+using Sakura.Framework.Extensions.TransformSequenceExtensions;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Transforms;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Covers retarget-in-place: an immediate transform on a property that is already animating redirects
+/// the in-flight transform instead of restarting it. This is what stops a per-frame retarget (e.g. a
+/// slider fill tracking a drag) from freezing at progress 0 when the update rate is low.
+/// </summary>
+[TestFixture]
+public class TransformRetargetTest
+{
+    private ManualClock manual = null!;
+    private FramedClock rootClock = null!;
+    private Container root = null!;
+    private Box box = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock
+        {
+            CurrentTime = 1000
+        };
+        rootClock = new FramedClock(manual);
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = rootClock
+        };
+        box = new Box
+        {
+            Size = new Vector2(0, 20)
+        };
+        root.Add(box);
+
+        root.Load();
+        root.LoadComplete();
+
+        for (int i = 0; i < 3; i++)
+            frame(null);
+    }
+
+    /// <summary>
+    /// Advances one frame faithfully to the real app order: the update clock is advanced "before" the
+    /// per-frame action (which stands in for input dispatch), so a transform created in the action and
+    /// the transforms applied in <see cref="Drawable.UpdateSubTree"/> share the same frame clock value.
+    /// </summary>
+    private void frame(Action? atFrameStart, double advance = 16)
+    {
+        manual.CurrentTime += advance;
+        rootClock.ProcessFrame();
+        atFrameStart?.Invoke();
+        root.UpdateSubTree();
+    }
+
+    private static List<Transform> transformsOf(Drawable d)
+    {
+        var field = typeof(Drawable).GetField("transforms", BindingFlags.NonPublic | BindingFlags.Instance);
+        var list = (IEnumerable?)field!.GetValue(d);
+        var result = new List<Transform>();
+        if (list != null)
+            result.AddRange(list.Cast<Transform>());
+        return result;
+    }
+
+    [Test]
+    public void TestPerFrameRetargetDoesNotFreeze()
+    {
+        // Change the resize target every frame (a drag under a low/stuttering update rate). The fill
+        // must climb toward the target rather than freeze at 0.
+        float[] widths = new float[10];
+        for (int i = 0; i < 10; i++)
+        {
+            float target = (i + 1) / 10f * 200f;
+            frame(() => box.ResizeTo(new Vector2(target, 20), 150));
+            widths[i] = box.Size.X;
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            for (int i = 1; i < widths.Length; i++)
+                Assert.That(widths[i], Is.GreaterThanOrEqualTo(widths[i - 1] - 0.01f), $"regressed at frame {i}: {string.Join(",", widths)}");
+
+            Assert.That(widths[^1], Is.GreaterThan(40f), $"fill froze: {string.Join(",", widths)}");
+        }
+    }
+
+    [Test]
+    public void TestInFlightRetargetPreservesTimeline()
+    {
+        frame(() => box.ResizeTo(new Vector2(200, 20), 200));
+
+        // partway through the first animation
+        frame(null, 80);
+        float mid = box.Size.X;
+        Assert.That(mid, Is.GreaterThan(0f).And.LessThan(200f), "should be mid-animation");
+
+        // retarget to a smaller value; must continue from the current value, not snap to 0 or restart
+        frame(() => box.ResizeTo(new Vector2(120, 20), 200));
+        Assert.That(box.Size.X, Is.GreaterThan(0f), "must not snap back to start on retarget");
+
+        // let it finish and settle exactly on the latest target
+        for (int i = 0; i < 20; i++) frame(null, 20);
+        Assert.That(box.Size.X, Is.EqualTo(120f).Within(0.01f), "must settle on the latest target");
+    }
+
+    [Test]
+    public void TestOnlyOneInFlightTransformAccumulates()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            float target = (i + 1) / 10f * 200f;
+            frame(() => box.ResizeTo(new Vector2(target, 20), 150));
+        }
+
+        int sizeTransforms = transformsOf(box).Count(t => t.Member == TransformMember.Size);
+
+        Assert.That(sizeTransforms, Is.LessThanOrEqualTo(1), "per-frame retargets must not accumulate transforms");
+    }
+
+    [Test]
+    public void TestInterruptIsSmooth()
+    {
+        box.Alpha = 0;
+        frame(() => box.FadeTo(1f, 300));
+
+        frame(null, 150); // ~ halfway up
+        float mid = box.Alpha;
+        Assert.That(mid, Is.GreaterThan(0.2f).And.LessThan(1f), "fade-in should be partway");
+
+        // interrupt with an immediate fade-out: alpha must continue DOWN from the current value,
+        // not jump to 0 (a fresh transform would capture start=current, but the timeline is preserved
+        // so it eases from mid toward 0).
+        frame(() => box.FadeTo(0f, 300));
+        Assert.That(box.Alpha, Is.LessThanOrEqualTo(mid + 0.01f), "interrupt must not jump upward");
+
+        for (int i = 0; i < 30; i++) frame(null, 20);
+        Assert.That(box.Alpha, Is.EqualTo(0f).Within(0.01f), "interrupt must settle on the new target");
+    }
+
+    [Test]
+    public void TestChainingPreserved()
+    {
+        // FadeIn then (sequentially) FadeOut. The delayed FadeOut must NOT retarget the FadeIn; both
+        // legs must run.
+        box.Alpha = 0;
+        frame(() => box.TransformSequence().FadeTo(1f, 200).Then().FadeTo(0f, 200));
+
+        // during the first leg alpha rises
+        for (int i = 0; i < 8; i++) frame(null, 20);
+        float peak = box.Alpha;
+        Assert.That(peak, Is.GreaterThan(0.5f), "first leg (fade-in) must run");
+
+        // during the second leg alpha falls back down
+        for (int i = 0; i < 15; i++) frame(null, 20);
+        Assert.That(box.Alpha, Is.LessThan(0.2f), "second leg (fade-out) must run after the first");
+    }
+
+    [Test]
+    public void TestLoopingTransformNotRetargeted()
+    {
+        // a looping spin (Rotation, looping) plus an immediate RotateTo must coexist: the immediate one
+        // must not retarget/absorb the loop. (Spin uses member None, RotateTo uses Rotation, so this
+        // also verifies members don't accidentally collide.)
+        box.Spin(1000);
+        frame(() => box.RotateTo(45f, 100));
+
+        int looping = 0;
+        foreach (var t in transformsOf(box))
+            if (t.IsLooping)
+                looping++;
+
+        Assert.That(looping, Is.GreaterThanOrEqualTo(1), "the looping transform must survive an immediate same-axis add");
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
+++ b/Sakura.Framework.Tests/Visuals/UserInterface/TestBasicSliderBar.cs
@@ -19,8 +19,8 @@ namespace Sakura.Framework.Tests.Visuals.UserInterface;
 
 public partial class TestBasicSliderBar : ManualInputManagerTestScene
 {
-    private BasicSliderBar<float> slider;
-    private SpriteText valueText;
+    private BasicSliderBar<float> slider = null!;
+    private SpriteText valueText = null!;
 
     [SetUp]
     public void SetUp()
@@ -86,7 +86,7 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
             InputManager.MoveMouseTo(new Vector2(slider.DrawRectangle.X + slider.DrawRectangle.Width + 50, slider.DrawRectangle.Y + 10)));
         AddStep("Release mouse", () => InputManager.ReleaseButton(MouseButton.Left));
 
-        AddAssert("Value is max", () => slider.Current.Value == slider.MaxValue);
+        AddAssert("Value is max", () => Precision.AlmostEquals(slider.Current.Value, slider.MaxValue));
 
         AddStep("Move mouse to right of slider", () => InputManager.MoveMouseTo(new Vector2(slider.DrawRectangle.X + slider.DrawRectangle.Width, slider.DrawRectangle.Y + 10)));
         AddStep("Press mouse again", () => InputManager.PressButton(MouseButton.Left));
@@ -94,7 +94,7 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
             InputManager.MoveMouseTo(new Vector2(slider.DrawRectangle.X - 50, slider.DrawRectangle.Y + 10)));
         AddStep("Release mouse", () => InputManager.ReleaseButton(MouseButton.Left));
 
-        AddAssert("Value is min", () => slider.Current.Value == slider.MinValue);
+        AddAssert("Value is min", () => Precision.AlmostEquals(slider.Current.Value, slider.MinValue));
     }
 
     [Test]
@@ -181,10 +181,10 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
         AddStep("Set initial value to 50", () => slider.Current.Value = 50f);
 
         AddStep("Press End", () => InputManager.PressKey(Key.End));
-        AddAssert("Value is max", () => slider.Current.Value == slider.MaxValue);
+        AddAssert("Value is max", () => Precision.AlmostEquals(slider.Current.Value, slider.MaxValue));
 
         AddStep("Press Home", () => InputManager.PressKey(Key.Home));
-        AddAssert("Value is min", () => slider.Current.Value == slider.MinValue);
+        AddAssert("Value is min", () => Precision.AlmostEquals(slider.Current.Value, slider.MinValue));
     }
 
     [Test]
@@ -198,11 +198,11 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
 
         AddStep("Set value to max", () => slider.Current.Value = slider.MaxValue);
         AddStep("Press Right at max", () => InputManager.PressKey(Key.Right));
-        AddAssert("Value stays at max", () => slider.Current.Value == slider.MaxValue);
+        AddAssert("Value stays at max", () => Precision.AlmostEquals(slider.Current.Value, slider.MaxValue));
 
         AddStep("Set value to min", () => slider.Current.Value = slider.MinValue);
         AddStep("Press Left at min", () => InputManager.PressKey(Key.Left));
-        AddAssert("Value stays at min", () => slider.Current.Value == slider.MinValue);
+        AddAssert("Value stays at min", () => Precision.AlmostEquals(slider.Current.Value, slider.MinValue));
     }
 
     [Test]
@@ -225,7 +225,7 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
     public void TestTwoSlidersSameReactive()
     {
         BasicSliderBar<float> slider2 = null!;
-        SpriteText valueText2 = null!;
+        SpriteText valueText2;
 
         AddStep("Add second slider", () =>
         {
@@ -275,17 +275,18 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
     }
 
     [Test]
-    public void TestContinuousDriveSnapsFill()
+    public void TestContinuousDriveAnimatesFillToTarget()
     {
+        AddStep("Reset value to 0", () => slider.Current.Value = 0f);
+        AddWaitStep("Let fill settle at 0", 20);
+        
         AddStep("Drive value continuously to 100", () =>
         {
-            slider.Current.Value = 0f;
-
             for (int i = 1; i <= 10; i++)
                 slider.Current.Value = i * 10f;
-
-            Assert.That(slider.CurrentFillWidth, Is.EqualTo(1f).Within(0.01f), "continuous drive should snap the fill");
         });
+
+        AddUntilStep("Fill animates up to full without freezing", () => Precision.AlmostEquals(slider.CurrentFillWidth, 1f, 0.02f));
     }
 
     [Test]
@@ -336,27 +337,27 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
 
         AddStep("Set value to 0", () => levelSlider.Current.Value = 0);
         AddStep("Press Right arrow once", () => InputManager.PressKey(Key.Right));
-        AddAssert("Value moved by exactly 1, not by the whole 255-wide range", () => levelSlider.Current.Value == 1);
+        AddAssert("Value moved by exactly 1, not by the whole 255-wide range", () => Precision.AlmostEquals(levelSlider.Current.Value, 1));
 
         AddStep("Press Right arrow 9 more times", () =>
         {
             for (int i = 0; i < 9; i++)
                 InputManager.PressKey(Key.Right);
         });
-        AddAssert("Value is 10 after 10 total presses of step 1", () => levelSlider.Current.Value == 10);
+        AddAssert("Value is 10 after 10 total presses of step 1", () => Precision.AlmostEquals(levelSlider.Current.Value, 10));
 
         AddStep("Press Ctrl+Right once", () => InputManager.PressKey(Key.Right, KeyModifiers.Control));
-        AddAssert("Ctrl+Right moves by 10x KeyboardStep (10)", () => levelSlider.Current.Value == 20);
+        AddAssert("Ctrl+Right moves by 10x KeyboardStep (10)", () => Precision.AlmostEquals(levelSlider.Current.Value, 20));
     }
 
     [Test]
     public void TestDirectAssignmentClampsToBounds()
     {
         AddStep("Set value far above MaxValue directly", () => slider.Current.Value = 9999f);
-        AddAssert("Value clamped to MaxValue", () => slider.Current.Value == slider.MaxValue);
+        AddAssert("Value clamped to MaxValue", () => Precision.AlmostEquals(slider.Current.Value, slider.MaxValue));
 
         AddStep("Set value far below MinValue directly", () => slider.Current.Value = -9999f);
-        AddAssert("Value clamped to MinValue", () => slider.Current.Value == slider.MinValue);
+        AddAssert("Value clamped to MinValue", () => Precision.AlmostEquals(slider.Current.Value, slider.MinValue));
     }
 
     [Test]
@@ -364,11 +365,11 @@ public partial class TestBasicSliderBar : ManualInputManagerTestScene
     {
         AddStep("Set value to 80", () => slider.Current.Value = 80f);
         AddStep("Lower MaxValue below the current value", () => slider.MaxValue = 50f);
-        AddAssert("Value re-clamped down to the new MaxValue", () => slider.Current.Value == 50f);
+        AddAssert("Value re-clamped down to the new MaxValue", () => Precision.AlmostEquals(slider.Current.Value, 50f));
 
         AddStep("Set value to 10 (still within [0, 50])", () => slider.Current.Value = 10f);
         AddStep("Raise MinValue above the current value", () => slider.MinValue = 30f);
-        AddAssert("Value re-clamped up to the new MinValue", () => slider.Current.Value == 30f);
+        AddAssert("Value re-clamped up to the new MinValue", () => Precision.AlmostEquals(slider.Current.Value, 30f));
 
         AddStep("Restore original bounds", () =>
         {

--- a/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
+++ b/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
@@ -21,15 +21,27 @@ public static class TransformExtensions
     /// </summary>
     private static T addTransform<T>(this Drawable drawable, T transform, double duration) where T : Transform
     {
+        // An "immediate" transform starts now (no pending Wait()/Then()/sequence offset). Only these
+        // may retarget an in-flight transform; delayed/chained ones are always appended so sequences
+        // keep their ordering. Capture before TimeUntilTransformsCanStart is reset below.
+        bool immediate = drawable.TimeUntilTransformsCanStart == 0;
+
         double startTime = drawable.Clock.CurrentTime + drawable.TimeUntilTransformsCanStart;
         transform.StartTime = startTime;
         transform.EndTime = startTime + duration;
 
-        drawable.AddTransform(transform);
-
         // Reset the delay after a transform has been added.
         // This makes subsequent chains concurrent by default unless another Wait() or Then() is called.
         drawable.TimeUntilTransformsCanStart = 0;
+
+        // Redirect an already-running transform on the same property in place rather than adding a new
+        // one, so per-frame retargets (e.g. a slider fill following a drag) keep advancing instead of
+        // restarting their timeline every frame and freezing. Only for real (non-instant) animations,
+        // instant sets fall through and snap as before.
+        if (immediate && duration > 0 && !drawable.SuppressRetargetOnAdd && drawable.TryRetargetInFlight(transform))
+            return transform;
+
+        drawable.AddTransform(transform);
         return transform;
     }
 
@@ -328,7 +340,10 @@ public static class TransformExtensions
         int countBefore = drawable.TransformCount;
         double savedDelay = drawable.TimeUntilTransformsCanStart;
 
+        bool savedSuppress = drawable.SuppressRetargetOnAdd;
+        drawable.SuppressRetargetOnAdd = true;
         builder(drawable);
+        drawable.SuppressRetargetOnAdd = savedSuppress;
 
         var added = new List<Transform>();
         drawable.CollectTransformsSince(countBefore, added);
@@ -353,7 +368,10 @@ public static class TransformExtensions
         int countBefore = drawable.TransformCount;
         double savedDelay = drawable.TimeUntilTransformsCanStart;
 
+        bool savedSuppress = drawable.SuppressRetargetOnAdd;
+        drawable.SuppressRetargetOnAdd = true;
         builder(drawable);
+        drawable.SuppressRetargetOnAdd = savedSuppress;
 
         var added = new List<Transform>();
         drawable.CollectTransformsSince(countBefore, added);

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -1198,6 +1198,41 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
     }
 
     /// <summary>
+    /// When true, transforms added to this drawable are appended as-is and never retarget an in-flight
+    /// transform (see <see cref="TryRetargetInFlight"/>). Set by <see cref="Transforms.TransformSequence{T}"/>
+    /// and looping builders while they lay down their transforms, so a sequence's first transform can't
+    /// hijack an unrelated in-flight one.
+    /// </summary>
+    internal bool SuppressRetargetOnAdd { get; set; }
+
+    /// <summary>
+    /// Attempts to redirect an in-flight, non-looping transform on the same <see cref="Transform.Member"/>
+    /// toward <paramref name="incoming"/>'s destination, preserving that transform's timeline so its
+    /// eased progress continues instead of restarting from zero. Returns true when an existing transform
+    /// adopted the target, in which case the caller must *not* add <paramref name="incoming"/> as well.
+    /// Only in-flight transforms (started and not yet finished) are eligible, so delayed/queued and
+    /// completed transforms are left untouched.
+    /// </summary>
+    internal bool TryRetargetInFlight(Transform incoming)
+    {
+        if (transforms == null || incoming.Member == TransformMember.None)
+            return false;
+
+        double now = Clock.CurrentTime;
+
+        for (int i = 0; i < transforms.Count; i++)
+        {
+            var e = transforms[i];
+            if (e.IsLooping || e.Member != incoming.Member)
+                continue;
+            if (e.StartTime <= now && now < e.EndTime && e.TryRetargetFrom(incoming))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Removes a specific transform from this drawable, if present.
     /// </summary>
     internal void RemoveTransform(Transform transform)
@@ -1284,7 +1319,7 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
             foreach (var t in transforms)
                 t.Apply(this, t.EndTime);
         }
-        
+
         transforms?.Clear();
         TimeUntilTransformsCanStart = 0;
 

--- a/Sakura.Framework/Graphics/Transforms/Transform.cs
+++ b/Sakura.Framework/Graphics/Transforms/Transform.cs
@@ -12,10 +12,44 @@ using Sakura.Framework.Utilities;
 
 namespace Sakura.Framework.Graphics.Transforms;
 
+/// <summary>
+/// The drawable property a <see cref="Transform"/> animates. Used to retarget an in-flight transform
+/// on the same property in place (see <see cref="Transform.TryRetargetFrom"/>) rather than clearing and
+/// recreating it, which would restart its timeline and can freeze rapidly-retargeted animations.
+/// <see cref="None"/> transforms (callbacks, auto-size) never participate in retargeting.
+/// </summary>
+public enum TransformMember
+{
+    None,
+    Position,
+    Size,
+    Scale,
+    Rotation,
+    Alpha,
+    Color,
+    EdgeEffectColour,
+    EdgeEffectRadius,
+}
+
 public abstract class Transform : ITransform
 {
     public double StartTime { get; set; }
     public double EndTime { get; set; }
+
+    /// <summary>
+    /// The drawable property this transform animates. Transforms with the same non <see cref="TransformMember.None"/>
+    /// member can retarget one another in place while in flight.
+    /// </summary>
+    public virtual TransformMember Member => TransformMember.None;
+
+    /// <summary>
+    /// Redirects this in-flight transform toward <paramref name="incoming"/>'s destination while keeping
+    /// this transform's <see cref="StartTime"/>, start value and <see cref="EndTime"/> — i.e. its
+    /// animation timeline — so progress continues smoothly instead of restarting.
+    /// Returns false (the default) when the two transforms are not the same concrete kind, in which case
+    /// the caller adds <paramref name="incoming"/> as a new transform instead.
+    /// </summary>
+    public virtual bool TryRetargetFrom(Transform incoming) => false;
 
     /// <summary>
     /// The easing applied to this transform's progress. Accepts any built-in easing curve
@@ -111,6 +145,17 @@ public class MoveTransform : Transform
     private bool valueCaptured;
     public Vector2 StartValue;
     public Vector2 EndValue;
+
+    public override TransformMember Member => TransformMember.Position;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not MoveTransform m) return false;
+        EndValue = m.EndValue;
+        Easing = m.Easing;
+        return true;
+    }
+
     public override void Apply(Drawable drawable, double time)
     {
         if (!valueCaptured)
@@ -127,6 +172,17 @@ public class ResizeTransform : Transform
     private bool valueCaptured;
     public Vector2 StartValue;
     public Vector2 EndValue;
+
+    public override TransformMember Member => TransformMember.Size;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not ResizeTransform r) return false;
+        EndValue = r.EndValue;
+        Easing = r.Easing;
+        return true;
+    }
+
     public override void Apply(Drawable drawable, double time)
     {
         if (!valueCaptured)
@@ -143,6 +199,17 @@ public class ScaleTransform : Transform
     private bool valueCaptured;
     public Vector2 StartValue;
     public Vector2 EndValue;
+
+    public override TransformMember Member => TransformMember.Scale;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not ScaleTransform s) return false;
+        EndValue = s.EndValue;
+        Easing = s.Easing;
+        return true;
+    }
+
     public override void Apply(Drawable drawable, double time)
     {
         if (!valueCaptured)
@@ -159,6 +226,17 @@ public class AlphaTransform : Transform
     private bool valueCaptured;
     public float StartValue;
     public float EndValue;
+
+    public override TransformMember Member => TransformMember.Alpha;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not AlphaTransform a) return false;
+        EndValue = a.EndValue;
+        Easing = a.Easing;
+        return true;
+    }
+
     public override void Apply(Drawable drawable, double time)
     {
         if (!valueCaptured)
@@ -201,6 +279,17 @@ public class RotateTransform : Transform
     private bool valueCaptured;
     public float StartValue;
     public float EndValue;
+
+    public override TransformMember Member => TransformMember.Rotation;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not RotateTransform r) return false;
+        EndValue = r.EndValue;
+        Easing = r.Easing;
+        return true;
+    }
+
     public override void Apply(Drawable drawable, double time)
     {
         if (!valueCaptured)
@@ -217,6 +306,16 @@ public class ColorTransform : Transform
     private bool valueCaptured;
     public Color StartValue;
     public Color EndValue;
+
+    public override TransformMember Member => TransformMember.Color;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not ColorTransform c) return false;
+        EndValue = c.EndValue;
+        Easing = c.Easing;
+        return true;
+    }
 
     public override void Apply(Drawable drawable, double time)
     {
@@ -240,6 +339,16 @@ public class EdgeEffectColourTransform : Transform
     private bool valueCaptured;
     public Color StartValue;
     public Color EndValue;
+
+    public override TransformMember Member => TransformMember.EdgeEffectColour;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not EdgeEffectColourTransform e) return false;
+        EndValue = e.EndValue;
+        Easing = e.Easing;
+        return true;
+    }
 
     public override void Apply(Drawable drawable, double time)
     {
@@ -265,6 +374,16 @@ public class EdgeEffectRadiusTransform : Transform
     private bool valueCaptured;
     public float StartValue;
     public float EndValue;
+
+    public override TransformMember Member => TransformMember.EdgeEffectRadius;
+
+    public override bool TryRetargetFrom(Transform incoming)
+    {
+        if (incoming is not EdgeEffectRadiusTransform e) return false;
+        EndValue = e.EndValue;
+        Easing = e.Easing;
+        return true;
+    }
 
     public override void Apply(Drawable drawable, double time)
     {

--- a/Sakura.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/Sakura.Framework/Graphics/Transforms/TransformSequence.cs
@@ -63,7 +63,12 @@ public class TransformSequence<T> where T : Drawable
         target.TimeUntilTransformsCanStart = currentOffset;
         int countBefore = target.TransformCount;
 
+        // Sequence transforms are always appended, never retargeted onto an unrelated in-flight
+        // transform — even the first one, whose offset can be 0 and would otherwise look "immediate".
+        bool savedSuppress = target.SuppressRetargetOnAdd;
+        target.SuppressRetargetOnAdd = true;
         action(target);
+        target.SuppressRetargetOnAdd = savedSuppress;
 
         // Capture newly added transforms.
         target.CollectTransformsSince(countBefore, sequenceTransforms);

--- a/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
@@ -40,11 +40,6 @@ public partial class BasicSliderBar<T> : SliderBar<T> where T : struct, INumber<
     private readonly Box background;
     private readonly Box selection;
 
-    private float fillTarget;
-    private float fillFrom;
-    private double fillStartTime;
-    private bool animatingFill;
-
     /// <summary>
     /// The selection fill's current width as a fraction of the full track, in [0, 1].
     /// While an animation is in flight this reflects the in-progress (eased) value rather than the
@@ -78,47 +73,17 @@ public partial class BasicSliderBar<T> : SliderBar<T> where T : struct, INumber<
 
     protected override void OnValueChanged(T value)
     {
-        fillTarget = GetFillFraction();
+        float target = GetFillFraction();
 
+        // Snap instantly when there is no animation window or before the tree is live (no clock yet).
         if (FillAnimationDuration <= 0 || !IsLoaded)
         {
-            animatingFill = false;
-            setFill(fillTarget);
+            selection.Size = new Vector2(target, 1);
             return;
         }
 
-        fillFrom = selection.Size.X;
-        fillStartTime = Clock.CurrentTime;
-        animatingFill = true;
+        selection.ResizeTo(new Vector2(target, 1), FillAnimationDuration, FillAnimationEasing);
     }
-
-    public override void Update()
-    {
-        if (animatingFill)
-        {
-            double elapsed = Clock.CurrentTime - fillStartTime;
-
-            if (elapsed <= 0)
-            {
-                setFill(fillFrom);
-            }
-            else if (elapsed >= FillAnimationDuration)
-            {
-                setFill(fillTarget);
-                animatingFill = false;
-            }
-            else
-            {
-                EasingFunction easing = FillAnimationEasing;
-                float progress = (float)easing.Apply(elapsed / FillAnimationDuration);
-                setFill(fillFrom + (fillTarget - fillFrom) * progress);
-            }
-        }
-
-        base.Update();
-    }
-
-    private void setFill(float fraction) => selection.Size = new Vector2(fraction, 1);
 
     protected override void OnFocusGained() => BorderColor = FocusColor;
 


### PR DESCRIPTION
This came from the fix in https://github.com/HelloYeew/sakura/commit/a28ddb4894ec3d93d08979d9991b9c582b14d66a that I "intentionally" fix the frame pacing manually but the next day I think it's really not a right fix.

On investigation at first I think it's because of threading issues. But it's not, the real cause is the event racing issues `ClearTransforms()` + `ResizeTo()` every value change stamps `StartTime == now`, so the transform starts at progress 0 that frame and gets cleared before any later frame can advance it. Under a stuttering update rate, every frame carries a pending change -> perpetual progress 0 -> frozen.

Also add more benchmark and manual clock test since added a lot of flag to make event check more required. The performance is almost the same since it's just a field check and no allocation created as always