### PR TITLE
Fix shader clipping issues and more problem related to masking

### DIFF
--- a/Sakura.Framework.Tests/Graphics/ContainerMaskScaleTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ContainerMaskScaleTest.cs
@@ -1,0 +1,272 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.IO;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Platform;
+using Sakura.Framework.Timing;
+using VertexData = Sakura.Framework.Graphics.Rendering.Vertex.Vertex;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+[TestFixture]
+public class ContainerMaskScaleTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock { CurrentTime = 1000 };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+    }
+
+    private void frame(double advanceMs = 16)
+    {
+        manual.CurrentTime += advanceMs;
+        root.UpdateSubTree();
+    }
+
+    private void settle()
+    {
+        for (int i = 0; i < 5; i++)
+            frame();
+    }
+
+    /// <summary>
+    /// Renders the container's draw node and returns the single mask that was pushed.
+    /// </summary>
+    private static RecordingRenderer.MaskCall pushDrawNode(Container container)
+    {
+        var recorder = new RecordingRenderer();
+        var node = (ContainerDrawNode)container.GenerateDrawNode(0);
+        node.Draw(recorder);
+
+        Assert.That(recorder.Pushes, Has.Count.EqualTo(1), "Masking container must push exactly one mask.");
+        return recorder.Pushes[0];
+    }
+
+    /// <summary>
+    /// A <see cref="CircularContainer"/> under a 2x ancestor scale. Before the fix the mask received the
+    /// unscaled radius (DrawSize/2 in logical space) against a doubled screen half-size, producing a
+    /// squircle. After the fix the radius scales too, so radius == half-size on both axes — a true circle.
+    /// </summary>
+    [Test]
+    public void TestCircularContainerStaysCircleUnderScale()
+    {
+        CircularContainer circle = null!;
+
+        var scaled = new Container
+        {
+            Scale = new Vector2(2f),
+            Size = new Vector2(200, 200),
+            Child = circle = new CircularContainer
+            {
+                Size = new Vector2(100, 100)
+            }
+        };
+
+        root.Add(scaled);
+        settle();
+
+        var mask = pushDrawNode(circle);
+
+        Assert.Multiple(() =>
+        {
+            // 100px logical -> 50px logical radius -> 100px screen half-size at 2x scale.
+            Assert.That(mask.HalfSize.X, Is.EqualTo(100).Within(0.05f), "Screen half-size must reflect the 2x scale.");
+            Assert.That(mask.HalfSize.Y, Is.EqualTo(100).Within(0.05f));
+
+            // The circle invariant: corner radius must equal the screen half-size, not the logical 50.
+            Assert.That(mask.CornerRadius, Is.EqualTo(mask.HalfSize.X).Within(0.05f),
+                "CircularContainer corner radius must scale with the half-size to stay a circle under scale.");
+        });
+    }
+
+    /// <summary>
+    /// A fractional (0.5x) scale must shrink the radius in lock-step too, so the shape over-rounds neither
+    /// way. Radius stays equal to the (halved) screen half-size.
+    /// </summary>
+    [Test]
+    public void TestCircularContainerStaysCircleUnderDownscale()
+    {
+        CircularContainer circle = null!;
+
+        var scaled = new Container
+        {
+            Scale = new Vector2(0.5f),
+            Size = new Vector2(200, 200),
+            Child = circle = new CircularContainer
+            {
+                Size = new Vector2(100, 100)
+            }
+        };
+
+        root.Add(scaled);
+        settle();
+
+        var mask = pushDrawNode(circle);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mask.HalfSize.X, Is.EqualTo(25).Within(0.05f), "100px at 0.5x → 25px screen half-size.");
+            Assert.That(mask.CornerRadius, Is.EqualTo(mask.HalfSize.X).Within(0.05f),
+                "Corner radius must track the down-scaled half-size.");
+        });
+    }
+
+    /// <summary>
+    /// At scale 1 the radius is unchanged — the fix must not regress the common unscaled case.
+    /// </summary>
+    [Test]
+    public void TestUnscaledCornerRadiusUnchanged()
+    {
+        Container box;
+
+        var parent = new Container
+        {
+            Size = new Vector2(200, 200),
+            Child = box = new Container
+            {
+                Size = new Vector2(120, 80),
+                Masking = true,
+                CornerRadius = 16
+            }
+        };
+
+        root.Add(parent);
+        settle();
+
+        var mask = pushDrawNode(box);
+
+        Assert.That(mask.CornerRadius, Is.EqualTo(16).Within(0.05f),
+            "At scale 1 the corner radius must equal the authored logical value.");
+    }
+
+    /// <summary>
+    /// A rounded, bordered container under a 2x scale: both the corner radius and the border thickness
+    /// are logical-space values that must be scaled into screen space when popped, so the border keeps a
+    /// consistent visual weight and corner curvature under scale.
+    /// </summary>
+    [Test]
+    public void TestBorderThicknessAndRadiusScaleTogether()
+    {
+        Container bordered = null!;
+
+        var scaled = new Container
+        {
+            Scale = new Vector2(2f),
+            Size = new Vector2(300, 300),
+            Child = bordered = new Container
+            {
+                Size = new Vector2(100, 100),
+                Masking = true,
+                CornerRadius = 10,
+                BorderThickness = 4,
+                BorderColor = Color.White
+            }
+        };
+
+        root.Add(scaled);
+        settle();
+
+        var recorder = new RecordingRenderer();
+        var node = (ContainerDrawNode)bordered.GenerateDrawNode(0);
+        node.Draw(recorder);
+
+        Assert.That(recorder.Pops, Has.Count.EqualTo(1), "Masking container must pop exactly one mask.");
+        var pop = recorder.Pops[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pop.CornerRadius, Is.EqualTo(20).Within(0.05f), "CornerRadius 10 at 2x → 20 screen.");
+            Assert.That(pop.BorderThickness, Is.EqualTo(8).Within(0.05f), "BorderThickness 4 at 2x → 8 screen.");
+        });
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IRenderer"/> that records the geometry passed to <c>PushMask</c>/<c>PopMask</c>.
+    /// Everything else is a no-op — <see cref="ContainerDrawNode.Draw"/> only touches these masking calls
+    /// (its child list is empty when the node is generated in isolation).
+    /// </summary>
+    private sealed class RecordingRenderer : IRenderer
+    {
+        public readonly struct MaskCall
+        {
+            public MaskCall(Vector2 center, Vector2 halfSize, float shearX, float cornerRadius, float borderThickness)
+            {
+                Center = center;
+                HalfSize = halfSize;
+                ShearX = shearX;
+                CornerRadius = cornerRadius;
+                BorderThickness = borderThickness;
+            }
+
+            public Vector2 Center { get; }
+            public Vector2 HalfSize { get; }
+            public float ShearX { get; }
+            public float CornerRadius { get; }
+            public float BorderThickness { get; }
+        }
+
+        public List<MaskCall> Pushes { get; } = new();
+        public List<MaskCall> Pops { get; } = new();
+
+        public void PushMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius)
+            => Pushes.Add(new MaskCall(maskCenter, maskHalfSize, shearX, cornerRadius, 0f));
+
+        public void PopMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<VertexData> maskVertices = default)
+            => Pops.Add(new MaskCall(maskCenter, maskHalfSize, shearX, cornerRadius, borderThickness));
+
+        public void DrawEdgeEffect(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius, float edgeRadius, Vector2 offset, Color color, bool glow, bool hollow, ReadOnlySpan<VertexData> quadVertices) { }
+
+        // unused members
+        public Texture WhitePixel => throw new NotSupportedException();
+        public Matrix4x4 ProjectionMatrix => default;
+        public Storage ShaderStorage { get; set; } = null!;
+        public DiskCache ShaderCache { get; set; } = null!;
+        public Vector2 RenderScale => Vector2.One;
+
+        void IRenderer.Initialize(IGraphicsSurface graphicsSurface) { }
+        public void Clear() { }
+        public void StartFrame() { }
+        public void SetRoot(DrawNode rootDrawNode) { }
+        public void Resize(int physicalWidth, int physicalHeight, int logicalWidth, int logicalHeight) { }
+        public void Draw(IClock clock) { }
+        public void DrawVertices(ReadOnlySpan<VertexData> vertices, Texture textureGl) { }
+        public void DrawQuads(ReadOnlySpan<VertexData> vertices, Texture textureGl) { }
+        public void SetBlendMode(BlendingMode blendingMode) { }
+        public void ScheduleToDrawThread(Action action) { }
+        public void FlushBatch() { }
+        public void RestoreMainShader() { }
+        public IShader CreateShader(Storage storage, string vertexPath, string fragmentPath) => throw new NotSupportedException();
+        public INativeVideoTexture CreateVideoTexture(int width, int height) => throw new NotSupportedException();
+        public INativeTexture CreateNativeTexture(int width, int height) => throw new NotSupportedException();
+        public IFrameBuffer CreateFrameBuffer(int width, int height, bool pixelSnapping = false) => throw new NotSupportedException();
+        public void BindFrameBuffer(IFrameBuffer frameBuffer, RectangleF sourceRect, Color clearColor = default) { }
+        public void UnbindFrameBuffer() { }
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/ContainerMaskScaleTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ContainerMaskScaleTest.cs
@@ -18,6 +18,9 @@ using VertexData = Sakura.Framework.Graphics.Rendering.Vertex.Vertex;
 
 namespace Sakura.Framework.Tests.Graphics;
 
+/// <summary>
+/// Regression test of https://github.com/HelloYeew/sakura/pull/152
+/// </summary>
 [TestFixture]
 public class ContainerMaskScaleTest
 {

--- a/Sakura.Framework.Tests/Graphics/FlowContainerPaddingTest.cs
+++ b/Sakura.Framework.Tests/Graphics/FlowContainerPaddingTest.cs
@@ -1,0 +1,270 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+[TestFixture]
+public class FlowContainerPaddingTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock { CurrentTime = 1000 };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+    }
+
+    private void frame(double advanceMs = 16)
+    {
+        manual.CurrentTime += advanceMs;
+        root.UpdateSubTree();
+    }
+
+    // Flow layout + auto-size + relative resolution need several passes to settle.
+    private void settle()
+    {
+        for (int i = 0; i < 5; i++)
+            frame();
+    }
+
+    /// <summary>
+    /// The exact scenario measured in the fix plan: a 260-wide panel → vertical
+    /// <see cref="FlowContainer"/> (relative width, auto height, 15px padding) → a relatively-sized
+    /// child. The child width is 260 − 30 = 230, its left edge sits 15px (one padding) inside the
+    /// flow, and its right edge lands on the inner content edge (flow.Right − 15), NOT the flow's
+    /// outer edge.
+    /// </summary>
+    [Test]
+    public void TestRelativeChildHonoursPaddingOnce()
+    {
+        Container flow = null!;
+        Container child = null!;
+
+        var panel = new Container
+        {
+            Position = new Vector2(40, 30),
+            Size = new Vector2(260, 380),
+            Child = flow = new FlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FlowDirection.Vertical,
+                Padding = new MarginPadding(15),
+                Child = child = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 40
+                }
+            }
+        };
+
+        root.Add(panel);
+        settle();
+
+        float flowLeft = flow.DrawRectangle.X;
+        float flowRight = flow.DrawRectangle.X + flow.DrawRectangle.Width;
+
+        Assert.Multiple(() =>
+        {
+            // Content width = flow width (260) minus both horizontal paddings (30).
+            Assert.That(child.DrawSize.X, Is.EqualTo(230).Within(0.01f),
+                "Relative child width must be flow width minus total horizontal padding.");
+
+            // Left edge is exactly ONE Padding.Left inside the flow (30 = 2x15 was the bug).
+            Assert.That(child.DrawRectangle.X - flowLeft, Is.EqualTo(15).Within(0.01f),
+                "Child left edge must sit exactly one Padding.Left inside the flow, not two.");
+
+            // Right edge lands on the inner content edge, not the flow's outer edge.
+            float childRight = child.DrawRectangle.X + child.DrawSize.X;
+            Assert.That(childRight, Is.EqualTo(flowRight - 15).Within(0.01f),
+                "Relative child right edge must stop at the inner content edge (flow.Right - Padding.Right).");
+            Assert.That(childRight, Is.LessThan(flowRight),
+                "Relative child must not overflow past the flow's outer edge.");
+        });
+    }
+
+    /// <summary>
+    /// A plain (non-relative) child in a padded flow must start at exactly <c>Padding.Left/Top</c>
+    /// relative to the flow — proving the fix applies to all flow children, not only relatively-sized
+    /// ones.
+    /// </summary>
+    [Test]
+    public void TestNonRelativeChildStartsAtPadding()
+    {
+        Container flow = null!;
+        Box child = null!;
+
+        var panel = new Container
+        {
+            Position = new Vector2(40, 30),
+            Size = new Vector2(260, 380),
+            Child = flow = new FlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FlowDirection.Vertical,
+                Padding = new MarginPadding(15),
+                Child = child = new Box
+                {
+                    Size = new Vector2(50, 40)
+                }
+            }
+        };
+
+        root.Add(panel);
+        settle();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(child.DrawRectangle.X - flow.DrawRectangle.X, Is.EqualTo(15).Within(0.01f),
+                "Non-relative child left edge must equal Padding.Left.");
+            Assert.That(child.DrawRectangle.Y - flow.DrawRectangle.Y, Is.EqualTo(15).Within(0.01f),
+                "Non-relative child top edge must equal Padding.Top.");
+        });
+    }
+
+    /// <summary>
+    /// An auto-sizing flow must still wrap its content plus BOTH padding edges. With a single 40px-tall
+    /// row and 15px padding the auto height is 40 + 30 = 70 — unchanged by the position fix.
+    /// </summary>
+    [Test]
+    public void TestAutoSizeIncludesBothPaddingEdges()
+    {
+        Container flow = null!;
+
+        var panel = new Container
+        {
+            Position = new Vector2(40, 30),
+            Size = new Vector2(260, 380),
+            Child = flow = new FlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FlowDirection.Vertical,
+                Padding = new MarginPadding(15),
+                Child = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 40
+                }
+            }
+        };
+
+        root.Add(panel);
+        settle();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(flow.DrawSize.X, Is.EqualTo(260).Within(0.01f), "Relative-width flow must fill the panel width.");
+            Assert.That(flow.DrawSize.Y, Is.EqualTo(70).Within(0.01f), "Auto height must be content (40) + top + bottom padding (30).");
+        });
+    }
+
+    /// <summary>
+    /// Follow-up to Bug 2: a flow child's OWN <see cref="Drawable.Margin"/> used to be double-applied
+    /// too — <c>PerformLayout</c> baked <c>Margin.Left/Top</c> into the child's <c>Position</c> while
+    /// <see cref="Drawable.UpdateTransforms"/> added it again. With a flow <c>Padding(15)</c> and a
+    /// child <c>Margin(10)</c>, the child must land 25px (15 + 10) inside the flow, not 35px (15 + 2x10).
+    /// </summary>
+    [Test]
+    public void TestChildMarginAppliedOnce()
+    {
+        Container flow = null!;
+        Box child = null!;
+
+        var panel = new Container
+        {
+            Position = new Vector2(40, 30),
+            Size = new Vector2(260, 380),
+            Child = flow = new FlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FlowDirection.Vertical,
+                Padding = new MarginPadding(15),
+                Child = child = new Box
+                {
+                    Size = new Vector2(50, 40),
+                    Margin = new MarginPadding(10)
+                }
+            }
+        };
+
+        root.Add(panel);
+        settle();
+
+        Assert.Multiple(() =>
+        {
+            // Padding.Left (15) + Margin.Left (10) = 25. The bug produced 35 (15 + 2x10).
+            Assert.That(child.DrawRectangle.X - flow.DrawRectangle.X, Is.EqualTo(25).Within(0.01f),
+                "Child left edge must be Padding.Left + Margin.Left, with the margin applied exactly once.");
+            Assert.That(child.DrawRectangle.Y - flow.DrawRectangle.Y, Is.EqualTo(25).Within(0.01f),
+                "Child top edge must be Padding.Top + Margin.Top, with the margin applied exactly once.");
+
+            // Auto height wraps the child's full margin box plus both paddings: 40 + 2x10 + 2x15 = 90.
+            Assert.That(flow.DrawSize.Y, Is.EqualTo(40 + 20 + 30).Within(0.01f),
+                "Auto height must include the child's full margin box (40 + 2x10) plus both paddings (30).");
+        });
+    }
+
+    /// <summary>
+    /// An auto-sizing flow on BOTH axes fits its widest/tallest content plus padding on each side.
+    /// </summary>
+    [Test]
+    public void TestAutoSizeBothAxesAroundContent()
+    {
+        Container flow = null!;
+
+        var panel = new Container
+        {
+            Position = new Vector2(40, 30),
+            Size = new Vector2(400, 400),
+            Child = flow = new FlowContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FlowDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+                Padding = new MarginPadding(15),
+                Children = new Drawable[]
+                {
+                    new Box { Size = new Vector2(120, 40) },
+                    new Box { Size = new Vector2(80, 30) }
+                }
+            }
+        };
+
+        root.Add(panel);
+        settle();
+
+        Assert.Multiple(() =>
+        {
+            // Widest child (120) + both paddings (30).
+            Assert.That(flow.DrawSize.X, Is.EqualTo(120 + 30).Within(0.01f));
+            // 40 + 6 spacing + 30 = 76 content, + both paddings (30) = 106.
+            Assert.That(flow.DrawSize.Y, Is.EqualTo(40 + 6 + 30 + 30).Within(0.01f));
+        });
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/FlowContainerPaddingTest.cs
+++ b/Sakura.Framework.Tests/Graphics/FlowContainerPaddingTest.cs
@@ -11,6 +11,9 @@ using Sakura.Framework.Timing;
 
 namespace Sakura.Framework.Tests.Graphics;
 
+/// <summary>
+/// Regression test of https://github.com/HelloYeew/sakura/pull/152
+/// </summary>
 [TestFixture]
 public class FlowContainerPaddingTest
 {

--- a/Sakura.Framework.Tests/Visuals/Containers/TestFlowContainer.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestFlowContainer.cs
@@ -129,8 +129,15 @@ public partial class TestFlowContainer : TestScene
             Precision.AlmostEquals(flow.Width, content_width + padding * 2));
         AddAssert("Height includes top and bottom padding", () =>
             Precision.AlmostEquals(flow.Height, child_size + padding * 2));
+        // Position is now padding-free: PerformLayout stores the bare flow position and
+        // Drawable.UpdateTransforms applies the parent padding once. The resolved on-screen
+        // position must therefore sit exactly one padding inside the flow (not two).
         AddAssert("First child offset by left/top padding", () =>
-            Precision.AlmostEquals(flow.Children.First().Position, new Vector2(padding, padding)));
+        {
+            var child = flow.Children.First();
+            return Precision.AlmostEquals(child.DrawRectangle.X - flow.DrawRectangle.X, padding)
+                   && Precision.AlmostEquals(child.DrawRectangle.Y - flow.DrawRectangle.Y, padding);
+        });
     }
 
     [Test]

--- a/Sakura.Framework.Tests/Visuals/Containers/TestNestedMaskingClip.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestNestedMaskingClip.cs
@@ -12,6 +12,9 @@ using Sakura.Framework.Testing;
 
 namespace Sakura.Framework.Tests.Visuals.Containers;
 
+/// <summary>
+/// Regression test of https://github.com/HelloYeew/sakura/pull/152
+/// </summary>
 public partial class TestNestedMaskingClip : TestScene
 {
     private const float panel_width = 260;

--- a/Sakura.Framework.Tests/Visuals/Containers/TestNestedMaskingClip.cs
+++ b/Sakura.Framework.Tests/Visuals/Containers/TestNestedMaskingClip.cs
@@ -1,0 +1,229 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.UserInterface;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Testing;
+
+namespace Sakura.Framework.Tests.Visuals.Containers;
+
+public partial class TestNestedMaskingClip : TestScene
+{
+    private const float panel_width = 260;
+    private const float panel_height = 380;
+
+    [SetUp]
+    public void SetUp()
+    {
+        AddStep("Clear screen", Clear);
+
+        AddStep("Add leak-detector backdrop", () => Add(new Box
+        {
+            RelativeSizeAxes = Axes.Both,
+            Color = Color.Magenta
+        }));
+    }
+
+    /// <summary>
+    /// App structure from real situation
+    /// </summary>
+    [Test]
+    public void TestColorPickerInScrollPanel()
+    {
+        ScrollableContainer scroll = null!;
+
+        AddStep("Add panel with scrolling color picker", () =>
+        {
+            Add(new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(panel_width, panel_height),
+                Masking = true, // clip any content that overflows the panel bounds
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0.6f,
+                        Color = Color.Black
+                    },
+                    scroll = new ScrollableContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = ScrollDirection.Vertical,
+                        AutoHideScrollbars = true,
+                        Child = new FlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FlowDirection.Vertical,
+                            Spacing = new Vector2(6, 6),
+                            Padding = new MarginPadding(15),
+                            Children = new Drawable[]
+                            {
+                                filler("Adjustments", Color.Orange),
+                                filler("Row A", Color.White),
+                                filler("Row B", Color.White),
+                                filler("Row C", Color.White),
+                                filler("Row D", Color.White),
+                                filler("Row E", Color.White),
+                                filler("Overlay colors", Color.Orange),
+                                new BasicColorPicker
+                                {
+                                    SaturationValueAreaSize = new Vector2(220, 130)
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        AddUntilStep("wait for layout", () => scroll.ScrollableExtent.Y > 0);
+
+        AddStep("Scroll to end (picker fully in view)", () => scroll.ScrollToEnd(animated: false));
+
+        AddSliderStep("Scroll position", 0f, 1f, 1f, v =>
+        {
+            if (scroll != null)
+                scroll.ScrollTo(new Vector2(0, v * scroll.ScrollableExtent.Y), animated: false);
+        });
+    }
+
+    [Test]
+    public void TestRoundedChildStraddlesOuterEdge()
+    {
+        Container roundedChild = null!;
+        Container panel = null!;
+
+        AddStep("Add panel with rounded child", () =>
+        {
+            Add(panel = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(panel_width, panel_height),
+                Masking = true,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0.6f,
+                        Color = Color.Black
+                    },
+                    roundedChild = new Container
+                    {
+                        Anchor = Anchor.TopLeft,
+                        Origin = Anchor.TopLeft,
+                        Size = new Vector2(220, 160),
+                        Masking = true,
+                        CornerRadius = 8,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Color = Color.LimeGreen
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        AddSliderStep("Child Y offset", 0f, panel_height + 40, panel_height - 120, y =>
+        {
+            if (roundedChild != null)
+                roundedChild.Y = y;
+        });
+
+        AddStep("Park child half past bottom edge", () =>
+        {
+            if (roundedChild != null)
+                roundedChild.Y = panel_height - 60;
+        });
+    }
+
+    [Test]
+    public void TestBorderLeaksPastAncestorMask()
+    {
+        Container borderedChild = null!;
+
+        AddStep("Add panel with bordered child", () =>
+        {
+            Add(new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(panel_width, panel_height),
+                Masking = true,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0.6f,
+                        Color = Color.Black
+                    },
+                    borderedChild = new Container
+                    {
+                        Anchor = Anchor.TopLeft,
+                        Origin = Anchor.TopLeft,
+                        Size = new Vector2(200, 120),
+                        Masking = true,
+                        CornerRadius = 12,
+                        BorderThickness = 6,
+                        BorderColor = Color.White,
+                        Child = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Color = Color.DarkGreen
+                        }
+                    }
+                }
+            });
+        });
+
+        AddSliderStep("Child Y offset", 0f, panel_height + 40, panel_height - 150, y =>
+        {
+            if (borderedChild != null)
+                borderedChild.Y = y;
+        });
+
+        AddStep("Park child straddling bottom edge", () =>
+        {
+            if (borderedChild != null)
+                borderedChild.Y = panel_height - 40;
+        });
+    }
+
+    private static Container filler(string text, Color color) => new Container
+    {
+        RelativeSizeAxes = Axes.X,
+        Height = 40,
+        Children = new Drawable[]
+        {
+            new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Alpha = 0.25f,
+                Color = Color.White
+            },
+            new SpriteText
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Margin = new MarginPadding { Left = 8 },
+                Text = text,
+                Color = color
+            }
+        }
+    };
+}

--- a/Sakura.Framework/Graphics/Containers/FlowContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/FlowContainer.cs
@@ -179,16 +179,13 @@ public partial class FlowContainer : Container
                     ? new Vector2(currentFlow, lineStartCross)
                     : new Vector2(lineStartCross, currentFlow);
 
-                // include the child's own margin and the container's padding.
-                var childPosPixels = new Vector2(basePos.X + child.Margin.Left, basePos.Y + child.Margin.Top);
-                var finalPos = new Vector2(childPosPixels.X + Padding.Left, childPosPixels.Y + Padding.Top);
+                if (!Precision.AlmostEquals(child.Position, basePos))
+                    child.Position = basePos;
 
-                if (!Precision.AlmostEquals(child.Position, finalPos))
-                    child.Position = finalPos;
-
-                // track content size (for auto-sizing).
-                float childRight = finalPos.X + drawSize.X + child.Margin.Right;
-                float childBottom = finalPos.Y + drawSize.Y + child.Margin.Bottom;
+                // Track content size (for auto-sizing). The measure spans the child's full margin box
+                // starting at basePos, decoupled from the (margin-free) stored Position above.
+                float childRight = basePos.X + totalSize.X;
+                float childBottom = basePos.Y + totalSize.Y;
 
                 if (childRight > maxRight) maxRight = childRight;
                 if (childBottom > maxBottom) maxBottom = childBottom;
@@ -217,11 +214,13 @@ public partial class FlowContainer : Container
     {
         Vector2 newSize = Size;
 
+        // maxRight/maxBottom are now padding-free (see PerformLayout), so add the full padding on each
+        // axis to size the container around its content plus both padding edges.
         if ((AutoSizeAxes & Axes.X) != 0)
-            newSize.X = maxRight + Padding.Right;
+            newSize.X = maxRight + Padding.Total.X;
 
         if ((AutoSizeAxes & Axes.Y) != 0)
-            newSize.Y = maxBottom + Padding.Bottom;
+            newSize.Y = maxBottom + Padding.Total.Y;
 
         if (!Precision.AlmostEquals(Size, newSize))
             Size = newSize;

--- a/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
@@ -70,14 +70,23 @@ public class ContainerDrawNode : DrawNode
         float scaleY = DrawSize.Y > 0 ? screenHalfSize.Y / (DrawSize.Y * 0.5f) : 1f;
         float uniformScale = (scaleX + scaleY) * 0.5f;
 
+        // CornerRadius and BorderThickness are authored in local (logical) pixels, but the mask/border
+        // shader compares them against the screen-space half-size, which already includes every ancestor
+        // Scale. Convert both into screen space so a CircularContainer (CornerRadius == DrawSize/2) stays
+        // a circle under scale instead of turning into a squircle. Matches the edge-effect convention.
+        // Non-uniform scale (scaleX != scaleY) can't be expressed by a single-float radius; the average
+        // is the pragmatic choice and matches the edge-effect path.
+        float cornerRadiusScreen = CornerRadius * uniformScale;
+        float borderThicknessScreen = BorderThickness * uniformScale;
+
         bool hasEdgeEffect = EdgeEffect.Type != EdgeEffectType.None && EdgeEffect.Color.A > 0;
 
         // Shadows render behind the container's contents.
         if (hasEdgeEffect && EdgeEffect.Type == EdgeEffectType.Shadow)
-            drawEdgeEffect(renderer, screenCenter, screenHalfSize, scaleX, scaleY, uniformScale);
+            drawEdgeEffect(renderer, screenCenter, screenHalfSize, scaleX, scaleY, uniformScale, cornerRadiusScreen);
 
         if (Masking)
-            renderer.PushMask(screenCenter, screenHalfSize, ShearX, CornerRadius);
+            renderer.PushMask(screenCenter, screenHalfSize, ShearX, cornerRadiusScreen);
 
         foreach (var child in Children)
         {
@@ -102,11 +111,11 @@ public class ContainerDrawNode : DrawNode
         }
 
         if (Masking)
-            renderer.PopMask(screenCenter, screenHalfSize, ShearX, CornerRadius, BorderThickness, BorderColor, Vertices);
+            renderer.PopMask(screenCenter, screenHalfSize, ShearX, cornerRadiusScreen, borderThicknessScreen, BorderColor, Vertices);
 
         // Glows render on top of the container's contents.
         if (hasEdgeEffect && EdgeEffect.Type == EdgeEffectType.Glow)
-            drawEdgeEffect(renderer, screenCenter, screenHalfSize, scaleX, scaleY, uniformScale);
+            drawEdgeEffect(renderer, screenCenter, screenHalfSize, scaleX, scaleY, uniformScale, cornerRadiusScreen);
     }
 
     /// <summary>
@@ -114,15 +123,14 @@ public class ContainerDrawNode : DrawNode
     /// The quad covers the container shape inflated by the (screen-space) edge radius so that the
     /// shader's signed-distance falloff has room to render; the shape itself is shaded in the fragment shader.
     /// </summary>
-    private void drawEdgeEffect(IRenderer renderer, Vector2 screenCenter, Vector2 screenHalfSize, float scaleX, float scaleY, float uniformScale)
+    private void drawEdgeEffect(IRenderer renderer, Vector2 screenCenter, Vector2 screenHalfSize, float scaleX, float scaleY, float uniformScale, float cornerRadiusScreen)
     {
         float edgeRadiusScreen = Math.Max(0f, EdgeEffect.Radius) * uniformScale;
 
-        // The effect must follow the container's exact corner curvature, so it uses the SAME
-        // corner-radius convention as the masking/border path (unscaled CornerRadius against the
-        // screen-space half size). Roundness is an optional adjustment expressed in the same units.
-        // Using the scaled value here would make the glow corners visibly rounder than the box.
-        float cornerRadius = CornerRadius + Math.Max(0f, EdgeEffect.Roundness);
+        // The effect follows the container's exact corner curvature, so it shares the same screen-space
+        // corner radius the masking/border path uses. Roundness is an optional adjustment expressed in
+        // local pixels, scaled to match.
+        float cornerRadius = cornerRadiusScreen + Math.Max(0f, EdgeEffect.Roundness) * uniformScale;
 
         Vector2 offsetScreen = new Vector2(EdgeEffect.Offset.X * scaleX, EdgeEffect.Offset.Y * scaleY);
 

--- a/Sakura.Framework/Graphics/UserInterface/ColorPicker.cs
+++ b/Sakura.Framework/Graphics/UserInterface/ColorPicker.cs
@@ -99,13 +99,13 @@ public abstract partial class ColorPicker : Container
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    ColorInfo = ColorInfo.GradientHorizontal(Color.White, Color.White.WithAlpha((byte)0))
+                    ColorInfo = ColorInfo.GradientHorizontal(Color.White, Color.White.WithAlpha(0))
                 },
                 // Transparent at the top fading to black at the bottom (value falls off downward).
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    ColorInfo = ColorInfo.GradientVertical(Color.Black.WithAlpha((byte)0), Color.Black)
+                    ColorInfo = ColorInfo.GradientVertical(Color.Black.WithAlpha(0), Color.Black)
                 },
                 new NonPositionalContainer
                 {

--- a/Sakura.Framework/Resources/Shaders/shader.frag
+++ b/Sakura.Framework/Resources/Shaders/shader.frag
@@ -95,6 +95,12 @@ void main()
         if (finalColor.a <= 0.0) discard;
 
         FragColor = finalColor;
+
+        // Borders must honour any enclosing parent mask, exactly like the edge-effect path above.
+        // Without this the border quad is drawn everywhere its own geometry reaches, so a bordered
+        // masking child leaks its border past a rectangular ancestor mask.
+        if (!applyClipping(v_FragPos, v_ClipData, v_ClipShearX, v_ClipRadius, FragColor))
+            discard;
         return;
     }
 

--- a/Sakura.Framework/Testing/TestBrowserApp.cs
+++ b/Sakura.Framework/Testing/TestBrowserApp.cs
@@ -162,10 +162,89 @@ public partial class TestBrowserApp : App
                 loadTest(currentTest.GetType());
         }, Color.Transparent));
 
-        headerFlow.Add(autoRunCheckbox = new BasicCheckbox()
+        headerFlow.Add(new Container()
         {
             Anchor = Anchor.CentreLeft,
-            Origin = Anchor.CentreLeft
+            Origin = Anchor.CentreLeft,
+            RelativeSizeAxes = Axes.Y,
+            Size = new Vector2(1000, 1),
+            Child = new FlowContainer()
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Spacing = new Vector2(5, 0),
+                Children = new Drawable[]
+                {
+                    autoRunCheckbox = new BasicCheckbox()
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Size = new Vector2(20)
+                    },
+                    new SpriteText()
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = "Auto Run",
+                        Margin = new MarginPadding { Right = 20 },
+                        Font = FontUsage.Default.With(size: 15)
+                    },
+                    new SpriteText()
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = "Volume",
+                        Font = FontUsage.Default.With(size: 15)
+                    },
+                    volumeSlider = new BasicSliderBar<double>()
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Size = new Vector2(150, 20),
+                        MinValue = 0,
+                        MaxValue = 1
+                    },
+                    new SpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = "Rate",
+                        Font = FontUsage.Default.With(size: 15),
+                        Margin = new MarginPadding { Left = 10, Right = 10 }
+                    },
+                    clockRateSlider = new BasicSliderBar<double>
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Size = new Vector2(120, 20),
+                        MinValue = 0.0,
+                        MaxValue = 4.0
+                    },
+                    new ClickableContainer
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        AutoSizeAxes = Axes.X,
+                        RelativeSizeAxes = Axes.Y,
+                        Margin = new MarginPadding { Left = 4 },
+                        Action = () => clockRateSlider.Current.Value = 1.0,
+                        Child = clockRateLabel = new SpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Text = "1.00×",
+                            Font = FontUsage.Default.With(size: 14),
+                            Color = Color.LightGreen,
+                            Width = 60
+                        }
+                    },
+                    new HeaderButton("Background", () =>
+                    {
+                        testContentBackgroundBox.FadeToColor(ColorExtensions.GetRandomColor(), 250, Easing.OutQuint);
+                    }, Color.Transparent)
+                }
+            }
         });
 
         autoRunCheckbox.Current.BindTo(autoRunEnabled);
@@ -181,80 +260,12 @@ public partial class TestBrowserApp : App
             }
         };
 
-        headerFlow.Add(new SpriteText()
-        {
-            Anchor = Anchor.CentreLeft,
-            Origin = Anchor.CentreLeft,
-            Text = "Auto Run",
-            Margin = new MarginPadding { Right = 20 },
-            Font = FontUsage.Default.With(size: 15)
-        });
-
-        headerFlow.Add(new SpriteText()
-        {
-            Anchor = Anchor.CentreLeft,
-            Origin = Anchor.CentreLeft,
-            Text = "Volume",
-            Font = FontUsage.Default.With(size: 15)
-        });
-
-        headerFlow.Add(volumeSlider = new BasicSliderBar<double>()
-        {
-            Anchor = Anchor.CentreLeft,
-            Origin = Anchor.CentreLeft,
-            Size = new Vector2(150, 20),
-            MinValue = 0,
-            MaxValue = 1
-        });
-
         var volumeReactive = Host.FrameworkConfigManager.Get<double>(FrameworkSetting.MasterVolume);
         volumeSlider.Current.Value = volumeReactive.Value;
 
         volumeReactive.BindValueChanged(e => volumeSlider.Current.Value = e.NewValue, true);
 
-        headerFlow.Add(new SpriteText
-        {
-            Anchor = Anchor.CentreLeft,
-            Origin = Anchor.CentreLeft,
-            Text = "Rate",
-            Font = FontUsage.Default.With(size: 15),
-            Margin = new MarginPadding { Left = 10, Right = 10 }
-        });
-
-        headerFlow.Add(clockRateSlider = new BasicSliderBar<double>
-        {
-            Anchor = Anchor.CentreLeft,
-            Origin = Anchor.CentreLeft,
-            Size = new Vector2(120, 20),
-            MinValue = 0.0,
-            MaxValue = 4.0
-        });
-
         clockRateSlider.Current.Value = InitialClockRate;
-
-        headerFlow.Add(new ClickableContainer
-        {
-            Anchor = Anchor.CentreLeft,
-            Origin = Anchor.CentreLeft,
-            AutoSizeAxes = Axes.X,
-            RelativeSizeAxes = Axes.Y,
-            Margin = new MarginPadding { Left = 4 },
-            Action = () => clockRateSlider.Current.Value = 1.0,
-            Child = clockRateLabel = new SpriteText
-            {
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                Text = "1.00×",
-                Font = FontUsage.Default.With(size: 14),
-                Color = Color.LightGreen,
-                Width = 60
-            }
-        });
-
-        headerFlow.Add(new HeaderButton("Background", () =>
-        {
-            testContentBackgroundBox.FadeToColor(ColorExtensions.GetRandomColor(), 250, Easing.OutQuint);
-        }, Color.Transparent));
 
         clockRateSlider.Current.ValueChanged += e =>
         {


### PR DESCRIPTION
- Fix border and corner radius still draw outside clipping area when masking applied
<img width="528" height="964" alt="image" src="https://github.com/user-attachments/assets/7e379055-2f7a-4615-9cde-b7bdd0b3f84a" />

<img width="486" height="88" alt="image" src="https://github.com/user-attachments/assets/23e9953e-86fe-43d8-ba2a-31908773cc93" />

- Make edge effect and corner radius DPI-aware
- Only apply margin and padding only one time on container calculation

