### PR TITLE
Refactor and rename all usage of british "colour" to american "color"

### DIFF
--- a/Sakura.Framework.Benchmarks/Benchmarks/UpdateLoopBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/UpdateLoopBenchmarks.cs
@@ -121,7 +121,7 @@ public class UpdateLoopBenchmarks
 
     /// <summary>
     /// Every box fades (alpha-only change) every frame. Quantifies how expensive a
-    /// colour-only invalidation is — ideally far cheaper than a positional one.
+    /// color-only invalidation is — ideally far cheaper than a positional one.
     /// </summary>
     [Benchmark]
     public void UpdateSubTree_AllChildrenFade()

--- a/Sakura.Framework.Tests/Graphics/ColorInfoTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ColorInfoTest.cs
@@ -13,7 +13,7 @@ public class ColorInfoTest
     {
         ColorInfo info = Color.Red;
 
-        Assert.That(info.HasSingleColour, Is.True);
+        Assert.That(info.HasSingleColor, Is.True);
         Assert.That(info.TopLeft, Is.EqualTo(Color.Red));
         Assert.That(info.TopRight, Is.EqualTo(Color.Red));
         Assert.That(info.BottomLeft, Is.EqualTo(Color.Red));
@@ -25,7 +25,7 @@ public class ColorInfoTest
     {
         var info = ColorInfo.Solid(Color.Lime);
 
-        Assert.That(info.HasSingleColour, Is.True);
+        Assert.That(info.HasSingleColor, Is.True);
         Assert.That(info.TopLeft, Is.EqualTo(Color.Lime));
     }
 
@@ -34,8 +34,8 @@ public class ColorInfoTest
     {
         var info = ColorInfo.GradientHorizontal(Color.Red, Color.Blue);
 
-        Assert.That(info.HasSingleColour, Is.False);
-        // Left edge (TL, BL) = left colour; right edge (TR, BR) = right colour.
+        Assert.That(info.HasSingleColor, Is.False);
+        // Left edge (TL, BL) = left color; right edge (TR, BR) = right color
         Assert.That(info.TopLeft, Is.EqualTo(Color.Red));
         Assert.That(info.BottomLeft, Is.EqualTo(Color.Red));
         Assert.That(info.TopRight, Is.EqualTo(Color.Blue));
@@ -47,8 +47,8 @@ public class ColorInfoTest
     {
         var info = ColorInfo.GradientVertical(Color.Red, Color.Blue);
 
-        Assert.That(info.HasSingleColour, Is.False);
-        // Top edge (TL, TR) = top colour; bottom edge (BL, BR) = bottom colour.
+        Assert.That(info.HasSingleColor, Is.False);
+        // Top edge (TL, TR) = top color; bottom edge (BL, BR) = bottom color.
         Assert.That(info.TopLeft, Is.EqualTo(Color.Red));
         Assert.That(info.TopRight, Is.EqualTo(Color.Red));
         Assert.That(info.BottomLeft, Is.EqualTo(Color.Blue));
@@ -118,7 +118,7 @@ public class ColorInfoTest
     public void TestLerpEndpoints()
     {
         // Build endpoints via FromArgb so they compare equal to Lerp's FromArgb-reconstructed
-        // corners (Color equality is identity-sensitive: a named colour != its ARGB twin).
+        // corners (Color equality is identity-sensitive: a named color != its ARGB twin).
         var red = Color.FromArgb(255, 255, 0, 0);
         var blue = Color.FromArgb(255, 0, 0, 255);
         var a = ColorInfo.GradientHorizontal(red, blue);

--- a/Sakura.Framework.Tests/Graphics/InvalidationCascadeTest.cs
+++ b/Sakura.Framework.Tests/Graphics/InvalidationCascadeTest.cs
@@ -390,7 +390,7 @@ public class InvalidationCascadeTest
     }
 
     [Test]
-    public void TestFadeUsesColourFastPathWithoutGeometryRegeneration()
+    public void TestFadeUsesColorFastPathWithoutGeometryRegeneration()
     {
         var box = new CountingBox
         {
@@ -407,10 +407,10 @@ public class InvalidationCascadeTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(box.TransformUpdates, Is.Zero, "A colour-only change must not regenerate geometry.");
-            Assert.That(box.DrawAlpha, Is.EqualTo(0.5f).Within(0.001f), "DrawAlpha must still update on the colour fast path.");
-            Assert.That(box.VerticesForAssert[0].Color.W, Is.EqualTo(0.5f).Within(0.001f), "Vertex alpha must be rewritten on the colour fast path.");
-            Assert.That(box.DrawRectangle.X, Is.EqualTo(40).Within(0.01f), "Geometry must be untouched by a colour-only change.");
+            Assert.That(box.TransformUpdates, Is.Zero, "A color-only change must not regenerate geometry.");
+            Assert.That(box.DrawAlpha, Is.EqualTo(0.5f).Within(0.001f), "DrawAlpha must still update on the color fast path.");
+            Assert.That(box.VerticesForAssert[0].Color.W, Is.EqualTo(0.5f).Within(0.001f), "Vertex alpha must be rewritten on the color fast path.");
+            Assert.That(box.DrawRectangle.X, Is.EqualTo(40).Within(0.01f), "Geometry must be untouched by a color-only change.");
         });
     }
 
@@ -449,7 +449,7 @@ public class InvalidationCascadeTest
         // a container (without AlwaysPresent) fading itself out to exactly zero alpha
         // must still tell its children their effective alpha dropped to zero. Container.Update()
         // previously returned early as soon as its own Alpha reached zero, before ever reaching the
-        // Colour-invalidation cascade so a child's cached DrawAlpha stayed stuck at its last
+        // Color-invalidation cascade so a child's cached DrawAlpha stayed stuck at its last
         // nonzero value forever (until the parent faded back in, which isn't affected by the same
         // early return).
         var screen = new Container { Size = new Vector2(400, 300) };

--- a/Sakura.Framework.Tests/Rendering/EdgeEffectDrawNodeTest.cs
+++ b/Sakura.Framework.Tests/Rendering/EdgeEffectDrawNodeTest.cs
@@ -58,7 +58,7 @@ public class EdgeEffectDrawNodeTest
         target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Shadow,
-            Colour = Color.FromArgb(128, Color.Black),
+            Color = Color.FromArgb(128, Color.Black),
             Radius = 12,
             Roundness = 4,
             Offset = new Vector2(0, 5),
@@ -73,7 +73,7 @@ public class EdgeEffectDrawNodeTest
             Assert.That(node.EdgeEffect.Radius, Is.EqualTo(12).Within(tolerance));
             Assert.That(node.EdgeEffect.Roundness, Is.EqualTo(4).Within(tolerance));
             Assert.That(node.EdgeEffect.Offset.Y, Is.EqualTo(5).Within(tolerance));
-            Assert.That(node.EdgeEffect.Colour.A, Is.EqualTo(128));
+            Assert.That(node.EdgeEffect.Color.A, Is.EqualTo(128));
         });
     }
 
@@ -92,7 +92,7 @@ public class EdgeEffectDrawNodeTest
         target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Glow,
-            Colour = Color.Cyan,
+            Color = Color.Cyan,
             Radius = 20,
         };
 
@@ -110,7 +110,7 @@ public class EdgeEffectDrawNodeTest
         target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Glow,
-            Colour = Color.White,
+            Color = Color.White,
             Radius = 0,
         };
 
@@ -128,16 +128,16 @@ public class EdgeEffectDrawNodeTest
     }
 
     [Test]
-    public void TestEdgeEffectColourTransform()
+    public void TestEdgeEffectColorTransform()
     {
         target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Shadow,
-            Colour = Color.Black,
+            Color = Color.Black,
             Radius = 10,
         };
 
-        var transform = new EdgeEffectColourTransform
+        var transform = new EdgeEffectColorTransform
         {
             StartTime = 0,
             EndTime = 100,
@@ -148,9 +148,9 @@ public class EdgeEffectDrawNodeTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(target.EdgeEffect.Colour.R, Is.EqualTo(255));
-            Assert.That(target.EdgeEffect.Colour.G, Is.EqualTo(255));
-            Assert.That(target.EdgeEffect.Colour.B, Is.EqualTo(255));
+            Assert.That(target.EdgeEffect.Color.R, Is.EqualTo(255));
+            Assert.That(target.EdgeEffect.Color.G, Is.EqualTo(255));
+            Assert.That(target.EdgeEffect.Color.B, Is.EqualTo(255));
             Assert.That(target.EdgeEffect.Type, Is.EqualTo(EdgeEffectType.Shadow));
             Assert.That(target.EdgeEffect.Radius, Is.EqualTo(10).Within(tolerance));
         });

--- a/Sakura.Framework.Tests/Visuals/Containers/TestBufferedContainer.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestBufferedContainer.cs
@@ -159,7 +159,7 @@ public partial class TestBufferedContainer : TestScene
 
             bufferedContainer.BlurSigma = new Vector2(8);
             bufferedContainer.EffectBlending = BlendingMode.Additive;
-            bufferedContainer.EffectColour = Color.Gold;
+            bufferedContainer.EffectColor = Color.Gold;
             bufferedContainer.EffectPlacement = EffectPlacement.Behind;
             bufferedContainer.DrawOriginal = true;
         });
@@ -179,21 +179,21 @@ public partial class TestBufferedContainer : TestScene
             bufferedContainer.BlurRotation = 0;
             bufferedContainer.GrayscaleStrength = 0;
             bufferedContainer.EffectBlending = null;
-            bufferedContainer.EffectColour = Color.White;
+            bufferedContainer.EffectColor = Color.White;
             bufferedContainer.EffectPlacement = EffectPlacement.Behind;
             bufferedContainer.DrawOriginal = false;
         });
 
-        AddStep("Background colour dark red", () =>
+        AddStep("Background color dark red", () =>
         {
             if (bufferedContainer != null)
-                bufferedContainer.BackgroundColour = Color.DarkRed;
+                bufferedContainer.BackgroundColor = Color.DarkRed;
         });
 
         AddStep("Background transparent", () =>
         {
             if (bufferedContainer != null)
-                bufferedContainer.BackgroundColour = default;
+                bufferedContainer.BackgroundColor = default;
         });
 
         AddStep("Toggle animation", () => animate = !animate);

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestBlendMode.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestBlendMode.cs
@@ -17,7 +17,7 @@ namespace Sakura.Framework.Tests.Visuals.Drawables;
 /// <summary>
 /// Visual test for <see cref="Drawable.Blending"/> across all <see cref="BlendingMode"/>s, for both
 /// the white-pixel path (a solid <see cref="Box"/>) and the textured path (a <see cref="Sprite"/>).
-/// Each foreground overlaps a colourful background so the blend math is visible (Additive brightens,
+/// Each foreground overlaps a colorful background so the blend math is visible (Additive brightens,
 /// Multiply/Screen tint, Opaque overwrites, etc.).
 /// </summary>
 public partial class TestBlendMode : TestScene
@@ -39,7 +39,7 @@ public partial class TestBlendMode : TestScene
     public void SetUp() => AddStep("Clear", Clear);
 
     /// <summary>
-    /// A colourful background (red/green/blue bands + a white stripe) so any blend mode shows a
+    /// A colorful background (red/green/blue bands + a white stripe) so any blend mode shows a
     /// distinct, readable result where the foreground overlaps it.
     /// </summary>
     private void addBackground()
@@ -63,7 +63,9 @@ public partial class TestBlendMode : TestScene
         });
     }
 
-    /// <summary>White-pixel (solid colour) foreground for every blend mode, as a labelled column.</summary>
+    /// <summary>
+    /// White-pixel (solid color) foreground for every blend mode, as a labelled column.
+    /// </summary>
     [Test]
     public void TestWhitePixelAllModes()
     {
@@ -71,7 +73,9 @@ public partial class TestBlendMode : TestScene
         AddStep("Add boxes (one per mode)", () => Add(buildModeRow(textured: false)));
     }
 
-    /// <summary>Textured foreground (small.png) for every blend mode.</summary>
+    /// <summary>
+    /// Textured foreground (small.png) for every blend mode.
+    /// </summary>
     [Test]
     public void TestTexturedAllModes()
     {
@@ -79,7 +83,9 @@ public partial class TestBlendMode : TestScene
         AddStep("Add sprites (one per mode)", () => Add(buildModeRow(textured: true)));
     }
 
-    /// <summary>Switch a single overlapping box's blend mode live, one mode per <see cref="BlendingMode"/>.</summary>
+    /// <summary>
+    /// Switch a single overlapping box's blend mode live, one mode per <see cref="BlendingMode"/>.
+    /// </summary>
     [TestCaseSource(nameof(all_modes))]
     public void TestWhitePixelSingle(BlendingMode mode)
     {
@@ -98,7 +104,9 @@ public partial class TestBlendMode : TestScene
         AddStep($"Blending = {mode}", () => box.Blending = mode);
     }
 
-    /// <summary>Switch a single overlapping sprite's blend mode live, one mode per <see cref="BlendingMode"/>.</summary>
+    /// <summary>
+    /// Switch a single overlapping sprite's blend mode live, one mode per <see cref="BlendingMode"/>.
+    /// </summary>
     [TestCaseSource(nameof(all_modes))]
     public void TestTexturedSingle(BlendingMode mode)
     {
@@ -117,7 +125,9 @@ public partial class TestBlendMode : TestScene
         AddStep($"Blending = {mode}", () => sprite.Blending = mode);
     }
 
-    /// <summary>Interactive: a slider-free pair of buttons to cycle blend modes on both drawable types.</summary>
+    /// <summary>
+    /// Interactive: a slider-free pair of buttons to cycle blend modes on both drawable types.
+    /// </summary>
     [Test]
     public void TestInteractive()
     {

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestEdgeEffect.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestEdgeEffect.cs
@@ -47,7 +47,7 @@ public partial class TestEdgeEffect : TestScene
         AddStep("Apply drop shadow", () => target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Shadow,
-            Colour = Color.FromArgb(160, Color.Black),
+            Color = Color.FromArgb(160, Color.Black),
             Radius = 25,
             Offset = new Vector2(0, 8),
         });
@@ -61,7 +61,7 @@ public partial class TestEdgeEffect : TestScene
         AddStep("Apply glow", () => target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Glow,
-            Colour = Color.FromArgb(200, Color.Cyan),
+            Color = Color.FromArgb(200, Color.Cyan),
             Radius = 30,
         });
 
@@ -74,7 +74,7 @@ public partial class TestEdgeEffect : TestScene
         AddStep("Set up glow", () => target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Glow,
-            Colour = Color.FromArgb(220, Color.Magenta),
+            Color = Color.FromArgb(220, Color.Magenta),
             Radius = 0,
         });
 
@@ -91,7 +91,7 @@ public partial class TestEdgeEffect : TestScene
         AddStep("Apply hollow glow (outline)", () => target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Glow,
-            Colour = Color.FromArgb(220, Color.Lime),
+            Color = Color.FromArgb(220, Color.Lime),
             Radius = 18,
             Hollow = true,
         });
@@ -105,13 +105,13 @@ public partial class TestEdgeEffect : TestScene
         AddStep("Apply opaque shadow", () => target.EdgeEffect = new EdgeEffectParameters
         {
             Type = EdgeEffectType.Shadow,
-            Colour = Color.FromArgb(255, Color.Black),
+            Color = Color.FromArgb(255, Color.Black),
             Radius = 25,
         });
 
         AddStep("Fade edge effect out", () => target.FadeEdgeEffectTo(0f, 800));
         AddWaitStep("Wait for fade", 800);
-        AddAssert("Edge effect alpha near zero", () => target.EdgeEffect.Colour.A <= 1);
+        AddAssert("Edge effect alpha near zero", () => target.EdgeEffect.Color.A <= 1);
     }
 
     private bool glow = true;
@@ -125,7 +125,7 @@ public partial class TestEdgeEffect : TestScene
     private void applyEdgeEffect() => target.EdgeEffect = new EdgeEffectParameters
     {
         Type = glow ? EdgeEffectType.Glow : EdgeEffectType.Shadow,
-        Colour = Color.FromArgb((int)Math.Clamp(alpha * 255f, 0f, 255f), glow ? Color.Lime : Color.Black),
+        Color = Color.FromArgb((int)Math.Clamp(alpha * 255f, 0f, 255f), glow ? Color.Lime : Color.Black),
         Radius = radius,
         Roundness = roundness,
         Offset = new Vector2(offsetX, offsetY),

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestIconSprite.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestIconSprite.cs
@@ -50,7 +50,7 @@ public partial class TestIconSprite : TestScene
         AddWaitStep("Wait for fading", 200);
         AddAssert("Icon is faded", () => icon.Alpha < 1);
         AddStep("Reset transforms", () => icon.Alpha = 1);
-        AddStep("Flash icon", () => icon.FlashColour(Color.Red, 200));
+        AddStep("Flash icon", () => icon.FlashColor(Color.Red, 200));
     }
 
     [Test]

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestTransforms.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestTransforms.cs
@@ -123,22 +123,22 @@ public partial class TestTransforms : TestScene
     }
 
     [Test]
-    public void TestFadeToColour()
+    public void TestFadeToColor()
     {
-        AddStep("Fade to red 500ms", () => subject.FadeToColour(Color.Red, 500));
+        AddStep("Fade to red 500ms", () => subject.FadeToColor(Color.Red, 500));
         AddWaitStep("Wait", 500);
-        AddStep("Fade to green 500ms", () => subject.FadeToColour(Color.Green, 500));
+        AddStep("Fade to green 500ms", () => subject.FadeToColor(Color.Green, 500));
         AddWaitStep("Wait", 500);
-        AddStep("Fade to original 500ms", () => subject.FadeToColour(Color.CornflowerBlue, 500));
+        AddStep("Fade to original 500ms", () => subject.FadeToColor(Color.CornflowerBlue, 500));
         AddWaitStep("Wait", 500);
     }
 
     [Test]
-    public void TestFlashColour()
+    public void TestFlashColor()
     {
-        AddStep("Flash white 400ms", () => subject.FlashColour(Color.White, 400));
+        AddStep("Flash white 400ms", () => subject.FlashColor(Color.White, 400));
         AddWaitStep("Wait", 500);
-        AddStep("Flash red 400ms", () => subject.FlashColour(Color.Red, 400));
+        AddStep("Flash red 400ms", () => subject.FlashColor(Color.Red, 400));
         AddWaitStep("Wait", 500);
     }
 
@@ -343,7 +343,7 @@ public partial class TestTransforms : TestScene
     {
         // Several boxes stacked vertically, each with a different damping ratio, all launched
         // together so the effect of damping (bouncy → critical → over-damped) is visible side by side.
-        (double damping, Color colour)[] rows =
+        (double damping, Color color)[] rows =
         {
             (0.2, Color.Tomato),
             (0.4, Color.Orange),
@@ -365,7 +365,7 @@ public partial class TestTransforms : TestScene
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Size = new Vector2(50),
-                    Color = rows[i].colour,
+                    Color = rows[i].color,
                     Position = new Vector2(-220, y)
                 });
             }

--- a/Sakura.Framework.Tests/Visuals/Text/TestSpriteText.cs
+++ b/Sakura.Framework.Tests/Visuals/Text/TestSpriteText.cs
@@ -150,7 +150,7 @@ public partial class TestSpriteText : TestScene
     {
         SpriteText tintedEmojiText = null!;
 
-        AddStep("Add red-tinted colour emoji text", () => Add(tintedEmojiText = new SpriteText
+        AddStep("Add red-tinted color emoji text", () => Add(tintedEmojiText = new SpriteText
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
@@ -159,7 +159,7 @@ public partial class TestSpriteText : TestScene
             Font = new FontUsage(size: 48, weight: "Regular", italics: false)
         }));
 
-        AddAssert("colour glyph vertices are untinted while text glyph vertices are tinted red", () =>
+        AddAssert("color glyph vertices are untinted while text glyph vertices are tinted red", () =>
         {
             var glyphs = getShapedGlyphs(tintedEmojiText);
             var vertices = getTextVertices(tintedEmojiText);

--- a/Sakura.Framework/Extensions/ColorExtensions/ColorExtensions.cs
+++ b/Sakura.Framework/Extensions/ColorExtensions/ColorExtensions.cs
@@ -316,7 +316,7 @@ public static class ColorExtensions
     /// <summary>
     /// Decomposes a <see cref="Color"/> into HSV (Hue, Saturation, Value/Brightness) components,
     /// each in the range 0 to 1. This is the model used by the classic saturation/value square +
-    /// hue slider colour picker, and is distinct from the HSL model used by <see cref="ToHSL"/>.
+    /// hue slider color picker, and is distinct from the HSL model used by <see cref="ToHSL"/>.
     /// </summary>
     /// <param name="color">The color to decompose.</param>
     /// <param name="h">Hue component (0 to 1).</param>

--- a/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
+++ b/Sakura.Framework/Extensions/DrawableExtensions/TransformExtensions.cs
@@ -212,26 +212,26 @@ public static class TransformExtensions
         => drawable.FadeTo(0, duration, easing);
 
     /// <summary>
-    /// Instantly flashes the drawable to a specific colour, then fades back to its original colour over a duration.
+    /// Instantly flashes the drawable to a specific color, then fades back to its original color over a duration.
     /// </summary>
-    public static Drawable FlashColour(this Drawable drawable, Color flashColour, double duration, EasingFunction easing = default)
+    public static Drawable FlashColor(this Drawable drawable, Color flashColor, double duration, EasingFunction easing = default)
     {
         drawable.addTransform(new FlashColorTransform
         {
-            FlashColour = flashColour,
+            FlashColor = flashColor,
             Easing = easing
         }, duration);
         return drawable;
     }
 
     /// <summary>
-    /// Fades the drawable's colour to a specific colour over a duration.
+    /// Fades the drawable's color to a specific color over a duration.
     /// </summary>
-    public static Drawable FadeToColour(this Drawable drawable, Color newColour, double duration = 0, EasingFunction easing = default)
+    public static Drawable FadeToColor(this Drawable drawable, Color newColor, double duration = 0, EasingFunction easing = default)
     {
         drawable.addTransform(new ColorTransform
         {
-            EndValue = newColour,
+            EndValue = newColor,
             Easing = easing
         }, duration);
         return drawable;
@@ -240,11 +240,11 @@ public static class TransformExtensions
     /// <summary>
     /// Animates the container's edge-effect color to a specific color over a duration.
     /// </summary>
-    public static T FadeEdgeEffectTo<T>(this T container, Color newColour, double duration = 0, EasingFunction easing = default) where T : Container
+    public static T FadeEdgeEffectTo<T>(this T container, Color newColor, double duration = 0, EasingFunction easing = default) where T : Container
     {
-        container.addTransform(new EdgeEffectColourTransform
+        container.addTransform(new EdgeEffectColorTransform
         {
-            EndValue = newColour,
+            EndValue = newColor,
             Easing = easing
         }, duration);
         return container;
@@ -256,7 +256,7 @@ public static class TransformExtensions
     /// </summary>
     public static T FadeEdgeEffectTo<T>(this T container, float newAlpha, double duration = 0, EasingFunction easing = default) where T : Container
     {
-        var current = container.EdgeEffect.Colour;
+        var current = container.EdgeEffect.Color;
         var target = Color.FromArgb((int)Math.Clamp(newAlpha * 255f, 0f, 255f), current);
         return container.FadeEdgeEffectTo(target, duration, easing);
     }

--- a/Sakura.Framework/Extensions/TransformSequenceExtensions/TransformSequenceExtensions.cs
+++ b/Sakura.Framework/Extensions/TransformSequenceExtensions/TransformSequenceExtensions.cs
@@ -73,9 +73,9 @@ public static class TransformSequenceExtensions
     public static TransformSequence<T> FadeInFromZero<T>(this TransformSequence<T> seq, double duration = 0, EasingFunction easing = default) where T : Drawable
         => seq.Append(d => d.FadeInFromZero(duration, easing));
 
-    public static TransformSequence<T> FadeToColour<T>(this TransformSequence<T> seq, Color colour, double duration = 0, EasingFunction easing = default) where T : Drawable
-        => seq.Append(d => d.FadeToColour(colour, duration, easing));
+    public static TransformSequence<T> FadeToColor<T>(this TransformSequence<T> seq, Color color, double duration = 0, EasingFunction easing = default) where T : Drawable
+        => seq.Append(d => d.FadeToColor(color, duration, easing));
 
-    public static TransformSequence<T> FlashColour<T>(this TransformSequence<T> seq, Color flashColour, double duration, EasingFunction easing = default) where T : Drawable
-        => seq.Append(d => d.FlashColour(flashColour, duration, easing));
+    public static TransformSequence<T> FlashColor<T>(this TransformSequence<T> seq, Color flashColor, double duration, EasingFunction easing = default) where T : Drawable
+        => seq.Append(d => d.FlashColor(flashColor, duration, easing));
 }

--- a/Sakura.Framework/Graphics/Colors/ColorInfo.cs
+++ b/Sakura.Framework/Graphics/Colors/ColorInfo.cs
@@ -34,7 +34,7 @@ public readonly struct ColorInfo : IEquatable<ColorInfo>
 
     /// <summary>
     /// Implicitly treats a single <see cref="Color"/> as a solid <see cref="ColorInfo"/> so existing
-    /// <c>drawable.Color = someColour</c> call sites keep working.
+    /// <c>drawable.Color = someColor</c> call sites keep working.
     /// </summary>
     public static implicit operator ColorInfo(Color color) => Solid(color);
 
@@ -56,7 +56,7 @@ public readonly struct ColorInfo : IEquatable<ColorInfo>
     /// <summary>
     /// Whether all four corners are the same color (i.e. this is effectively a solid color).
     /// </summary>
-    public bool HasSingleColour => TopLeft == TopRight && TopLeft == BottomLeft && TopLeft == BottomRight;
+    public bool HasSingleColor => TopLeft == TopRight && TopLeft == BottomLeft && TopLeft == BottomRight;
 
     /// <summary>
     /// Scales every corner's alpha by <paramref name="factor"/>, returning a new <see cref="ColorInfo"/>.
@@ -100,5 +100,5 @@ public readonly struct ColorInfo : IEquatable<ColorInfo>
     public static bool operator !=(ColorInfo left, ColorInfo right) => !left.Equals(right);
 
     public override string ToString() =>
-        HasSingleColour ? $"Solid({TopLeft})" : $"Gradient(TL={TopLeft}, TR={TopRight}, BL={BottomLeft}, BR={BottomRight})";
+        HasSingleColor ? $"Solid({TopLeft})" : $"Gradient(TL={TopLeft}, TR={TopRight}, BL={BottomLeft}, BR={BottomRight})";
 }

--- a/Sakura.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/BufferedContainer.cs
@@ -18,7 +18,7 @@ namespace Sakura.Framework.Graphics.Containers;
 /// static content via <see cref="CacheDrawnFrameBuffer"/>, and texture-space effects:
 /// Gaussian blur (<see cref="BlurSigma"/>, <see cref="BlurRotation"/>), grayscale
 /// (<see cref="GrayscaleStrength"/>), effect tint/blending/placement
-/// (<see cref="EffectColour"/>, <see cref="EffectBlending"/>, <see cref="EffectPlacement"/>)
+/// (<see cref="EffectColor"/>, <see cref="EffectBlending"/>, <see cref="EffectPlacement"/>)
 /// and glow/bloom-style compositing via <see cref="DrawOriginal"/>.
 /// </para>
 /// <para>
@@ -147,21 +147,21 @@ public partial class BufferedContainer : Container
         }
     }
 
-    private Color effectColour = Color.White;
+    private Color effectColor = Color.White;
 
     /// <summary>
     /// Multiplicative color of the effect result (e.g. the blurred image). Default white.
     /// Does not affect the original drawn when <see cref="DrawOriginal"/> is true.
     /// </summary>
-    public Color EffectColour
+    public Color EffectColor
     {
-        get => effectColour;
+        get => effectColor;
         set
         {
-            if (effectColour.Equals(value))
+            if (effectColor.Equals(value))
                 return;
 
-            effectColour = value;
+            effectColor = value;
             Invalidate(InvalidationFlags.DrawInfo);
         }
     }
@@ -207,20 +207,20 @@ public partial class BufferedContainer : Container
 
     // Note: not Color.Transparent (which is white with zero alpha and would fringe to
     // white when children blend over it) — true transparent black.
-    private Color backgroundColour = default;
+    private Color backgroundColor = default;
 
     /// <summary>
     /// The color the buffer is cleared to before children render. Transparent black by default.
     /// </summary>
-    public Color BackgroundColour
+    public Color BackgroundColor
     {
-        get => backgroundColour;
+        get => backgroundColor;
         set
         {
-            if (backgroundColour.Equals(value))
+            if (backgroundColor.Equals(value))
                 return;
 
-            backgroundColour = value;
+            backgroundColor = value;
             ForceRedraw();
         }
     }

--- a/Sakura.Framework/Graphics/Containers/EdgeEffectParameters.cs
+++ b/Sakura.Framework/Graphics/Containers/EdgeEffectParameters.cs
@@ -35,9 +35,9 @@ public enum EdgeEffectType
 public struct EdgeEffectParameters : IEquatable<EdgeEffectParameters>
 {
     /// <summary>
-    /// The colour of the edge effect (including its alpha). Premultiplied at draw time.
+    /// The color of the edge effect (including its alpha). Premultiplied at draw time.
     /// </summary>
-    public Color Colour;
+    public Color Color;
 
     /// <summary>
     /// The offset of the edge effect from the container's shape, in local pixels.
@@ -68,7 +68,7 @@ public struct EdgeEffectParameters : IEquatable<EdgeEffectParameters>
     public bool Hollow;
 
     public readonly bool Equals(EdgeEffectParameters other) =>
-        Colour.Equals(other.Colour)
+        Color.Equals(other.Color)
         && Offset.Equals(other.Offset)
         && Type == other.Type
         && Radius == other.Radius
@@ -77,7 +77,7 @@ public struct EdgeEffectParameters : IEquatable<EdgeEffectParameters>
 
     public override readonly bool Equals(object? obj) => obj is EdgeEffectParameters other && Equals(other);
 
-    public override readonly int GetHashCode() => HashCode.Combine(Colour, Offset, (int)Type, Radius, Roundness, Hollow);
+    public override readonly int GetHashCode() => HashCode.Combine(Color, Offset, (int)Type, Radius, Roundness, Hollow);
 
     public static bool operator ==(EdgeEffectParameters left, EdgeEffectParameters right) => left.Equals(right);
 

--- a/Sakura.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/Sakura.Framework/Graphics/Cursor/CursorContainer.cs
@@ -104,7 +104,7 @@ public partial class CursorContainer : Container, IRemoveFromDrawVisualiser
 
         public override bool OnClick(MouseButtonEvent e)
         {
-            iconSprite.FlashColour(Color.White, 300, Easing.OutQuint);
+            iconSprite.FlashColor(Color.White, 300, Easing.OutQuint);
             return base.OnClick(e);
         }
 

--- a/Sakura.Framework/Graphics/Drawables/Container.cs
+++ b/Sakura.Framework/Graphics/Drawables/Container.cs
@@ -442,7 +442,7 @@ public partial class Container : Drawable
     {
         // Check whether our layout was dirty before base.Update() is called, as it will clear our invalidation flags.
         bool layoutWasInvalidated = (Invalidation & InvalidationFlags.DrawInfo) != 0;
-        bool colourWasInvalidated = (Invalidation & InvalidationFlags.Colour) != 0;
+        bool colorWasInvalidated = (Invalidation & InvalidationFlags.Color) != 0;
 
         if (AutoSizeAxes != Axes.None && layoutWasInvalidated)
         {
@@ -456,11 +456,11 @@ public partial class Container : Drawable
 
         base.Update();
 
-        if (colourWasInvalidated)
+        if (colorWasInvalidated)
         {
             foreach (var child in children)
             {
-                child.Invalidate(InvalidationFlags.Colour, false);
+                child.Invalidate(InvalidationFlags.Color, false);
             }
         }
 

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -310,10 +310,10 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
     }
 
     /// <summary>
-    /// The per-corner colour of this drawable. Set a <see cref="Colors.ColorInfo"/> gradient (e.g.
-    /// <see cref="Colors.ColorInfo.GradientHorizontal"/>) to have the renderer interpolate colour
+    /// The per-corner color of this drawable. Set a <see cref="Colors.ColorInfo"/> gradient (e.g.
+    /// <see cref="Colors.ColorInfo.GradientHorizontal"/>) to have the renderer interpolate color
     /// across the quad, or a single <see cref="Colors.Color"/> (implicitly converted to a solid
-    /// <see cref="Colors.ColorInfo"/>) for a flat colour.
+    /// <see cref="Colors.ColorInfo"/>) for a flat color.
     /// </summary>
     public ColorInfo ColorInfo
     {
@@ -322,14 +322,14 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
         {
             if (colorInfo.Equals(value)) return;
             colorInfo = value;
-            Invalidate(InvalidationFlags.Colour);
+            Invalidate(InvalidationFlags.Color);
         }
     }
 
     /// <summary>
-    /// The flat colour of this drawable. This is a back-compat shim over <see cref="ColorInfo"/>:
+    /// The flat color of this drawable. This is a back-compat shim over <see cref="ColorInfo"/>:
     /// the getter returns the top-left corner, and the setter collapses the whole drawable to a
-    /// solid colour. Use <see cref="ColorInfo"/> directly for gradients.
+    /// solid color. Use <see cref="ColorInfo"/> directly for gradients.
     /// </summary>
     public Color Color
     {
@@ -348,7 +348,7 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
             alpha = Math.Clamp(value, 0f, 1f);
             bool isVisible = alpha > 0;
 
-            Invalidate(InvalidationFlags.Colour);
+            Invalidate(InvalidationFlags.Color);
 
             // Visibility is a layout input: auto-size containers skip hidden children
             // (e.g. a dropdown grows only while its menu is shown), so crossing the
@@ -605,9 +605,9 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
     }
 
     /// <summary>
-    /// Converts an sRGB corner <see cref="Color"/> to a linear-space vertex colour, folding
-    /// <see cref="DrawAlpha"/> and the colour's own alpha into the <c>W</c> component (RGB is not
-    /// premultiplied). Shared by <see cref="GenerateVertices"/> and <see cref="UpdateDrawColour"/>
+    /// Converts an sRGB corner <see cref="Color"/> to a linear-space vertex color, folding
+    /// <see cref="DrawAlpha"/> and the color's own alpha into the <c>W</c> component (RGB is not
+    /// premultiplied). Shared by <see cref="GenerateVertices"/> and <see cref="UpdateDrawColor"/>
     /// so both stay in sync.
     /// </summary>
     private Vector4 toLinear(Color c) => new Vector4(
@@ -617,11 +617,11 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
         DrawAlpha * (c.A / 255f));
 
     /// <summary>
-    /// Writes the four corner colours of <see cref="colorInfo"/> into the existing quad vertices.
+    /// Writes the four corner colors of <see cref="colorInfo"/> into the existing quad vertices.
     /// The corner→index mapping must match <see cref="GenerateVertices"/>
     /// (0 = TopLeft, 1 = TopRight, 2 = BottomRight, 3 = BottomLeft).
     /// </summary>
-    private void writeCornerColours()
+    private void writeCornerColors()
     {
         Vertices[0].Color = toLinear(colorInfo.TopLeft);
         Vertices[1].Color = toLinear(colorInfo.TopRight);
@@ -712,9 +712,9 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
         Vertices[2] = new Vertex { Position = new Vector2(vBottomRight.X, vBottomRight.Y), TexCoords = uvBottomRight };
         Vertices[3] = new Vertex { Position = new Vector2(vBottomLeft.X, vBottomLeft.Y), TexCoords = new Vector2(uvTopLeft.X, uvBottomRight.Y) };
 
-        // Per-corner colour (solid or gradient), converted to linear space. Must run after the
+        // Per-corner color (solid or gradient), converted to linear space. Must run after the
         // vertices exist and match the corner→index mapping above.
-        writeCornerColours();
+        writeCornerColors();
 
         // Calculate DrawRectangle in screen space
         float minX = Math.Min(vTopLeft.X, Math.Min(vTopRight.X, Math.Min(vBottomLeft.X, vBottomRight.X)));
@@ -981,7 +981,7 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
 
         Invalidation |= flags;
 
-        if ((flags & (InvalidationFlags.DrawInfo | InvalidationFlags.Colour)) != 0)
+        if ((flags & (InvalidationFlags.DrawInfo | InvalidationFlags.Color)) != 0)
         {
             DrawNodeInvalidationId++;
 
@@ -1112,7 +1112,7 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
             DrawAlpha = 0;
             // Keep pending geometry invalidation (and the own-geometry marker) so a drawable
             // that moved while hidden recomputes — and cascades to children — once shown again.
-            Invalidation &= ~InvalidationFlags.Colour;
+            Invalidation &= ~InvalidationFlags.Color;
             return;
         }
 
@@ -1120,11 +1120,11 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
         {
             UpdateTransforms();
         }
-        else if ((Invalidation & InvalidationFlags.Colour) != 0)
+        else if ((Invalidation & InvalidationFlags.Color) != 0)
         {
-            // Colour-only change (fades are the common case in gameplay): rewrite the
-            // vertex colours without redoing matrix and vertex-position work.
-            UpdateDrawColour();
+            // Color-only change (fades are the common case in gameplay): rewrite the
+            // vertex colors without redoing matrix and vertex-position work.
+            UpdateDrawColor();
         }
 
         Invalidation = InvalidationFlags.None;
@@ -1134,17 +1134,17 @@ public abstract partial class Drawable : IDependencyInjectionCandidate
     /// <summary>
     /// Recomputes <see cref="DrawAlpha"/> and rewrites the color of the existing vertices
     /// without regenerating geometry. Called for color-only invalidations. Handles both solid
-    /// colours and per-corner gradients (via <see cref="ColorInfo"/>) for the default quad.
+    /// colors and per-corner gradients (via <see cref="ColorInfo"/>) for the default quad.
     /// Drawables whose vertices don't follow the default quad layout must override this
     /// (falling back to <see cref="UpdateTransforms"/> is always correct).
     /// </summary>
-    protected virtual void UpdateDrawColour()
+    protected virtual void UpdateDrawColor()
     {
         DrawAlpha = (Parent?.DrawAlpha ?? 1f) * Alpha;
 
-        // Rewrite per-corner colours so gradients survive the colour-only fast path (used by fades);
+        // Rewrite per-corner colors so gradients survive the color-only fast path (used by fades);
         // toLinear folds the freshly-computed DrawAlpha into every corner.
-        writeCornerColours();
+        writeCornerColors();
     }
 
     /// <summary>
@@ -1575,7 +1575,7 @@ public enum InvalidationFlags
     /// <summary>
     /// The color of the drawable has changed.
     /// </summary>
-    Colour = 1 << 1,
+    Color = 1 << 1,
 
     /// <summary>
     /// A catch-all for all invalidation types.

--- a/Sakura.Framework/Graphics/Drawables/Path.cs
+++ b/Sakura.Framework/Graphics/Drawables/Path.cs
@@ -92,7 +92,7 @@ public partial class Path : Drawable
     /// Regenerate the full geometry instead, so a <see cref="Drawable.Color"/> change (e.g. a fade, or a
     /// recolor) takes effect immediately rather than waiting for the next geometry invalidation.
     /// </summary>
-    protected override void UpdateDrawColour() => UpdateTransforms();
+    protected override void UpdateDrawColor() => UpdateTransforms();
 
     protected override void GenerateVertices()
     {

--- a/Sakura.Framework/Graphics/Drawables/SpriteText.cs
+++ b/Sakura.Framework/Graphics/Drawables/SpriteText.cs
@@ -317,7 +317,7 @@ public partial class SpriteText : Drawable
         renderer.DrawQuads(slice, texture);
     }
 
-    protected override void UpdateDrawColour()
+    protected override void UpdateDrawColor()
     {
         DrawAlpha = (Parent?.DrawAlpha ?? 1f) * Alpha;
 

--- a/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
+++ b/Sakura.Framework/Graphics/Performance/DrawVisualiser.cs
@@ -386,7 +386,7 @@ public partial class DrawVisualiser : FocusedOverlayContainer, IRemoveFromDrawVi
             if (hoveredDrawable != lastHoveredDrawable)
             {
                 inspectHighlightBox.Color = Color.LimeGreen;
-                inspectHighlightBox.FlashColour(Color.White, 300, Easing.OutQuint);
+                inspectHighlightBox.FlashColor(Color.White, 300, Easing.OutQuint);
             }
             lastHoveredDrawable = hoveredDrawable;
         }

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -559,9 +559,9 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
 
             protected internal override VertexTopology Topology => VertexTopology.Triangles;
 
-            // Bars carry non-uniform per-vertex colours; the base colour-only fast path
+            // Bars carry non-uniform per-vertex colors; the base color-only fast path
             // would flatten them, so fall back to a full regeneration.
-            protected override void UpdateDrawColour() => UpdateTransforms();
+            protected override void UpdateDrawColor() => UpdateTransforms();
 
             protected override void GenerateVertices()
             {

--- a/Sakura.Framework/Graphics/Rendering/BufferedContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/BufferedContainerDrawNode.cs
@@ -35,10 +35,10 @@ public class BufferedContainerDrawNode : ContainerDrawNode
     private float blurRotation;
     private float grayscaleStrength;
     private bool drawOriginal;
-    private Vector4 effectColourLinear = new Vector4(1, 1, 1, 1);
+    private Vector4 effectColorLinear = new Vector4(1, 1, 1, 1);
     private BlendingMode? effectBlending;
     private EffectPlacement effectPlacement;
-    private Color backgroundColour;
+    private Color backgroundColor;
 
     public override void ApplyState(Drawable source)
     {
@@ -55,10 +55,10 @@ public class BufferedContainerDrawNode : ContainerDrawNode
         drawOriginal = buffered.DrawOriginal;
         effectBlending = buffered.EffectBlending;
         effectPlacement = buffered.EffectPlacement;
-        backgroundColour = buffered.BackgroundColour;
+        backgroundColor = buffered.BackgroundColor;
 
-        var ec = buffered.EffectColour;
-        effectColourLinear = new Vector4(
+        var ec = buffered.EffectColor;
+        effectColorLinear = new Vector4(
             ColorExtensions.SrgbToLinear(ec.R),
             ColorExtensions.SrgbToLinear(ec.G),
             ColorExtensions.SrgbToLinear(ec.B),
@@ -107,7 +107,7 @@ public class BufferedContainerDrawNode : ContainerDrawNode
 
         if (needsRedraw)
         {
-            renderer.BindFrameBuffer(shared.FrameBuffer, rect, backgroundColour);
+            renderer.BindFrameBuffer(shared.FrameBuffer, rect, backgroundColor);
 
             // Children render with their normal screen-space coordinates (the bound
             // projection maps the captured rect onto the buffer), including any masking
@@ -279,46 +279,46 @@ public class BufferedContainerDrawNode : ContainerDrawNode
         // to children in this framework; color does not), so the composite quads must apply
         // only the color tint and the color's own alpha — strip DrawAlpha to avoid
         // double-applying the fade.
-        Vector4 baseColour = Vertices.Length > 0 ? Vertices[0].Color : new Vector4(1, 1, 1, DrawAlpha);
-        baseColour.W = DrawAlpha > 0 ? baseColour.W / DrawAlpha : 0;
+        Vector4 baseColor = Vertices.Length > 0 ? Vertices[0].Color : new Vector4(1, 1, 1, DrawAlpha);
+        baseColor.W = DrawAlpha > 0 ? baseColor.W / DrawAlpha : 0;
 
         var effectBuffer = shared!.FinalEffectBuffer;
 
         if (effectBuffer == null)
         {
             // No effects: just the original content.
-            drawQuad(renderer, shared.FrameBuffer!, rect, baseColour, Blending);
+            drawQuad(renderer, shared.FrameBuffer!, rect, baseColor, Blending);
             return;
         }
 
-        var effectQuadColour = new Vector4(
-            baseColour.X * effectColourLinear.X,
-            baseColour.Y * effectColourLinear.Y,
-            baseColour.Z * effectColourLinear.Z,
-            baseColour.W * effectColourLinear.W);
+        var effectQuadColor = new Vector4(
+            baseColor.X * effectColorLinear.X,
+            baseColor.Y * effectColorLinear.Y,
+            baseColor.Z * effectColorLinear.Z,
+            baseColor.W * effectColorLinear.W);
 
         var effectQuadBlending = effectBlending ?? Blending;
 
         if (effectPlacement == EffectPlacement.Behind)
         {
-            drawQuad(renderer, effectBuffer, rect, effectQuadColour, effectQuadBlending);
+            drawQuad(renderer, effectBuffer, rect, effectQuadColor, effectQuadBlending);
 
             if (drawOriginal)
-                drawQuad(renderer, shared.FrameBuffer!, rect, baseColour, Blending);
+                drawQuad(renderer, shared.FrameBuffer!, rect, baseColor, Blending);
         }
         else
         {
             if (drawOriginal)
-                drawQuad(renderer, shared.FrameBuffer!, rect, baseColour, Blending);
+                drawQuad(renderer, shared.FrameBuffer!, rect, baseColor, Blending);
 
-            drawQuad(renderer, effectBuffer, rect, effectQuadColour, effectQuadBlending);
+            drawQuad(renderer, effectBuffer, rect, effectQuadColor, effectQuadBlending);
         }
     }
 
-    private static void drawQuad(IRenderer renderer, IFrameBuffer buffer, RectangleF rect, Vector4 colour, BlendingMode blending)
+    private static void drawQuad(IRenderer renderer, IFrameBuffer buffer, RectangleF rect, Vector4 color, BlendingMode blending)
     {
         Span<Vertex.Vertex> quad = stackalloc Vertex.Vertex[4];
-        fillQuad(quad, rect, colour);
+        fillQuad(quad, rect, color);
 
         renderer.SetBlendMode(blending);
         renderer.DrawQuads(quad, buffer.Texture);

--- a/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
@@ -70,7 +70,7 @@ public class ContainerDrawNode : DrawNode
         float scaleY = DrawSize.Y > 0 ? screenHalfSize.Y / (DrawSize.Y * 0.5f) : 1f;
         float uniformScale = (scaleX + scaleY) * 0.5f;
 
-        bool hasEdgeEffect = EdgeEffect.Type != EdgeEffectType.None && EdgeEffect.Colour.A > 0;
+        bool hasEdgeEffect = EdgeEffect.Type != EdgeEffectType.None && EdgeEffect.Color.A > 0;
 
         // Shadows render behind the container's contents.
         if (hasEdgeEffect && EdgeEffect.Type == EdgeEffectType.Shadow)
@@ -149,7 +149,7 @@ public class ContainerDrawNode : DrawNode
         quad[3] = new Vertex.Vertex { Position = bl, TexCoords = new Vector2(0, 1), Color = new Vector4(1, 1, 1, 1) };
 
         // Premultiply the effect alpha by the container's overall draw alpha so it fades with the container.
-        var color = EdgeEffect.Colour;
+        var color = EdgeEffect.Color;
         if (DrawAlpha < 1f)
             color = Color.FromArgb((int)Math.Clamp(color.A * DrawAlpha, 0f, 255f), color);
 

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
@@ -61,7 +61,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     private float renderScaleX = 1.0f;
     private float renderScaleY = 1.0f;
 
-    private static readonly Color4 clear_colour = new Color4(0f, 0f, 0f, 1f);
+    private static readonly Color4 clear_color = new Color4(0f, 0f, 0f, 1f);
 
     // Register mapping from the sakura-spirv HLSL cross-compile (resources ordered by (set,binding),
     // per-kind counters): ProjectionBlock -> VS b0, MaskBlock -> PS b1, u_Textures[16] -> PS t0..t15 / s0.
@@ -424,7 +424,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
 
         frameBufferStack.Clear();
         setRenderTarget(backBufferRtv, backBufferWidth, backBufferHeight);
-        context.ClearRenderTargetView(backBufferRtv, clear_colour);
+        context.ClearRenderTargetView(backBufferRtv, clear_color);
 
         currentShader = mainShader;
         currentBlendMode = BlendingMode.Alpha;
@@ -703,7 +703,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
 
     /// <summary>
     /// Draws the rounded/sheared border ring via the main shader's border path (u_IsBorder). Border
-    /// geometry + colour travel through the MaskBlock CB (PS b1)
+    /// geometry + color travel through the MaskBlock CB (PS b1)
     /// </summary>
     private void drawBorder(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<SakuraVertex> vertices)
     {
@@ -798,7 +798,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     /// cancels the HLSL vertex shader's per-pass Y-flip so the GL-tuned BufferedContainer chain stays
     /// correct
     /// </summary>
-    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColour = default)
+    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColor = default)
     {
         if (device == null || frameBuffer is not D3D11FrameBuffer fb)
             return;
@@ -812,7 +812,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         currentClip = ClipState.None;
 
         setRenderTarget(fb.RenderTargetView, fb.Width, fb.Height);
-        context.ClearRenderTargetView(fb.RenderTargetView, toColor4(clearColour));
+        context.ClearRenderTargetView(fb.RenderTargetView, toColor4(clearColor));
         uploadProjection();
     }
 

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -444,7 +444,7 @@ public class GLRenderer : IGLRenderer, IDisposable
     /// </summary>
     public IFrameBuffer CreateFrameBuffer(int width, int height, bool pixelSnapping = false) => new GLFrameBuffer(gl, width, height, pixelSnapping);
 
-    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColour = default)
+    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColor = default)
     {
         var glFrameBuffer = (GLFrameBuffer)frameBuffer;
 
@@ -485,7 +485,7 @@ public class GLRenderer : IGLRenderer, IDisposable
             Radius = 0
         };
 
-        gl.ClearColor(clearColour.R / 255f, clearColour.G / 255f, clearColour.B / 255f, clearColour.A / 255f);
+        gl.ClearColor(clearColor.R / 255f, clearColor.G / 255f, clearColor.B / 255f, clearColor.A / 255f);
         gl.Clear(ClearBufferMask.ColorBufferBit);
         gl.ClearColor(Color.Black);
     }

--- a/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
@@ -103,7 +103,7 @@ public class HeadlessRenderer : IRenderer
 
     public IFrameBuffer CreateFrameBuffer(int width, int height, bool pixelSnapping = false) => new HeadlessFrameBuffer(WhitePixel, width, height);
 
-    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColour = default)
+    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColor = default)
     {
 
     }

--- a/Sakura.Framework/Graphics/Rendering/IRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/IRenderer.cs
@@ -160,11 +160,11 @@ public interface IRenderer
     /// Redirects subsequent draw commands into <paramref name="frameBuffer"/>.
     /// <paramref name="sourceRect"/> is the logical screen-space rectangle the buffer
     /// captures: geometry keeps its normal screen-space coordinates and is mapped onto the
-    /// buffer by an adjusted projection. The buffer is cleared to <paramref name="clearColour"/>
+    /// buffer by an adjusted projection. The buffer is cleared to <paramref name="clearColor"/>
     /// (default: transparent black).
     /// Nesting is supported; every call must be matched by <see cref="UnbindFrameBuffer"/>.
     /// </summary>
-    void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColour = default);
+    void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColor = default);
 
     /// <summary>
     /// Ends rendering into the most recently bound framebuffer, restoring the previous

--- a/Sakura.Framework/Graphics/Rendering/IShader.cs
+++ b/Sakura.Framework/Graphics/Rendering/IShader.cs
@@ -28,7 +28,7 @@ public interface IShader : IDisposable
 
     /// <summary>
     /// Sets a 3×3 matrix uniform from a row-major float[9] array.
-    /// Used by the video shader for YUV→RGB colour conversion coefficients.
+    /// Used by the video shader for YUV→RGB color conversion coefficients.
     /// </summary>
     void SetUniform(string name, float[] mat3X3);
 

--- a/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
@@ -49,7 +49,7 @@ public sealed class MetalRenderer : IMetalRenderer
     /// </summary>
     private const int mask_buffer_index = 1;
 
-    private static readonly (float r, float g, float b, float a) clear_colour = (0f, 0f, 0f, 1f);
+    private static readonly (float r, float g, float b, float a) clear_color = (0f, 0f, 0f, 1f);
 
     private float renderScaleX = 1.0f;
     private float renderScaleY = 1.0f;
@@ -112,7 +112,7 @@ public sealed class MetalRenderer : IMetalRenderer
         mainShader = new MetalShader(device, vertMsl, fragMsl, attributes, SakuraVertex.Size, mainShaderUniformBindings());
         currentShader = mainShader;
 
-        // 1x1 white pixel. The main shader always samples u_Textures[index]; solid-colour drawables
+        // 1x1 white pixel. The main shader always samples u_Textures[index]; solid-color drawables
         // sample this white texel so the result is white × v_Color. Bound to slot 0 each frame.
         var whiteTex = new MetalTexture(device, 1, 1);
         whiteTex.Upload(new byte[] { 255, 255, 255, 255 });
@@ -239,7 +239,7 @@ public sealed class MetalRenderer : IMetalRenderer
         while (drawThreadQueue.TryDequeue(out var action))
             action();
 
-        SakuraMetalNative.sakura_metal_begin_frame(device, clear_colour.r, clear_colour.g, clear_colour.b, clear_colour.a);
+        SakuraMetalNative.sakura_metal_begin_frame(device, clear_color.r, clear_color.g, clear_color.b, clear_color.a);
 
         frameBufferStack.Clear();
 
@@ -445,7 +445,7 @@ public sealed class MetalRenderer : IMetalRenderer
 
     /// <summary>
     /// Draws the rounded/sheared border quad via the main shader's border path (u_IsBorder). The
-    /// border colour and geometry travel through the MaskBlock UBO at fragment [[buffer(1)]]; the
+    /// border color and geometry travel through the MaskBlock UBO at fragment [[buffer(1)]]; the
     /// fragment shader computes the border ring from the signed-distance field. Mirrors
     /// <c>GLRenderer.drawBorder</c>, minus the GL-only batch/texture-slot bookkeeping.
     /// </summary>
@@ -541,7 +541,7 @@ public sealed class MetalRenderer : IMetalRenderer
     /// buffer (same convention as <c>GLRenderer.BindFrameBuffer</c>), opens the native offscreen pass,
     /// and re-binds all encoder state into the new pass.
     /// </summary>
-    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColour = default)
+    public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColor = default)
     {
         if (device == nint.Zero || frameBuffer is not MetalFrameBuffer metalFrameBuffer)
             return;
@@ -582,7 +582,7 @@ public sealed class MetalRenderer : IMetalRenderer
 
         SakuraMetalNative.sakura_metal_begin_offscreen(
             device, metalFrameBuffer.TextureHandle,
-            clearColour.R / 255f, clearColour.G / 255f, clearColour.B / 255f, clearColour.A / 255f);
+            clearColor.R / 255f, clearColor.G / 255f, clearColor.B / 255f, clearColor.A / 255f);
 
         // The offscreen pass opened a fresh encoder, re-establish pipeline/projection/mask/texture.
         rebindFrameState();

--- a/Sakura.Framework/Graphics/Rendering/Uniforms/UniformBlocks.cs
+++ b/Sakura.Framework/Graphics/Rendering/Uniforms/UniformBlocks.cs
@@ -39,8 +39,8 @@ public struct ProjectionBlock
 public struct MaskBlock
 {
     /// <summary>
-    /// Border colour (premultiplied as elsewhere). Maps to <c>vec4 u_BorderColor</c>.
-    /// Also reused as the edge-effect colour during the edge-effect pass.
+    /// Border color (premultiplied as elsewhere). Maps to <c>vec4 u_BorderColor</c>.
+    /// Also reused as the edge-effect color during the edge-effect pass.
     /// </summary>
     [FieldOffset(0)]
     public Vector4 BorderColor;
@@ -126,7 +126,7 @@ public struct MaskBlock
 public struct GrayscaleBlock
 {
     /// <summary>
-    /// 0 = original colours, 1 = fully grayscale. Maps to <c>float u_Strength</c>.
+    /// 0 = original colors, 1 = fully grayscale. Maps to <c>float u_Strength</c>.
     /// </summary>
     [FieldOffset(0)]
     public float Strength;

--- a/Sakura.Framework/Graphics/Text/Font.cs
+++ b/Sakura.Framework/Graphics/Text/Font.cs
@@ -752,8 +752,8 @@ public struct TextGlyph
     public int StartIndex;
 
     /// <summary>
-    /// Whether this glyph is a natively-coloured bitmap (e.g. color emoji) rather than a grayscale
-    /// outline glyph. Colour glyphs should be drawn without applying the drawable's tint color.
+    /// Whether this glyph is a natively-colored bitmap (e.g. color emoji) rather than a grayscale
+    /// outline glyph. Color glyphs should be drawn without applying the drawable's tint color.
     /// </summary>
     public bool IsColorGlyph;
 }

--- a/Sakura.Framework/Graphics/Textures/D3D11TextureManager.cs
+++ b/Sakura.Framework/Graphics/Textures/D3D11TextureManager.cs
@@ -37,7 +37,7 @@ public class D3D11TextureManager : ITextureManager
         this.storage = storage;
         this.imageLoader = imageLoader;
 
-        // The D3D11 renderer owns a 1x1 white texture, reuse it so solid-colour drawables sample white.
+        // The D3D11 renderer owns a 1x1 white texture, reuse it so solid-color drawables sample white.
         WhitePixel = renderer.WhitePixel;
         missingTexture = new Texture(renderer.CreateNativeTexture(1, 1));
         atlas = new TextureAtlas(renderer, usage: AtlasUsage.Textures);

--- a/Sakura.Framework/Graphics/Textures/MetalTextureManager.cs
+++ b/Sakura.Framework/Graphics/Textures/MetalTextureManager.cs
@@ -39,7 +39,7 @@ public class MetalTextureManager : ITextureManager
         this.storage = storage;
         this.imageLoader = imageLoader;
 
-        // The Metal renderer owns a 1x1 white texture; reuse it so solid-colour drawables sample white.
+        // The Metal renderer owns a 1x1 white texture; reuse it so solid-color drawables sample white.
         WhitePixel = renderer.WhitePixel;
         missingTexture = new Texture(renderer.CreateNativeTexture(1, 1));
         atlas = new TextureAtlas(renderer, usage: AtlasUsage.Textures);

--- a/Sakura.Framework/Graphics/Transforms/Transform.cs
+++ b/Sakura.Framework/Graphics/Transforms/Transform.cs
@@ -27,7 +27,7 @@ public enum TransformMember
     Rotation,
     Alpha,
     Color,
-    EdgeEffectColour,
+    EdgeEffectColor,
     EdgeEffectRadius,
 }
 
@@ -255,22 +255,22 @@ public class AlphaTransform : Transform
 
 public class FlashColorTransform : Transform
 {
-    public Color FlashColour;
-    private Color originalColour;
-    private bool colourCaptured;
+    public Color FlashColor;
+    private Color originalColor;
+    private bool colorCaptured;
 
     public override void Apply(Drawable drawable, double time)
     {
-        if (!colourCaptured)
+        if (!colorCaptured)
         {
-            originalColour = drawable.Color;
-            colourCaptured = true;
+            originalColor = drawable.Color;
+            colorCaptured = true;
         }
 
         double easedProgress = GetEasedProgress(time);
 
-        // lerp from the flash colour (at progress 0) to the original colour (at progress 1).
-        drawable.Color = ColorExtensions.Lerp(FlashColour, originalColour, (float)easedProgress);
+        // lerp from the flash color (at progress 0) to the original color (at progress 1).
+        drawable.Color = ColorExtensions.Lerp(FlashColor, originalColor, (float)easedProgress);
     }
 }
 
@@ -332,19 +332,19 @@ public class ColorTransform : Transform
 }
 
 /// <summary>
-/// Animates the <see cref="EdgeEffectParameters.Colour"/> of a <see cref="Container"/>'s edge effect.
+/// Animates the <see cref="EdgeEffectParameters.Color"/> of a <see cref="Container"/>'s edge effect.
 /// </summary>
-public class EdgeEffectColourTransform : Transform
+public class EdgeEffectColorTransform : Transform
 {
     private bool valueCaptured;
     public Color StartValue;
     public Color EndValue;
 
-    public override TransformMember Member => TransformMember.EdgeEffectColour;
+    public override TransformMember Member => TransformMember.EdgeEffectColor;
 
     public override bool TryRetargetFrom(Transform incoming)
     {
-        if (incoming is not EdgeEffectColourTransform e) return false;
+        if (incoming is not EdgeEffectColorTransform e) return false;
         EndValue = e.EndValue;
         Easing = e.Easing;
         return true;
@@ -356,12 +356,12 @@ public class EdgeEffectColourTransform : Transform
 
         if (!valueCaptured)
         {
-            StartValue = container.EdgeEffect.Colour;
+            StartValue = container.EdgeEffect.Color;
             valueCaptured = true;
         }
 
         var ee = container.EdgeEffect;
-        ee.Colour = ColorExtensions.Lerp(StartValue, EndValue, (float)GetEasedProgress(time));
+        ee.Color = ColorExtensions.Lerp(StartValue, EndValue, (float)GetEasedProgress(time));
         container.EdgeEffect = ee;
     }
 }

--- a/Sakura.Framework/Graphics/UserInterface/BasicButton.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicButton.cs
@@ -83,5 +83,5 @@ public partial class BasicButton : Button
 
     protected override void OnHoverLost() => background.Color = DefaultColor;
 
-    protected override void OnEnabledChanged(bool enabled) => background.FadeToColour(enabled ? DefaultColor : DefaultColor.Darken(0.5f), 100, Easing.OutQuint);
+    protected override void OnEnabledChanged(bool enabled) => background.FadeToColor(enabled ? DefaultColor : DefaultColor.Darken(0.5f), 100, Easing.OutQuint);
 }

--- a/Sakura.Framework/Graphics/UserInterface/BasicCheckbox.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicCheckbox.cs
@@ -78,10 +78,10 @@ public partial class BasicCheckbox : Checkbox
     }
 
     protected override void OnHovered() =>
-        background.FadeToColour(HoverColor, 100, Easing.OutQuint);
+        background.FadeToColor(HoverColor, 100, Easing.OutQuint);
 
     protected override void OnHoverLost() =>
-        background.FadeToColour(UncheckedColor, 100, Easing.OutQuint);
+        background.FadeToColor(UncheckedColor, 100, Easing.OutQuint);
 
     protected override void OnEnabledChanged(bool enabled) => this.FadeTo(enabled ? 1 : 0.5f, 100, Easing.OutQuint);
 }

--- a/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicSlideBar.cs
@@ -89,9 +89,9 @@ public partial class BasicSliderBar<T> : SliderBar<T> where T : struct, INumber<
 
     protected override void OnFocusLost() => BorderColor = Color.Transparent;
 
-    protected override void OnHovered() => background.FadeToColour(HoverColor, 100, Easing.OutQuint);
+    protected override void OnHovered() => background.FadeToColor(HoverColor, 100, Easing.OutQuint);
 
-    protected override void OnHoverLost() => background.FadeToColour(BackgroundColor, 100, Easing.OutQuint);
+    protected override void OnHoverLost() => background.FadeToColor(BackgroundColor, 100, Easing.OutQuint);
 
     protected override void OnEnabledChanged(bool enabled) => this.FadeTo(enabled ? 1f : 0.5f, 100, Easing.OutQuint);
 }

--- a/Sakura.Framework/Graphics/UserInterface/BasicTextBox.cs
+++ b/Sakura.Framework/Graphics/UserInterface/BasicTextBox.cs
@@ -12,35 +12,35 @@ using Sakura.Framework.Maths;
 namespace Sakura.Framework.Graphics.UserInterface;
 
 /// <summary>
-/// A ready-to-use text box with a green colour scheme.
+/// A ready-to-use text box with a green color scheme.
 /// For a custom-styled text box, extend <see cref="TextBox"/> directly.
 /// </summary>
 public partial class BasicTextBox : TextBox
 {
     private Box BackgroundBox => (Box)Background!;
 
-    private Color backgroundColour = Color.Green;
+    private Color backgroundColor = Color.Green;
 
     /// <summary>
-    /// Background colour while unfocused.
+    /// Background color while unfocused.
     /// </summary>
-    public Color BackgroundColour
+    public Color BackgroundColor
     {
-        get => backgroundColour;
+        get => backgroundColor;
         set
         {
-            backgroundColour = value;
+            backgroundColor = value;
             if (!HasFocus)
                 BackgroundBox.Color = value;
         }
     }
 
     /// <summary>
-    /// Background color while focused. Defaults to a lightened <see cref="BackgroundColour"/>.
+    /// Background color while focused. Defaults to a lightened <see cref="BackgroundColor"/>.
     /// </summary>
-    public Color? BackgroundFocusedColour { get; set; }
+    public Color? BackgroundFocusedColor { get; set; }
 
-    private Color effectiveFocusedColour => BackgroundFocusedColour ?? backgroundColour.Lighten(0.3f);
+    private Color effectiveFocusedColor => BackgroundFocusedColor ?? backgroundColor.Lighten(0.3f);
 
     public BasicTextBox()
     {
@@ -54,7 +54,7 @@ public partial class BasicTextBox : TextBox
     {
         RelativeSizeAxes = Axes.Both,
         Size = new Vector2(1),
-        Color = backgroundColour
+        Color = backgroundColor
     };
 
     protected override Drawable CreateCaret() => new Box
@@ -78,7 +78,7 @@ public partial class BasicTextBox : TextBox
         Alpha = 0f
     };
 
-    protected override void OnFocusGained() => BackgroundBox.FadeToColour(effectiveFocusedColour, 150, Easing.OutQuint);
+    protected override void OnFocusGained() => BackgroundBox.FadeToColor(effectiveFocusedColor, 150, Easing.OutQuint);
 
-    protected override void OnFocusLost() => BackgroundBox.FadeToColour(backgroundColour, 150, Easing.OutQuint);
+    protected override void OnFocusLost() => BackgroundBox.FadeToColor(backgroundColor, 150, Easing.OutQuint);
 }

--- a/Sakura.Framework/Graphics/UserInterface/KeyBinding/BasicKeyBindingRow.cs
+++ b/Sakura.Framework/Graphics/UserInterface/KeyBinding/BasicKeyBindingRow.cs
@@ -42,12 +42,12 @@ public partial class BasicKeyBindingRow<T> : KeyBindingRow<T> where T : struct, 
     private const float gap = 6;
 
     /// <summary>
-    /// Slot background colour when idle.
+    /// Slot background color when idle.
     /// </summary>
     public Color IdleColor { get; init; } = Color.DarkSlateGray;
 
     /// <summary>
-    /// Slot background colour while capturing.
+    /// Slot background color while capturing.
     /// </summary>
     public Color CapturingColor { get; init; } = Color.DarkSlateBlue;
 

--- a/Sakura.Framework/Resources/Shaders/grayscale.frag
+++ b/Sakura.Framework/Resources/Shaders/grayscale.frag
@@ -17,9 +17,9 @@ layout(set = 0, binding = 2, std140) uniform GrayscaleBlock
 
 void main()
 {
-    vec4 colour = texture(u_Texture, v_TexCoords);
+    vec4 color = texture(u_Texture, v_TexCoords);
 
-    float gray = dot(colour.rgb, vec3(0.299, 0.587, 0.114));
+    float gray = dot(color.rgb, vec3(0.299, 0.587, 0.114));
 
     // Modulate by v_Color (always 1,1,1,1 for the effect pass, so a no-op visually) so the varying
     // is not optimised out. Without it the fragment shader's input signature starts at location 1,
@@ -27,5 +27,5 @@ void main()
     // v_TexCoords from the vertex shader's location-0 output (v_Color) instead — sampling a constant
     // texcoord. Keeping location 0 present makes the interpolator registers line up. Matches the main
     // shader's `sampled * v_Color` convention.
-    FragColor = vec4(mix(colour.rgb, vec3(gray), u_Strength), colour.a) * v_Color;
+    FragColor = vec4(mix(color.rgb, vec3(gray), u_Strength), color.a) * v_Color;
 }

--- a/Sakura.Framework/Resources/Shaders/sh_Utils.glsl
+++ b/Sakura.Framework/Resources/Shaders/sh_Utils.glsl
@@ -41,9 +41,9 @@ float sdRoundParallelogram(in vec2 p, in vec2 b, in float sk, in float r) {
 //
 // fragPos    : screen-space position of the fragment (v_FragPos)
 // clipData   : (CenterX, CenterY, HalfWidth, HalfHeight)
-// clipShearX : horizontal shear multiplier 
+// clipShearX : horizontal shear multiplier
 // clipRadius : corner radius of the clip region
-// color      : current fragment colour -- alpha may be reduced by the fade
+// color      : current fragment color -- alpha may be reduced by the fade
 //
 // Returns true if the fragment should be kept, false if it should be discarded.
 bool applyClipping(in vec2 fragPos, in vec4 clipData, in float clipShearX, in float clipRadius, inout vec4 color) {

--- a/Sakura.Framework/Testing/TestBrowserApp.cs
+++ b/Sakura.Framework/Testing/TestBrowserApp.cs
@@ -253,7 +253,7 @@ public partial class TestBrowserApp : App
 
         headerFlow.Add(new HeaderButton("Background", () =>
         {
-            testContentBackgroundBox.FadeToColour(ColorExtensions.GetRandomColor(), 250, Easing.OutQuint);
+            testContentBackgroundBox.FadeToColor(ColorExtensions.GetRandomColor(), 250, Easing.OutQuint);
         }, Color.Transparent));
 
         clockRateSlider.Current.ValueChanged += e =>
@@ -913,20 +913,20 @@ public partial class TestBrowserApp : App
         public override bool OnHover(MouseEvent e)
         {
             backgroundBox.Color = originalBackgroundColor;
-            backgroundBox.FadeToColour(originalBackgroundColor.Lighten(0.5f), 50, Easing.OutQuint);
+            backgroundBox.FadeToColor(originalBackgroundColor.Lighten(0.5f), 50, Easing.OutQuint);
             return base.OnHover(e);
         }
 
         public override bool OnHoverLost(MouseEvent e)
         {
-            backgroundBox.FadeToColour(originalBackgroundColor, 50, Easing.OutQuint);
+            backgroundBox.FadeToColor(originalBackgroundColor, 50, Easing.OutQuint);
             return base.OnHoverLost(e);
         }
 
         public void Flash()
         {
             backgroundBox.Color = originalBackgroundColor;
-            backgroundBox.FlashColour(Color.White, 500, Easing.OutQuint);
+            backgroundBox.FlashColor(Color.White, 500, Easing.OutQuint);
         }
     }
 
@@ -981,26 +981,26 @@ public partial class TestBrowserApp : App
         public void SetState(bool isSuccess)
         {
             statusBox.Color = isSuccess ? Color.LimeGreen : Color.Red;
-            statusBox.FlashColour(isSuccess ? Color.LimeGreen.Lighten(0.5f) : Color.Red.Lighten(0.5f), 500, Easing.OutQuint);
+            statusBox.FlashColor(isSuccess ? Color.LimeGreen.Lighten(0.5f) : Color.Red.Lighten(0.5f), 500, Easing.OutQuint);
         }
 
         public override bool OnHover(MouseEvent e)
         {
             backgroundBox.Color = originalBackgroundColor;
-            backgroundBox.FadeToColour(originalBackgroundColor.Lighten(0.5f), 50, Easing.OutQuint);
+            backgroundBox.FadeToColor(originalBackgroundColor.Lighten(0.5f), 50, Easing.OutQuint);
             return base.OnHover(e);
         }
 
         public override bool OnHoverLost(MouseEvent e)
         {
-            backgroundBox.FadeToColour(originalBackgroundColor, 50, Easing.OutQuint);
+            backgroundBox.FadeToColor(originalBackgroundColor, 50, Easing.OutQuint);
             return base.OnHoverLost(e);
         }
 
         public void Flash()
         {
             backgroundBox.Color = originalBackgroundColor;
-            backgroundBox.FlashColour(Color.White, 500, Easing.OutQuint);
+            backgroundBox.FlashColor(Color.White, 500, Easing.OutQuint);
         }
 
         public void UpdateText(string newText)


### PR DESCRIPTION
Really want to do this for a long time now. 

Since [Tomori era](https://github.com/HelloYeew/tomori) we normally using american english in all place ("color" too) but due to the external library variable usage and my bad some new variable are using "colour" instead. So just take a time during benchmark run on new change to do this.

Thx to Rider for letting me do this in 5 minutes

TODO:

- [x] Breaking change notice