### PR TITLE
Add texture loader queue and improve texture storage and loader capabilities

### DIFF
--- a/Sakura.Framework.Tests/Graphics/ImageSharpImageLoaderTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ImageSharpImageLoaderTest.cs
@@ -1,0 +1,72 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Textures;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Test for <see cref="ImageSharpImageLoader"/>
+/// </summary>
+[TestFixture]
+public class ImageSharpImageLoaderTest
+{
+    private readonly ImageSharpImageLoader loader = new ImageSharpImageLoader();
+
+    private static MemoryStream jpeg(int width, int height)
+    {
+        var stream = new MemoryStream();
+        using (var image = new Image<Rgba32>(width, height))
+            image.SaveAsJpeg(stream);
+        stream.Position = 0;
+        return stream;
+    }
+
+    [Test]
+    public void CapsLongestEdgePreservingAspect()
+    {
+        using var stream = jpeg(4000, 2000); // 2:1
+
+        var raw = loader.Load(stream, 512);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Math.Max(raw.Width, raw.Height), Is.LessThanOrEqualTo(512));
+            Assert.That((float)raw.Width / raw.Height, Is.EqualTo(2f).Within(0.05f));
+            Assert.That(raw.Data.Length, Is.EqualTo(raw.Width * raw.Height * 4));
+        }
+    }
+
+    [Test]
+    public void DoesNotUpscaleSmallSource()
+    {
+        using var stream = jpeg(100, 80);
+
+        var raw = loader.Load(stream, 512);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(raw.Width, Is.EqualTo(100));
+            Assert.That(raw.Height, Is.EqualTo(80));
+        }
+    }
+
+    [Test]
+    public void NoLimitDecodesFullResolution()
+    {
+        using var stream = jpeg(1024, 768);
+
+        var raw = loader.Load(stream);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(raw.Width, Is.EqualTo(1024));
+            Assert.That(raw.Height, Is.EqualTo(768));
+        }
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/SharedTextureStoreTest.cs
+++ b/Sakura.Framework.Tests/Graphics/SharedTextureStoreTest.cs
@@ -1,0 +1,90 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Textures;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Test for <see cref="SharedTextureStore"/>
+/// </summary>
+[TestFixture]
+public class SharedTextureStoreTest
+{
+    private static Texture dummy() => new Texture(1, 1);
+
+    [Test]
+    public void CreatesOnceThenReuses()
+    {
+        var store = new SharedTextureStore();
+        int creates = 0;
+
+        var a = store.AddOrAcquire("k", () => { creates++; return dummy(); });
+        bool hit = store.TryAcquire("k", out var b);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(creates, Is.EqualTo(1));
+            Assert.That(hit, Is.True);
+            Assert.That(b, Is.SameAs(a));
+            Assert.That(store.Count, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void DisposesOnlyWhenLastReferenceReleased()
+    {
+        var store = new SharedTextureStore();
+        var tex = store.AddOrAcquire("k", dummy); // count 1
+        store.TryAcquire("k", out _); // count 2
+
+        int disposed = 0;
+        void release() => store.Release("k", _ => disposed++);
+
+        release(); // count 1
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(disposed, Is.Zero, "still referenced");
+            Assert.That(store.Count, Is.EqualTo(1));
+        }
+
+        release(); // count 0
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(disposed, Is.EqualTo(1), "disposed once at zero");
+            Assert.That(store.Count, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void ReAcquireAfterReleaseRecreates()
+    {
+        var store = new SharedTextureStore();
+        int creates = 0;
+
+        store.AddOrAcquire("k", () =>
+        {
+            creates++;
+            return dummy();
+        });
+        store.Release("k", _ => { });
+        store.AddOrAcquire("k", () =>
+        {
+            creates++;
+            return dummy();
+        });
+
+        Assert.That(creates, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ReleaseUnknownKeyIsNoOp()
+    {
+        var store = new SharedTextureStore();
+        int disposed = 0;
+
+        Assert.DoesNotThrow(() => store.Release("missing", _ => disposed++));
+        Assert.That(disposed, Is.Zero);
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/TextureUploadQueueTest.cs
+++ b/Sakura.Framework.Tests/Graphics/TextureUploadQueueTest.cs
@@ -19,7 +19,10 @@ public class TextureUploadQueueTest
     [Test]
     public void StopsAtBudgetAndCarriesRemainderOver()
     {
-        var queue = new TextureUploadQueue { BytesPerFrameBudget = 100 };
+        var queue = new TextureUploadQueue
+        {
+            BytesPerFrameBudget = 100
+        };
         var order = new List<int>();
 
         for (int i = 0; i < 4; i++)

--- a/Sakura.Framework.Tests/Graphics/TextureUploadQueueTest.cs
+++ b/Sakura.Framework.Tests/Graphics/TextureUploadQueueTest.cs
@@ -1,0 +1,71 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Textures;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Test for <see cref="TextureUploadQueue"/>
+/// </summary>
+[TestFixture]
+public class TextureUploadQueueTest
+{
+    private static readonly int[] expected = new[] { 0, 1 };
+    private static readonly int[] expected_array = new[] { 0, 1, 2, 3 };
+
+    [Test]
+    public void StopsAtBudgetAndCarriesRemainderOver()
+    {
+        var queue = new TextureUploadQueue { BytesPerFrameBudget = 100 };
+        var order = new List<int>();
+
+        for (int i = 0; i < 4; i++)
+        {
+            int id = i;
+            queue.Enqueue(() => order.Add(id), 60); // two per frame (60 + 60 >= 100)
+        }
+
+        queue.Process();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(order, Is.EqualTo(expected));
+            Assert.That(queue.PendingCount, Is.EqualTo(2));
+        }
+
+        queue.Process();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(order, Is.EqualTo(expected_array));
+            Assert.That(queue.PendingCount, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void AlwaysProcessesAtLeastOneEvenIfOverBudget()
+    {
+        var queue = new TextureUploadQueue
+        {
+            BytesPerFrameBudget = 10
+        };
+        int ran = 0;
+
+        queue.Enqueue(() => ran++, 1_000_000); // single item far exceeds the budget
+        queue.Process();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ran, Is.EqualTo(1));
+            Assert.That(queue.PendingCount, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void ProcessOnEmptyQueueIsNoOp()
+    {
+        var queue = new TextureUploadQueue();
+        Assert.DoesNotThrow(queue.Process);
+    }
+}

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -153,10 +153,12 @@ public partial class App : Container, IFocusManager, IInputManagerProvider, IDis
         TrackStore = new TrackStore(embeddedResourceStorage.GetStorageForDirectory("Tracks"), AudioManager);
         SampleStore = new SampleStore(embeddedResourceStorage.GetStorageForDirectory("Samples"), AudioManager);
 
+        IImageLoader imageLoader = CreateImageLoader();
+
         switch (Host.Renderer)
         {
             case GLRenderer:
-                TextureManager = new GLTextureManager(Host.Renderer, GLRenderer.GL, embeddedResourceStorage.GetStorageForDirectory("Textures"), CreateImageLoader());
+                TextureManager = new GLTextureManager(Host.Renderer, GLRenderer.GL, embeddedResourceStorage.GetStorageForDirectory("Textures"), imageLoader);
                 VideoStore = new VideoStore(embeddedResourceStorage.GetStorageForDirectory("Videos"), Host.Renderer, TextureManager);
                 FontStore = new RendererFontStore(Host.Renderer);
                 // TODO: This will exposed all framework file resource out, maybe find better way?
@@ -173,7 +175,7 @@ public partial class App : Container, IFocusManager, IInputManagerProvider, IDis
                 break;
 
             case MetalRenderer:
-                TextureManager = new MetalTextureManager(Host.Renderer, embeddedResourceStorage.GetStorageForDirectory("Textures"), CreateImageLoader());
+                TextureManager = new MetalTextureManager(Host.Renderer, embeddedResourceStorage.GetStorageForDirectory("Textures"), imageLoader);
                 FontStore = new RendererFontStore(Host.Renderer);
                 var metalFrameworkFontStorage = Host.FrameworkStorage.GetStorageForDirectory("Fonts");
                 var metalFontStorage = new CompositeStorage(metalFrameworkFontStorage, embeddedResourceStorage.GetStorageForDirectory("Fonts"));
@@ -182,11 +184,11 @@ public partial class App : Container, IFocusManager, IInputManagerProvider, IDis
                 break;
 
             case D3D11Renderer:
-                TextureManager = new D3D11TextureManager(Host.Renderer, embeddedResourceStorage.GetStorageForDirectory("Textures"), CreateImageLoader());
+                TextureManager = new D3D11TextureManager(Host.Renderer, embeddedResourceStorage.GetStorageForDirectory("Textures"), imageLoader);
                 FontStore = new RendererFontStore(Host.Renderer);
-                var d3d11FrameworkFontStorage = Host.FrameworkStorage.GetStorageForDirectory("Fonts");
-                var d3d11FontStorage = new CompositeStorage(d3d11FrameworkFontStorage, embeddedResourceStorage.GetStorageForDirectory("Fonts"));
-                FontStore.LoadDefaultFont(d3d11FontStorage);
+                var d3D11FrameworkFontStorage = Host.FrameworkStorage.GetStorageForDirectory("Fonts");
+                var d3D11FontStorage = new CompositeStorage(d3D11FrameworkFontStorage, embeddedResourceStorage.GetStorageForDirectory("Fonts"));
+                FontStore.LoadDefaultFont(d3D11FontStorage);
                 VideoStore = new VideoStore(embeddedResourceStorage.GetStorageForDirectory("Videos"), Host.Renderer, TextureManager);
                 break;
 
@@ -194,6 +196,7 @@ public partial class App : Container, IFocusManager, IInputManagerProvider, IDis
                 throw new NotSupportedException($"Renderer type {Host.Renderer.GetType().FullName} is not supported.");
         }
         Cache(TextureManager);
+        Cache(imageLoader);
         Cache(FontStore);
 
         Cache<IAudioStore<ITrack>>(TrackStore);

--- a/Sakura.Framework/Graphics/Containers/DelayedLoadWrapperContainer.cs
+++ b/Sakura.Framework/Graphics/Containers/DelayedLoadWrapperContainer.cs
@@ -72,6 +72,15 @@ public partial class DelayedLoadWrapperContainer : Container
     /// </summary>
     protected virtual bool IsOnScreen => !IsMaskedAway;
 
+    /// <summary>
+    /// How long in milliseconds this wrapper must be continuously on screen before its content loads. Evaluated
+    /// every frame, so subclasses can vary it dynamically e.g. a carousel can return a larger delay for
+    /// items further from the selection so the ones nearest the center load first, or lengthen it while
+    /// the list is scrolling fast so items merely flicked past never load. Defaults to
+    /// <see cref="TimeBeforeLoad"/>.
+    /// </summary>
+    protected virtual double LoadDelay => TimeBeforeLoad;
+
     public override void Update()
     {
         base.Update();
@@ -84,7 +93,7 @@ public partial class DelayedLoadWrapperContainer : Container
             else
                 TimeVisible = 0;
 
-            if (TimeVisible >= TimeBeforeLoad)
+            if (TimeVisible >= LoadDelay)
                 beginLoad();
         }
     }

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -40,8 +40,8 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
     private SpriteText executionModeText;
     private SpriteText rendererText;
 
-    private FontUsage graphFontUsage = FontUsage.Default.With(size: 14);
-    private FontUsage boldGraphFontUsage = FontUsage.Default.With(size: 14, weight: "Bold");
+    private readonly FontUsage graphFontUsage = FontUsage.Default.With(size: 14);
+    private readonly FontUsage boldGraphFontUsage = FontUsage.Default.With(size: 14, weight: "Bold");
 
     private const float extended_width = 400;
     private const float compact_width = 340;

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
@@ -53,7 +53,8 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
 
     private nint windowHandle;
 
-    private readonly ConcurrentQueue<Action> drawThreadQueue = new();
+    private readonly ConcurrentQueue<Action> drawThreadQueue = new ConcurrentQueue<Action>();
+    private readonly TextureUploadQueue textureUploadQueue = new TextureUploadQueue();
 
     private DrawNode rootNode;
     private Matrix4x4 projectionMatrix = Matrix4x4.Identity;
@@ -422,6 +423,9 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         while (drawThreadQueue.TryDequeue(out var action))
             action();
 
+        // Budgeted texture uploads spread a burst across frames (see TextureUploadQueue).
+        textureUploadQueue.Process();
+
         frameBufferStack.Clear();
         setRenderTarget(backBufferRtv, backBufferWidth, backBufferHeight);
         context.ClearRenderTargetView(backBufferRtv, clear_color);
@@ -761,6 +765,8 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     #endregion
 
     public void ScheduleToDrawThread(Action action) => drawThreadQueue.Enqueue(action);
+
+    public void ScheduleTextureUpload(Action upload, long approximateBytes) => textureUploadQueue.Enqueue(upload, approximateBytes);
 
     public INativeTexture CreateNativeTexture(int width, int height) => new D3D11Texture(device, context, width, height);
 

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -134,6 +134,7 @@ public class GLRenderer : IGLRenderer, IDisposable
     private DrawNode rootNode;
 
     private readonly ConcurrentQueue<Action> drawThreadQueue = new ConcurrentQueue<Action>();
+    private readonly Textures.TextureUploadQueue textureUploadQueue = new Textures.TextureUploadQueue();
 
     private uint currentFrameBufferHandle;
     private int currentViewportWidth = 1;
@@ -278,11 +279,18 @@ public class GLRenderer : IGLRenderer, IDisposable
         {
             action.Invoke();
         }
+
+        textureUploadQueue.Process();
     }
 
     public void ScheduleToDrawThread(Action action)
     {
         drawThreadQueue.Enqueue(action);
+    }
+
+    public void ScheduleTextureUpload(Action upload, long approximateBytes)
+    {
+        textureUploadQueue.Enqueue(upload, approximateBytes);
     }
 
     public void FlushBatch()

--- a/Sakura.Framework/Graphics/Rendering/IRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/IRenderer.cs
@@ -83,10 +83,20 @@ public interface IRenderer
     void ScheduleToDrawThread(Action action);
 
     /// <summary>
+    /// Schedules a texture upload to run on the draw thread within a per-frame byte budget, spreading a
+    /// burst of uploads across frames so no single frame stalls uploading them all (see
+    /// <see cref="Textures.TextureUploadQueue"/>). <paramref name="approximateBytes"/> is the rough
+    /// upload size used to spend the budget.
+    /// The default implementation is unbudgeted and simply forwards to <see cref="ScheduleToDrawThread"/>;
+    /// backends that own a <see cref="Textures.TextureUploadQueue"/> override this to honor the budget.
+    /// </summary>
+    void ScheduleTextureUpload(Action upload, long approximateBytes) => ScheduleToDrawThread(upload);
+
+    /// <summary>
     /// The current orthographic projection matrix used for rendering.
     /// Custom shaders must set this on their own program before drawing.
     /// </summary>
-    Maths.Matrix4x4 ProjectionMatrix { get; }
+    Matrix4x4 ProjectionMatrix { get; }
 
     /// <summary>
     /// Flushes any pending batched geometry to the GPU immediately.

--- a/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
@@ -30,6 +30,7 @@ public sealed class MetalRenderer : IMetalRenderer
     private BlendingMode currentBlendMode = BlendingMode.Alpha;
 
     private readonly ConcurrentQueue<Action> drawThreadQueue = new();
+    private readonly Sakura.Framework.Graphics.Textures.TextureUploadQueue textureUploadQueue = new();
 
     private DrawNode rootNode;
     private Matrix4x4 projectionMatrix = Matrix4x4.Identity;
@@ -238,6 +239,9 @@ public sealed class MetalRenderer : IMetalRenderer
         // Drain queued uploads (textures, glyphs) on the draw thread, before the render pass opens.
         while (drawThreadQueue.TryDequeue(out var action))
             action();
+
+        // Budgeted texture uploads spread a burst across frames (see TextureUploadQueue).
+        textureUploadQueue.Process();
 
         SakuraMetalNative.sakura_metal_begin_frame(device, clear_color.r, clear_color.g, clear_color.b, clear_color.a);
 
@@ -681,6 +685,8 @@ public sealed class MetalRenderer : IMetalRenderer
     #region Utilities
 
     public void ScheduleToDrawThread(Action action) => drawThreadQueue.Enqueue(action);
+
+    public void ScheduleTextureUpload(Action upload, long approximateBytes) => textureUploadQueue.Enqueue(upload, approximateBytes);
 
     public void FlushBatch()
     {

--- a/Sakura.Framework/Graphics/Textures/D3D11TextureManager.cs
+++ b/Sakura.Framework/Graphics/Textures/D3D11TextureManager.cs
@@ -26,6 +26,7 @@ public class D3D11TextureManager : ITextureManager
 
     private readonly Texture missingTexture;
     private readonly TextureAtlas atlas;
+    private readonly SharedTextureStore sharedTextures = new SharedTextureStore();
 
     public Texture WhitePixel { get; }
 
@@ -54,7 +55,8 @@ public class D3D11TextureManager : ITextureManager
         try
         {
             using var stream = storage.GetStream(path);
-            if (stream == null) throw new FileNotFoundException($"Texture not found: {path}");
+            if (stream == null)
+                throw new FileNotFoundException($"Texture not found: {path}");
 
             var rawImage = imageLoader.Load(stream);
             byte[] pixelDataCopy = rawImage.Data.ToArray();
@@ -72,7 +74,7 @@ public class D3D11TextureManager : ITextureManager
             {
                 var nativeTexture = renderer.CreateNativeTexture(imageWidth, imageHeight);
                 texture = new Texture(nativeTexture);
-                renderer.ScheduleToDrawThread(() => nativeTexture.Upload(pixelDataCopy));
+                renderer.ScheduleTextureUpload(() => nativeTexture.Upload(pixelDataCopy), (long)imageWidth * imageHeight * 4);
             }
 
             textureCache[path] = texture;
@@ -93,11 +95,11 @@ public class D3D11TextureManager : ITextureManager
 
         byte[] dataCopy = pixelData.ToArray();
 
-        renderer.ScheduleToDrawThread(() =>
+        renderer.ScheduleTextureUpload(() =>
         {
             ReadOnlySpan<byte> span = dataCopy;
             nativeTexture.Upload(span);
-        });
+        }, (long)width * height * 4);
 
         if (!string.IsNullOrEmpty(cacheKey))
         {
@@ -114,6 +116,28 @@ public class D3D11TextureManager : ITextureManager
 
         return texture;
     }
+
+    public bool TryAcquireSharedTexture(string cacheKey, out Texture texture) => sharedTextures.TryAcquire(cacheKey, out texture);
+
+    public Texture AcquireSharedTexture(string cacheKey, int width, int height, ReadOnlySpan<byte> pixelData)
+    {
+        byte[] dataCopy = pixelData.ToArray();
+
+        return sharedTextures.AddOrAcquire(cacheKey, () =>
+        {
+            var nativeTexture = renderer.CreateNativeTexture(width, height);
+            var texture = new Texture(nativeTexture);
+            renderer.ScheduleTextureUpload(() => nativeTexture.Upload(dataCopy), (long)width * height * 4);
+            return texture;
+        });
+    }
+
+    public void ReleaseSharedTexture(string cacheKey) => sharedTextures.Release(cacheKey, texture =>
+    {
+        var native = texture.BackendTexture;
+        if (native != null && native != WhitePixel.BackendTexture && native != missingTexture.BackendTexture && !atlas.OwnsNativeTexture(native))
+            renderer.ScheduleToDrawThread(() => native.Dispose());
+    });
 
     public bool Evict(string path)
     {

--- a/Sakura.Framework/Graphics/Textures/GLTextureManager.cs
+++ b/Sakura.Framework/Graphics/Textures/GLTextureManager.cs
@@ -26,6 +26,7 @@ public class GLTextureManager : ITextureManager
     private readonly ConcurrentDictionary<IVideoTexture, byte> videoTextures = new ConcurrentDictionary<IVideoTexture, byte>();
 
     private readonly Texture missingTexture;
+    private readonly SharedTextureStore sharedTextures = new SharedTextureStore();
 
     /// <summary>
     /// A 1x1 white pixel texture.
@@ -82,10 +83,10 @@ public class GLTextureManager : ITextureManager
                 var glTexture = new GLTexture(gl, imageWidth, imageHeight);
                 texture = new Texture(glTexture);
 
-                renderer.ScheduleToDrawThread(() =>
+                renderer.ScheduleTextureUpload(() =>
                 {
                     glTexture.Upload(pixelDataCopy);
-                });
+                }, (long)imageWidth * imageHeight * 4);
             }
 
             textureCache[path] = texture;
@@ -106,11 +107,11 @@ public class GLTextureManager : ITextureManager
 
         byte[] dataCopy = pixelData.ToArray();
 
-        renderer.ScheduleToDrawThread(() =>
+        renderer.ScheduleTextureUpload(() =>
         {
             ReadOnlySpan<byte> span = dataCopy;
             glTexture.Upload(span);
-        });
+        }, (long)width * height * 4);
 
         if (!string.IsNullOrEmpty(cacheKey))
         {
@@ -127,6 +128,28 @@ public class GLTextureManager : ITextureManager
 
         return texture;
     }
+
+    public bool TryAcquireSharedTexture(string cacheKey, out Texture texture) => sharedTextures.TryAcquire(cacheKey, out texture);
+
+    public Texture AcquireSharedTexture(string cacheKey, int width, int height, ReadOnlySpan<byte> pixelData)
+    {
+        byte[] dataCopy = pixelData.ToArray();
+
+        return sharedTextures.AddOrAcquire(cacheKey, () =>
+        {
+            var glTexture = new GLTexture(gl, width, height);
+            var texture = new Texture(glTexture);
+            renderer.ScheduleTextureUpload(() => glTexture.Upload(dataCopy), (long)width * height * 4);
+            return texture;
+        });
+    }
+
+    public void ReleaseSharedTexture(string cacheKey) => sharedTextures.Release(cacheKey, texture =>
+    {
+        var native = texture.BackendTexture;
+        if (native != null && native != WhitePixel.BackendTexture && native != missingTexture.BackendTexture && !Atlas.OwnsNativeTexture(native))
+            renderer.ScheduleToDrawThread(native.Dispose);
+    });
 
     private Texture createNullTexture()
     {

--- a/Sakura.Framework/Graphics/Textures/HeadlessTextureManager.cs
+++ b/Sakura.Framework/Graphics/Textures/HeadlessTextureManager.cs
@@ -12,6 +12,8 @@ public class HeadlessTextureManager : ITextureManager
 
     public TextureAtlas? Atlas => null;
 
+    private readonly SharedTextureStore sharedTextures = new SharedTextureStore();
+
     public HeadlessTextureManager()
     {
         WhitePixel = createDummyTexture(1, 1);
@@ -20,6 +22,13 @@ public class HeadlessTextureManager : ITextureManager
     public Texture Get(string path) => WhitePixel;
 
     public Texture FromPixelData(int width, int height, ReadOnlySpan<byte> pixelData, string cacheKey = null) => createDummyTexture(width, height);
+
+    public bool TryAcquireSharedTexture(string cacheKey, out Texture texture) => sharedTextures.TryAcquire(cacheKey, out texture);
+
+    public Texture AcquireSharedTexture(string cacheKey, int width, int height, ReadOnlySpan<byte> pixelData)
+        => sharedTextures.AddOrAcquire(cacheKey, () => createDummyTexture(width, height));
+
+    public void ReleaseSharedTexture(string cacheKey) => sharedTextures.Release(cacheKey, texture => texture.Dispose());
 
     public bool Evict(string path) => true;
 

--- a/Sakura.Framework/Graphics/Textures/IImageLoader.cs
+++ b/Sakura.Framework/Graphics/Textures/IImageLoader.cs
@@ -16,4 +16,22 @@ public interface IImageLoader
     /// <param name="stream">The input stream containing image data.</param>
     /// <returns>>The raw image data.</returns>
     ImageRawData Load(Stream stream);
+
+    /// <summary>
+    /// Loads image data from the provided stream, decoding it at (at most) <paramref name="maxDimension"/>
+    /// pixels on its longest edge, preserving aspect ratio. Decoders that support it (e.g. JPEG) reduce
+    /// the image while decoding, so a large source never has to be fully decoded then shrunk. The image is
+    /// only ever downscaled, never enlarged.
+    /// </summary>
+    /// <remarks>
+    /// Use this for thumbnails, cover art and other cases where the display size is far smaller than the
+    /// source — it avoids decoding, allocating and uploading far more pixels than can be shown.
+    /// </remarks>
+    /// <param name="stream">The input stream containing image data.</param>
+    /// <param name="maxDimension">
+    /// The maximum length (px) of the longest edge. Values &lt;= 0 mean "no limit" and behave exactly like
+    /// <see cref="Load(Stream)"/>.
+    /// </param>
+    /// <returns>The raw image data.</returns>
+    ImageRawData Load(Stream stream, int maxDimension);
 }

--- a/Sakura.Framework/Graphics/Textures/ITextureManager.cs
+++ b/Sakura.Framework/Graphics/Textures/ITextureManager.cs
@@ -41,6 +41,29 @@ public interface ITextureManager : IDisposable
     bool Evict(string path);
 
     /// <summary>
+    /// If a reference-counted texture is already held for <paramref name="cacheKey"/>, increments its
+    /// reference count and returns it (no decode/upload). Returns false otherwise, in which case the
+    /// caller should decode and call <see cref="AcquireSharedTexture"/>. Balance with
+    /// <see cref="ReleaseSharedTexture"/>. See <see cref="SharedTextureStore"/>.
+    /// </summary>
+    bool TryAcquireSharedTexture(string cacheKey, out Texture texture);
+
+    /// <summary>
+    /// Returns a reference-counted texture shared under <paramref name="cacheKey"/>, uploading
+    /// <paramref name="pixelData"/> on first use or reusing (and ref-counting) the existing one. Use for
+    /// images shown in multiple places or reloaded repeatedly (e.g. cover art). Every acquire must be
+    /// balanced by a <see cref="ReleaseSharedTexture"/>; do not <see cref="Texture.Dispose"/> the result
+    /// directly, as it may be shared.
+    /// </summary>
+    Texture AcquireSharedTexture(string cacheKey, int width, int height, ReadOnlySpan<byte> pixelData);
+
+    /// <summary>
+    /// Releases one reference previously taken via <see cref="TryAcquireSharedTexture"/> or
+    /// <see cref="AcquireSharedTexture"/>. The GPU texture is disposed once the last reference is released.
+    /// </summary>
+    void ReleaseSharedTexture(string cacheKey);
+
+    /// <summary>
     /// Retrieves all currently loaded and cached regular textures.
     /// </summary>
     IEnumerable<Texture> GetAllTextures();

--- a/Sakura.Framework/Graphics/Textures/ImageSharpImageLoader.cs
+++ b/Sakura.Framework/Graphics/Textures/ImageSharpImageLoader.cs
@@ -1,8 +1,10 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System;
 using System.IO;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
@@ -13,14 +15,84 @@ namespace Sakura.Framework.Graphics.Textures;
 /// </summary>
 public class ImageSharpImageLoader : IImageLoader
 {
-    public ImageRawData Load(Stream stream)
+    public ImageRawData Load(Stream stream) => Load(stream, 0);
+
+    public ImageRawData Load(Stream stream, int maxDimension)
     {
+        if (maxDimension > 0)
+        {
+            byte[] bytes = readAll(stream);
+            return load(bytes, decodeSizeFor(bytes, maxDimension), maxDimension);
+        }
+
         using var image = Image.Load<Rgba32>(stream);
+        return finish(image);
+    }
+
+    private static ImageRawData load(byte[] bytes, Size? decodeTarget, int maxDimension)
+    {
+        var options = new DecoderOptions { TargetSize = decodeTarget };
+        using var image = Image.Load<Rgba32>(options, new MemoryStream(bytes));
+
+        if (Math.Max(image.Width, image.Height) > maxDimension)
+        {
+            image.Mutate(x => x.Resize(new ResizeOptions
+            {
+                Size = new Size(maxDimension, maxDimension),
+                Mode = ResizeMode.Max
+            }));
+        }
+
+        return finish(image);
+    }
+
+    private static ImageRawData finish(Image<Rgba32> image)
+    {
         image.Mutate(x => x.AutoOrient());
 
         byte[] pixels = new byte[image.Width * image.Height * 4];
         image.CopyPixelDataTo(pixels);
 
         return new ImageRawData(image.Width, image.Height, pixels);
+    }
+
+    /// <summary>
+    /// The size hint passed to the decoder: the source scaled so its longest edge is
+    /// <paramref name="maxDimension"/>, or <c>null</c> when the source is already small enough (so it is
+    /// never upscaled) or its header can't be read.
+    /// </summary>
+    private static Size? decodeSizeFor(byte[] bytes, int maxDimension)
+    {
+        int sw, sh;
+        try
+        {
+            var info = Image.Identify(bytes);
+            sw = info.Width;
+            sh = info.Height;
+        }
+        catch
+        {
+            return null;
+        }
+
+        int longest = Math.Max(sw, sh);
+        if (longest <= 0 || longest <= maxDimension)
+            return null;
+
+        float scale = (float)maxDimension / longest;
+        return new Size(
+            Math.Max(1, (int)MathF.Ceiling(sw * scale)),
+            Math.Max(1, (int)MathF.Ceiling(sh * scale))
+        );
+    }
+
+    private static byte[] readAll(Stream stream)
+    {
+        if (stream is MemoryStream existing)
+            return existing.ToArray();
+
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
     }
 }

--- a/Sakura.Framework/Graphics/Textures/MetalTextureManager.cs
+++ b/Sakura.Framework/Graphics/Textures/MetalTextureManager.cs
@@ -28,6 +28,7 @@ public class MetalTextureManager : ITextureManager
 
     private readonly Texture missingTexture;
     private readonly TextureAtlas atlas;
+    private readonly SharedTextureStore sharedTextures = new SharedTextureStore();
 
     public Texture WhitePixel { get; }
 
@@ -74,7 +75,7 @@ public class MetalTextureManager : ITextureManager
             {
                 var nativeTexture = renderer.CreateNativeTexture(imageWidth, imageHeight);
                 texture = new Texture(nativeTexture);
-                renderer.ScheduleToDrawThread(() => nativeTexture.Upload(pixelDataCopy));
+                renderer.ScheduleTextureUpload(() => nativeTexture.Upload(pixelDataCopy), (long)imageWidth * imageHeight * 4);
             }
 
             textureCache[path] = texture;
@@ -95,11 +96,11 @@ public class MetalTextureManager : ITextureManager
 
         byte[] dataCopy = pixelData.ToArray();
 
-        renderer.ScheduleToDrawThread(() =>
+        renderer.ScheduleTextureUpload(() =>
         {
             ReadOnlySpan<byte> span = dataCopy;
             nativeTexture.Upload(span);
-        });
+        }, (long)width * height * 4);
 
         if (!string.IsNullOrEmpty(cacheKey))
         {
@@ -116,6 +117,28 @@ public class MetalTextureManager : ITextureManager
 
         return texture;
     }
+
+    public bool TryAcquireSharedTexture(string cacheKey, out Texture texture) => sharedTextures.TryAcquire(cacheKey, out texture);
+
+    public Texture AcquireSharedTexture(string cacheKey, int width, int height, ReadOnlySpan<byte> pixelData)
+    {
+        byte[] dataCopy = pixelData.ToArray();
+
+        return sharedTextures.AddOrAcquire(cacheKey, () =>
+        {
+            var nativeTexture = renderer.CreateNativeTexture(width, height);
+            var texture = new Texture(nativeTexture);
+            renderer.ScheduleTextureUpload(() => nativeTexture.Upload(dataCopy), (long)width * height * 4);
+            return texture;
+        });
+    }
+
+    public void ReleaseSharedTexture(string cacheKey) => sharedTextures.Release(cacheKey, texture =>
+    {
+        var native = texture.BackendTexture;
+        if (native != null && native != WhitePixel.BackendTexture && native != missingTexture.BackendTexture && !atlas.OwnsNativeTexture(native))
+            renderer.ScheduleToDrawThread(native.Dispose);
+    });
 
     public bool Evict(string path)
     {

--- a/Sakura.Framework/Graphics/Textures/SharedTextureStore.cs
+++ b/Sakura.Framework/Graphics/Textures/SharedTextureStore.cs
@@ -1,0 +1,119 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Sakura.Framework.Graphics.Textures;
+
+/// <summary>
+/// Reference-counts textures shared by a string key, so identical images e.g. the same texture shown
+/// by several drawables at once, or re-loaded as a list scrolls a panel back into view will map to a single
+/// GPU texture instead of one decode/upload per user. Each <see cref="TryAcquire"/>/<see cref="AddOrAcquire"/>
+/// must be balanced by a <see cref="Release"/>, the underlying texture is disposed only when the last
+/// reference is released.
+/// </summary>
+public sealed class SharedTextureStore
+{
+    private sealed class Entry
+    {
+        public readonly Texture Texture;
+        public int Count;
+
+        public Entry(Texture texture)
+        {
+            Texture = texture;
+            Count = 1;
+        }
+    }
+
+    private readonly Lock sync = new Lock();
+    private readonly Dictionary<string, Entry> entries = new Dictionary<string, Entry>();
+
+    /// <summary>
+    /// Number of distinct keys currently held
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (sync)
+                return entries.Count;
+        }
+    }
+
+    /// <summary>
+    /// If <paramref name="key"/> is already held, increments its reference count and returns its texture.
+    /// Returns false otherwise (decode, then call <see cref="AddOrAcquire"/>).
+    /// </summary>
+    public bool TryAcquire(string key, out Texture texture)
+    {
+        lock (sync)
+        {
+            if (!string.IsNullOrEmpty(key) && entries.TryGetValue(key, out var entry))
+            {
+                entry.Count++;
+                texture = entry.Texture;
+                return true;
+            }
+        }
+
+        texture = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the texture for <paramref name="key"/>, creating and storing it via <paramref name="create"/>
+    /// on first use (reference count 1) or incrementing the count of the existing one. Handles the race
+    /// where two threads miss simultaneously: <paramref name="create"/> runs at most once per live key.
+    /// </summary>
+    public Texture AddOrAcquire(string key, Func<Texture> create)
+    {
+        if (string.IsNullOrEmpty(key))
+            throw new ArgumentException("A non-empty key is required.", nameof(key));
+        ArgumentNullException.ThrowIfNull(create);
+
+        lock (sync)
+        {
+            if (entries.TryGetValue(key, out var existing))
+            {
+                existing.Count++;
+                return existing.Texture;
+            }
+
+            var texture = create();
+            entries[key] = new Entry(texture);
+            return texture;
+        }
+    }
+
+    /// <summary>
+    /// Releases one reference to <paramref name="key"/>. When the last reference is released the entry is
+    /// removed and <paramref name="dispose"/> is invoked (outside the lock) so the caller can free the GPU
+    /// resource. No-op for an unknown or already-freed key.
+    /// </summary>
+    public void Release(string key, Action<Texture>? dispose)
+    {
+        if (string.IsNullOrEmpty(key))
+            return;
+
+        Texture? toDispose = null;
+
+        lock (sync)
+        {
+            if (entries.TryGetValue(key, out var entry))
+            {
+                entry.Count--;
+                if (entry.Count <= 0)
+                {
+                    entries.Remove(key);
+                    toDispose = entry.Texture;
+                }
+            }
+        }
+
+        if (toDispose != null)
+            dispose?.Invoke(toDispose);
+    }
+}

--- a/Sakura.Framework/Graphics/Textures/TextureUploadQueue.cs
+++ b/Sakura.Framework/Graphics/Textures/TextureUploadQueue.cs
@@ -1,0 +1,85 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Concurrent;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Graphics.Textures;
+
+/// <summary>
+/// A draw-thread work queue for texture uploads with a per-frame byte budget. Uploads are enqueued from
+/// any thread (typically an async texture load) and drained on the draw thread once per frame by
+/// <see cref="Process"/>, stopping once the frame's budget is spent so the rest carry over to later
+/// frames.
+/// </summary>
+/// <remarks>
+/// At least one queued upload is always processed per call, so an item larger than the whole budget can
+/// never be starved. Ordering is FIFO, preserving the order uploads were requested in.
+/// </remarks>
+public sealed class TextureUploadQueue
+{
+    /// <summary>
+    /// The default per-frame budget (bytes). ~8 MB is roughly 8 downscaled cover textures per frame from tested project.
+    /// </summary>
+    public const long DEFAULT_BYTES_PER_FRAME = 8 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum total upload bytes to process per <see cref="Process"/> call. The first queued item is
+    /// always processed even if it alone exceeds this.
+    /// </summary>
+    public long BytesPerFrameBudget { get; set; } = DEFAULT_BYTES_PER_FRAME;
+
+    private readonly ConcurrentQueue<PendingUpload> queue = new ConcurrentQueue<PendingUpload>();
+
+    private static readonly GlobalStatistic<int> stat_pending = GlobalStatistics.Get<int>("Textures", "Upload Queue (pending)");
+    private static readonly GlobalStatistic<long> stat_processed = GlobalStatistics.Get<long>("Textures", "Uploads Processed");
+    private static readonly GlobalStatistic<long> stat_bytes_last_frame = GlobalStatistics.Get<long>("Textures", "Upload Bytes / Frame");
+
+    /// <summary>
+    /// Number of uploads currently waiting (approximate, for stats/debugging).
+    /// </summary>
+    public int PendingCount => queue.Count;
+
+    /// <summary>
+    /// Enqueue an upload to run on the draw thread within the frame budget.
+    /// </summary>
+    /// <param name="upload">The upload action; runs on the draw thread.</param>
+    /// <param name="approximateBytes">Rough size of the upload, used to spend the budget.</param>
+    public void Enqueue(Action upload, long approximateBytes)
+    {
+        if (upload == null)
+            throw new ArgumentNullException(nameof(upload));
+
+        queue.Enqueue(new PendingUpload(upload, Math.Max(0, approximateBytes)));
+        stat_pending.Value = queue.Count;
+    }
+
+    /// <summary>
+    /// Drains queued uploads on the draw thread until the per-frame budget is spent (always at least one).
+    /// Call once per frame from the renderer's frame start.
+    /// </summary>
+    public void Process()
+    {
+        long spent = 0;
+        int processed = 0;
+
+        while (queue.TryDequeue(out var item))
+        {
+            item.Action();
+            spent += item.Bytes;
+            processed++;
+
+            // Budget checked after running so a single over-budget upload still makes progress.
+            if (spent >= BytesPerFrameBudget)
+                break;
+        }
+
+        stat_bytes_last_frame.Value = spent;
+        stat_pending.Value = queue.Count;
+        if (processed > 0)
+            stat_processed.Value += processed;
+    }
+
+    private readonly record struct PendingUpload(Action Action, long Bytes);
+}


### PR DESCRIPTION
- Add load delay for `DelayedLoadWrapperContainer`
- Cache default `IImageLoader` in App DI heirarchy
- Add texture upload queue : in my case when a lot of texture got loaded a lot at once make the app freeze, this add an upload queue to it so it's gradully upload not at once and break everything
- Add auto-sizing support when load texture via `IImageLoader`