### PR TITLE
More memory fix implementation

### DIFF
--- a/Sakura.Framework.Benchmarks/Benchmarks/ImageDecodeBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/ImageDecodeBenchmarks.cs
@@ -1,0 +1,159 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Maths;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Sakura.Framework.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Test based on usage in yuuki. (heavy load texture in song selection screen)
+/// </summary>
+[MemoryDiagnoser]
+public class ImageDecodeBenchmarks
+{
+    /// <summary>
+    /// A cover-sized source, encoded once. Real covers are JPEG or PNG of roughly this size.
+    /// </summary>
+    private byte[] encodedPng = null!;
+
+    private byte[] encodedJpeg = null!;
+
+    private ImageSharpImageLoader loader = null!;
+
+    /// <summary>
+    /// What a carousel asks for: a cover reduced to fit a card.
+    /// </summary>
+    private static readonly ImageLoadOptions cover_target = ImageLoadOptions.FillTarget(new Vector2(320, 180));
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        loader = new ImageSharpImageLoader();
+
+        using var source = new Image<Rgba32>(1920, 1080);
+
+        // A flat image compresses to almost nothing, which would make the encoded-buffer rental
+        // unrepresentatively small. Vary every pixel so the encoded size is realistic.
+        source.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+
+                for (int x = 0; x < row.Length; x++)
+                    row[x] = new Rgba32((byte)(x * 7 % 256), (byte)(y * 13 % 256), (byte)((x ^ y) % 256), 255);
+            }
+        });
+
+        using (var buffer = new MemoryStream())
+        {
+            source.SaveAsPng(buffer);
+            encodedPng = buffer.ToArray();
+        }
+
+        using (var buffer = new MemoryStream())
+        {
+            source.SaveAsJpeg(buffer);
+            encodedJpeg = buffer.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Reports the encoded sizes once, so the allocation figures below can be read against them.
+    /// </summary>
+    [Benchmark]
+    public int EncodedSizes() => encodedPng.Length + encodedJpeg.Length;
+
+    /// <summary>
+    /// Full-size decode, which skips the encoded buffer entirely — so its allocation is the
+    /// <c>ImageRawData.Rent</c> half on its own.
+    /// </summary>
+    [Benchmark]
+    public int Decode_FullSize_NoTarget()
+    {
+        using var stream = new MemoryStream(encodedPng, writable: false);
+        using var raw = loader.Load(stream);
+
+        return raw.Width;
+    }
+
+    /// <summary>
+    /// The path a cover actually takes: a target size, so the header is identified first and the encoded
+    /// bytes are buffered to allow it. Allocation here is both rentals plus ImageSharp's own working set.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public int Decode_WithTarget_Png()
+    {
+        using var stream = new MemoryStream(encodedPng, writable: false);
+        using var raw = loader.Load(stream, cover_target);
+
+        return raw.Width;
+    }
+
+    [Benchmark]
+    public int Decode_WithTarget_Jpeg()
+    {
+        using var stream = new MemoryStream(encodedJpeg, writable: false);
+        using var raw = loader.Load(stream, cover_target);
+
+        return raw.Width;
+    }
+
+    /// <summary>
+    /// The same targeted decode from a stream that refuses to seek, which is the one shape that genuinely
+    /// has to buffer the encoded bytes — a compressed or archive-backed source. Read against
+    /// <see cref="Decode_WithTarget_Png"/>: the gap is what seek ability is worth.
+    /// </summary>
+    [Benchmark]
+    public int Decode_WithTarget_NonSeekable()
+    {
+        using var stream = new UnseekableStream(new MemoryStream(encodedPng, writable: false));
+        using var raw = loader.Load(stream, cover_target);
+
+        return raw.Width;
+    }
+
+    /// <summary>
+    /// A stream that refuses to seek or report a length.
+    /// </summary>
+    private sealed class UnseekableStream : Stream
+    {
+        private readonly Stream inner;
+
+        public UnseekableStream(Stream inner)
+        {
+            this.inner = inner;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new System.NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new System.NotSupportedException();
+            set => throw new System.NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new System.NotSupportedException();
+        public override void SetLength(long value) => throw new System.NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new System.NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                inner.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Sakura.Framework.Benchmarks/Benchmarks/VertexBatchScopingBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/VertexBatchScopingBenchmarks.cs
@@ -1,0 +1,257 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+using Vertex = Sakura.Framework.Graphics.Rendering.Vertex.Vertex;
+
+namespace Sakura.Framework.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Benchmark for vertex structural change (shared vertex batches instead of per-drawable vertex arrays)
+/// Test based on yuuki. song selection screen that this "should"(?) make the performance better
+/// the number came from dotMemory snapshot
+/// </summary>
+[MemoryDiagnoser]
+public class VertexBatchScopingBenchmarks
+{
+    /// <summary>
+    /// Vertices per glyph, matching <c>SpriteText.computeLayout</c>.
+    /// </summary>
+    private const int vertices_per_glyph = 4;
+
+    /// <summary>
+    /// A drawable that owns a variable-length vertex array the way <see cref="SpriteText"/> does, with a
+    /// draw node that copies it grow-only. Stands in for a shaped label of a given glyph count.
+    /// </summary>
+    private sealed partial class GlyphRun : Drawable
+    {
+        private int glyphCount;
+
+        public GlyphRun(int glyphCount)
+        {
+            SetGlyphCount(glyphCount);
+        }
+
+        private int vertexCount => glyphCount * vertices_per_glyph;
+
+        public void SetGlyphCount(int value)
+        {
+            glyphCount = value;
+
+            if (Vertices.Length < vertexCount)
+                Vertices = new Vertex[vertexCount];
+        }
+
+        protected override DrawNode CreateDrawNode() => new GlyphRunDrawNode();
+
+        private sealed class GlyphRunDrawNode : DrawNode
+        {
+            protected override void ApplyVertices(Drawable source)
+            {
+                var run = (GlyphRun)source;
+
+                // Grow-only, exactly as SpriteTextDrawNode.ApplyVertices is. The base class now owns the
+                // grow-only storage; this override still exists because the source buffer is itself
+                // grow-only, so only the live range may be copied rather than the whole array.
+                SetVertexCount(run.vertexCount);
+                run.Vertices.AsSpan(0, run.vertexCount).CopyTo(WritableVertices);
+            }
+        }
+    }
+
+    private Container root = null!;
+    private ManualClock clock = null!;
+
+    private GlyphRun boxSized = null!;
+    private GlyphRun label = null!;
+    private GlyphRun title = null!;
+
+    private DrawNode boxNode = null!;
+    private DrawNode labelNode = null!;
+    private DrawNode titleNode = null!;
+
+    private Container textHeavyRoot = null!;
+    private ManualClock textHeavyClock = null!;
+    private Container textHeavyHolder = null!;
+
+    private int frame;
+
+    /// <summary>
+    /// A 30-character label and an 80-character title, which is what a song-select row carries.
+    /// </summary>
+    private const int label_glyphs = 30;
+
+    private const int title_glyphs = 80;
+
+    /// <summary>
+    /// Rows on screen in a scrolling carousel, each with a title and an artist line.
+    /// </summary>
+    private const int rows_on_screen = 60;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        (root, clock) = BenchmarkTree.CreateRoot();
+
+        boxSized = new GlyphRun(1) { Size = new Vector2(16, 16) };
+        label = new GlyphRun(label_glyphs) { Size = new Vector2(200, 20) };
+        title = new GlyphRun(title_glyphs) { Size = new Vector2(600, 24) };
+
+        root.Add(boxSized);
+        root.Add(label);
+        root.Add(title);
+        BenchmarkTree.LoadAndSettle(root, clock);
+
+        boxNode = boxSized.GenerateDrawNode(0);
+        labelNode = label.GenerateDrawNode(0);
+        titleNode = title.GenerateDrawNode(0);
+
+        (textHeavyRoot, textHeavyClock) = BenchmarkTree.CreateRoot();
+
+        var holder = new Container { RelativeSizeAxes = Axes.Both };
+
+        for (int i = 0; i < rows_on_screen; i++)
+        {
+            holder.Add(new GlyphRun(title_glyphs) { Position = new Vector2(0, i * 12), Size = new Vector2(600, 24) });
+            holder.Add(new GlyphRun(label_glyphs) { Position = new Vector2(0, i * 12 + 6), Size = new Vector2(200, 20) });
+        }
+
+        textHeavyHolder = holder;
+        textHeavyRoot.Add(holder);
+        BenchmarkTree.LoadAndSettle(textHeavyRoot, textHeavyClock);
+    }
+
+    #region The per-frame copy — what a shared batch would replace with a direct write
+
+    /// <summary>
+    /// One drawable's vertex snapshot at the default 4 vertices. The floor.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public void ApplyVertices_4() => boxNode.ApplyState(boxSized);
+
+    /// <summary>
+    /// A 30-glyph label: 120 vertices, 7.2 KB copied.
+    /// </summary>
+    [Benchmark]
+    public void ApplyVertices_Label120() => labelNode.ApplyState(label);
+
+    /// <summary>
+    /// An 80-glyph title: 320 vertices, 19.2 KB copied, once per frame per title on screen.
+    /// </summary>
+    [Benchmark]
+    public void ApplyVertices_Title320() => titleNode.ApplyState(title);
+
+    #endregion
+
+    #region Steady state vs. churn
+
+    /// <summary>
+    /// A full frame over a carousel-shaped tree that is not changing: 60 rows, two runs each. Expected to
+    /// allocate nothing, since every array is already big enough — which is the point worth pinning before
+    /// redesigning anything, because it means SF-21's win here is CPU and resident footprint rather than
+    /// the GC churn the original profile attributed to it.
+    /// </summary>
+    [Benchmark]
+    public DrawNode Frame_TextHeavy_SteadyState()
+    {
+        frame++;
+        textHeavyClock.CurrentTime += BenchmarkTree.FRAME_STEP_MS;
+        textHeavyRoot.UpdateSubTree();
+        return textHeavyRoot.GenerateDrawNodeSubtree(frame % 3);
+    }
+
+    /// <summary>
+    /// The same tree while it scrolls. The holder moves every frame, so every row's transforms and vertices
+    /// are recomputed and re-copied — which is what song select actually does, and the only state in which
+    /// the per-frame copy cost above is paid at all.
+    /// </summary>
+    /// <remarks>
+    /// Compare against <see cref="Frame_TextHeavy_SteadyState"/>: the difference between the two is the
+    /// entire per-frame vertex cost SF-21 would remove, and the ratio is what says whether the
+    /// architectural change is worth it.
+    /// </remarks>
+    [Benchmark]
+    public DrawNode Frame_TextHeavy_Scrolling()
+    {
+        frame++;
+        textHeavyHolder.Position = new Vector2(0, frame % 2 == 0 ? 0 : 1);
+
+        textHeavyClock.CurrentTime += BenchmarkTree.FRAME_STEP_MS;
+        textHeavyRoot.UpdateSubTree();
+        return textHeavyRoot.GenerateDrawNodeSubtree(frame % 3);
+    }
+
+    /// <summary>
+    /// The case that does allocate: a row gets a longer string than the array it inherited, so both the
+    /// source array and the draw node's copy are replaced. Includes constructing the row, so read the
+    /// allocation against the arithmetic — two 320-vertex arrays is 38,400 bytes of the figure.
+    /// </summary>
+    [Benchmark]
+    public void GrowVertices_LongerTextInARecycledRow()
+    {
+        // Start small so each iteration has something to grow into, then grow past it.
+        var run = new GlyphRun(1);
+        var node = run.GenerateDrawNode(0);
+
+        run.SetGlyphCount(title_glyphs);
+        node.ApplyState(run);
+    }
+
+    #endregion
+
+    #region Resident footprint
+
+    /// <summary>
+    /// Builds and settles a whole song-select-shaped screen, so the reported allocation is the resident cost
+    /// of one screen's worth of text geometry — these arrays are retained, not churned, so allocated and
+    /// resident are the same figure here.
+    /// </summary>
+    /// <remarks>
+    /// Read against <see cref="Construct_TextHeavyScreen_FourVertexRuns"/>, which builds the identical tree
+    /// with 4-vertex runs. The difference is what the glyph vertices themselves cost, and therefore the
+    /// ceiling on what a shared batch could give back — one buffer sized to the frame instead of four arrays
+    /// per drawable.
+    /// </remarks>
+    [Benchmark]
+    public Container Construct_TextHeavyScreen() => buildScreen(title_glyphs, label_glyphs);
+
+    /// <summary>
+    /// The same tree with every run at the default 4 vertices, isolating the fixed per-drawable cost from
+    /// the glyph-count-dependent one.
+    /// </summary>
+    [Benchmark]
+    public Container Construct_TextHeavyScreen_FourVertexRuns() => buildScreen(1, 1);
+
+    private static Container buildScreen(int titleGlyphs, int labelGlyphs)
+    {
+        var (screenRoot, screenClock) = BenchmarkTree.CreateRoot();
+        var holder = new Container { RelativeSizeAxes = Axes.Both };
+
+        for (int i = 0; i < rows_on_screen; i++)
+        {
+            holder.Add(new GlyphRun(titleGlyphs) { Position = new Vector2(0, i * 12), Size = new Vector2(600, 24) });
+            holder.Add(new GlyphRun(labelGlyphs) { Position = new Vector2(0, i * 12 + 6), Size = new Vector2(200, 20) });
+        }
+
+        screenRoot.Add(holder);
+        BenchmarkTree.LoadAndSettle(screenRoot, screenClock);
+
+        // Three frames so all three draw-node buffers exist, which is the steady state a running app is in.
+        for (int f = 0; f < 3; f++)
+        {
+            screenClock.CurrentTime += BenchmarkTree.FRAME_STEP_MS;
+            screenRoot.UpdateSubTree();
+            screenRoot.GenerateDrawNodeSubtree(f);
+        }
+
+        return screenRoot;
+    }
+
+    #endregion
+}

--- a/Sakura.Framework.Tests/Graphics/DecodeConcurrencyTest.cs
+++ b/Sakura.Framework.Tests/Graphics/DecodeConcurrencyTest.cs
@@ -1,0 +1,208 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Logging;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+[TestFixture]
+public class DecodeConcurrencyTest
+{
+    private HeadlessTextureManager textureManager = null!;
+    private int originalLimit;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        textureManager = new HeadlessTextureManager();
+        originalLimit = TextureUploads.MaxConcurrentDecodes;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        TextureUploads.MaxConcurrentDecodes = originalLimit;
+        textureManager.Dispose();
+    }
+
+    [Test]
+    public void TheDefaultIsOneAtATime()
+    {
+        Assert.That(TextureUploads.MaxConcurrentDecodes, Is.EqualTo(1));
+    }
+
+    /// <summary>
+    /// Zero or less would deadlock a <see cref="SemaphoreSlim"/> built from it, so it clamps.
+    /// </summary>
+    [Test]
+    public void TheLimitCannotBeSetBelowOne()
+    {
+        TextureUploads.MaxConcurrentDecodes = 0;
+        Assert.That(TextureUploads.MaxConcurrentDecodes, Is.EqualTo(1));
+
+        TextureUploads.MaxConcurrentDecodes = -5;
+        Assert.That(TextureUploads.MaxConcurrentDecodes, Is.EqualTo(1));
+    }
+
+    /// <summary>
+    /// The gate actually gates: a decoder that blocks inside <c>Load</c> keeps every other caller out, and
+    /// the observed peak overlap never exceeds the configured limit.
+    /// </summary>
+    [Test]
+    public void ConcurrentCallersNeverExceedTheLimit()
+    {
+        TextureUploads.MaxConcurrentDecodes = 2;
+
+        var loader = new BlockingLoader();
+
+        var tasks = new Task[8];
+
+        for (int i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = Task.Run(() => TextureUploads.FromStream(
+                new MemoryStream(new byte[16]),
+                new TextureCreationOptions(),
+                new HeadlessRenderer(textureManager),
+                loader,
+                new SharedTextureStore(),
+                static _ => { }));
+        }
+
+        Assert.That(Task.WaitAll(tasks, TimeSpan.FromSeconds(30)), Is.True, "the gate must not deadlock");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(loader.PeakConcurrent, Is.LessThanOrEqualTo(2), "never more decoders at once than the limit");
+            Assert.That(loader.TotalCalls, Is.EqualTo(8), "and every caller still got its turn");
+        });
+    }
+
+    /// <summary>
+    /// Raising the limit replaces the gate. A decode already in flight holds a permit on the old instance,
+    /// so this is the case where a naive implementation releases into a semaphore that never issued it.
+    /// </summary>
+    [Test]
+    public void ChangingTheLimitMidFlightDoesNotCorruptTheGate()
+    {
+        TextureUploads.MaxConcurrentDecodes = 1;
+
+        var loader = new BlockingLoader();
+        var entered = new ManualResetEventSlim(false);
+        loader.OnEntered = () => entered.Set();
+
+        var first = Task.Run(() => TextureUploads.FromStream(
+            new MemoryStream(new byte[16]), new TextureCreationOptions(),
+            new HeadlessRenderer(textureManager), loader, new SharedTextureStore(), static _ => { }));
+
+        Assert.That(entered.Wait(TimeSpan.FromSeconds(10)), Is.True, "the first decode has to be in flight");
+
+        // Swap the gate out from under it.
+        TextureUploads.MaxConcurrentDecodes = 4;
+
+        loader.Unblock();
+        Assert.That(first.Wait(TimeSpan.FromSeconds(10)), Is.True);
+
+        // The new gate must still admit exactly its limit and no more.
+        loader.Reset();
+        loader.Block();
+
+        var tasks = new Task[6];
+
+        for (int i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = Task.Run(() => TextureUploads.FromStream(
+                new MemoryStream(new byte[16]), new TextureCreationOptions(),
+                new HeadlessRenderer(textureManager), loader, new SharedTextureStore(), static _ => { }));
+        }
+
+        Assert.That(Task.WaitAll(tasks, TimeSpan.FromSeconds(30)), Is.True);
+        Assert.That(loader.PeakConcurrent, Is.LessThanOrEqualTo(4));
+    }
+
+    /// <summary>
+    /// A loader that records how many callers are inside it at once, and can be held there on demand.
+    /// Returns nothing decodable, which <see cref="TextureUploads.FromStream"/> treats as a failed decode —
+    /// enough to exercise the gate without needing a real image or GPU.
+    /// </summary>
+    private class BlockingLoader : IImageLoader
+    {
+        private int concurrent;
+        private int peak;
+        private int calls;
+        private ManualResetEventSlim? hold;
+
+        public int PeakConcurrent => Volatile.Read(ref peak);
+        public int TotalCalls => Volatile.Read(ref calls);
+
+        public Action? OnEntered;
+
+        public void Block() => hold = new ManualResetEventSlim(false);
+
+        public void Unblock() => hold?.Set();
+
+        public void Reset()
+        {
+            Volatile.Write(ref peak, 0);
+            Volatile.Write(ref calls, 0);
+        }
+
+        public BlockingLoader()
+        {
+            Block();
+
+            // Released shortly after each entry, so the peak is observable without the test having to
+            // coordinate every caller.
+            Task.Run(async () =>
+            {
+                await Task.Delay(150).ConfigureAwait(false);
+                Unblock();
+            });
+        }
+
+        public ImageRawData Load(Stream stream) => Load(stream, ImageLoadOptions.FullSize);
+
+        public ImageRawData Load(Stream stream, int maxDimension) => Load(stream, ImageLoadOptions.MaxDimension(maxDimension));
+
+        public ImageRawData Load(Stream stream, ImageLoadOptions options)
+        {
+            Interlocked.Increment(ref calls);
+
+            int now = Interlocked.Increment(ref concurrent);
+
+            int observed = Volatile.Read(ref peak);
+            while (now > observed)
+            {
+                int previous = Interlocked.CompareExchange(ref peak, now, observed);
+                if (previous == observed)
+                    break;
+
+                observed = previous;
+            }
+
+            OnEntered?.Invoke();
+
+            try
+            {
+                hold?.Wait(TimeSpan.FromSeconds(5));
+                return default;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref concurrent);
+            }
+        }
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/ImageDecodeResidencyProbe.cs
+++ b/Sakura.Framework.Tests/Graphics/ImageDecodeResidencyProbe.cs
@@ -1,0 +1,336 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Maths;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// A measurement, not an assertion: what it costs to read an encoded image's header before decoding it.
+/// <para>
+/// Both halves of the decode need the bytes — the header, to pick a decode size, and then the decoder
+/// itself. A seekable source can serve both by rewinding; anything else has to be held in memory. This
+/// probe prices the three ways of doing that, and then shows what the choice is worth end to end.
+/// </para>
+/// <para>
+/// Totals come from <see cref="GC.GetTotalAllocatedBytes"/> rather than BenchmarkDotNet's
+/// <c>MemoryDiagnoser</c>, which counts only the benchmark thread and reads near zero here — ImageSharp
+/// decodes with parallel workers, and the rental only misses under concurrency.
+/// </para>
+/// </summary>
+[TestFixture]
+[Explicit("measurement probe, run by name")]
+public class ImageDecodeResidencyProbe
+{
+    private const int iterations = 20;
+    private const int warmup = 3;
+
+    /// <summary>
+    /// A 1920x1080 photo-like JPEG. Noise rather than a flat fill, so the encoded file is a realistic
+    /// megabyte or so instead of a handful of compressible bytes.
+    /// </summary>
+    private static byte[] encodedBackground()
+    {
+        var random = new Random(1234);
+
+        using var image = new Image<Rgba32>(1920, 1080);
+
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+
+                for (int x = 0; x < row.Length; x++)
+                    row[x] = new Rgba32((byte)random.Next(256), (byte)random.Next(256), (byte)random.Next(256), 255);
+            }
+        });
+
+        using var stream = new MemoryStream();
+        image.SaveAsJpeg(stream);
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// The step that changed, in isolation: obtain the image's dimensions and leave a stream the decoder
+    /// could read, without decoding. No full decode to hide the difference in.
+    /// </summary>
+    [Test]
+    public void MeasureHeaderReadStrategies()
+    {
+        byte[] encoded = encodedBackground();
+
+        TestContext.Out.WriteLine($"encoded file: {encoded.Length:N0} bytes, {iterations} iterations\n");
+
+        foreach (int concurrency in new[] { 1, 8 })
+        {
+            TestContext.Out.WriteLine($"-- header read only, {concurrency} at a time --");
+
+            report("identify + rewind (now)", concurrency, () => identifyAndRewind(encoded));
+            report("rent first (was)", concurrency, () => rentFirst(encoded));
+            report("copy first (non-seekable)", concurrency, () => copyFirst(encoded));
+
+            TestContext.Out.WriteLine(string.Empty);
+        }
+    }
+
+    /// <summary>
+    /// The same choice end to end, through the real loader: a seekable stream takes the rewind path, a
+    /// forward-only one has to be copied. Shows how much of the decode's total the header read is.
+    /// </summary>
+    [Test]
+    public void MeasureFullDecode()
+    {
+        byte[] encoded = encodedBackground();
+        var target = ImageLoadOptions.FillTarget(new Vector2(400, 300));
+
+        TestContext.Out.WriteLine($"encoded file: {encoded.Length:N0} bytes, {iterations} decodes to a 400x300 fill\n");
+
+        foreach (int concurrency in new[] { 1, 8 })
+        {
+            TestContext.Out.WriteLine($"-- full decode, {concurrency} at a time --");
+
+            report("seekable", concurrency, () =>
+            {
+                using var stream = new MemoryStream(encoded, 0, encoded.Length, writable: false);
+                new ImageSharpImageLoader().Load(stream, target).Dispose();
+            });
+
+            report("forward-only", concurrency, () =>
+            {
+                using var stream = new ForwardOnlyStream(new MemoryStream(encoded, 0, encoded.Length, writable: false));
+                new ImageSharpImageLoader().Load(stream, target).Dispose();
+            });
+
+            TestContext.Out.WriteLine(string.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Which <em>thread</em> rents and which returns, holding everything else constant.
+    /// <para>
+    /// <see cref="ArrayPool{T}.Shared"/> is <c>TlsOverPerCoreLockedStacksArrayPool</c>: its fast path is a
+    /// <c>[ThreadStatic]</c> cache holding <b>one array per bucket per thread</b>, backed by per-core stacks.
+    /// The decode path rents on whichever pool thread <c>LoadComponentAsync</c> happened to use and returns on
+    /// the draw thread once the upload has run — so the renting thread's fast path is cold every time and the
+    /// returning thread's is the only one being filled. Neither <c>MaxConcurrentDecodes</c> nor
+    /// <c>MaxOutstandingUploads</c> changes that, which is the suspected reason an in-app profile showed
+    /// ~149 MB of <c>ImageRawData.Rent</c> served by fresh allocation under both.
+    /// </para>
+    /// <para>
+    /// Counts distinct array instances rather than bytes, so thread and task overhead cannot flatter or
+    /// distort the result: perfect reuse is 1, a total miss is one per iteration.
+    /// </para>
+    /// </summary>
+    [Test]
+    public void MeasureRentAndReturnThreadAffinity()
+    {
+        const int size = 400 * 300 * 4;
+        const int cycles = 40;
+
+        TestContext.Out.WriteLine($"{cycles} rent/return cycles of {size:N0} bytes from ArrayPool<byte>.Shared\n");
+
+        reportAffinity("rent and return on one thread", size, cycles, dedicatedRenter: true, dedicatedReturner: true, sameThread: true);
+        reportAffinity("one renter, one returner", size, cycles, dedicatedRenter: true, dedicatedReturner: true, sameThread: false);
+        reportAffinity("pool threads rent, one returns", size, cycles, dedicatedRenter: false, dedicatedReturner: true, sameThread: false);
+        reportAffinity("pool threads rent and return", size, cycles, dedicatedRenter: false, dedicatedReturner: false, sameThread: false);
+
+        // The candidate fix. ArrayPool<T>.Create returns a ConfigurableArrayPool: a per-bucket lock over a
+        // shared array of buffers, with no [ThreadStatic] layer at all, so which thread rents and which
+        // returns stops mattering. Same worst-case shape as the row above it.
+        TestContext.Out.WriteLine(string.Empty);
+
+        var configurable = ArrayPool<byte>.Create(maxArrayLength: 64 * 1024 * 1024, maxArraysPerBucket: 4);
+
+        reportAffinity("ArrayPool.Create, pool threads rent, one returns", size, cycles,
+            dedicatedRenter: false, dedicatedReturner: true, sameThread: false, pool: configurable);
+    }
+
+    private static void reportAffinity(string label, int size, int cycles, bool dedicatedRenter, bool dedicatedReturner, bool sameThread, ArrayPool<byte>? pool = null)
+    {
+        var shared = pool ?? ArrayPool<byte>.Shared;
+
+        // Reference equality, so this counts distinct array instances the pool handed out.
+        var seen = new HashSet<byte[]>();
+
+        var returner = new BlockingCollection<byte[]>();
+
+        var returnThread = new Thread(() =>
+        {
+            foreach (byte[] array in returner.GetConsumingEnumerable())
+                shared.Return(array);
+        })
+        { IsBackground = true };
+
+        if (dedicatedReturner && !sameThread)
+            returnThread.Start();
+
+        for (int i = 0; i < cycles; i++)
+        {
+            byte[] rented;
+
+            if (dedicatedRenter)
+                rented = shared.Rent(size);
+            else
+                rented = Task.Run(() => shared.Rent(size)).GetAwaiter().GetResult();
+
+            lock (seen)
+                seen.Add(rented);
+
+            if (sameThread)
+                shared.Return(rented);
+            else if (dedicatedReturner)
+                returner.Add(rented);
+            else
+                Task.Run(() => shared.Return(rented)).GetAwaiter().GetResult();
+        }
+
+        returner.CompleteAdding();
+
+        if (dedicatedReturner && !sameThread)
+            returnThread.Join(TimeSpan.FromSeconds(10));
+
+        TestContext.Out.WriteLine($"{label,-48} {seen.Count,3} distinct array(s) for {cycles} rentals");
+    }
+
+    private static int identifyAndRewind(byte[] encoded)
+    {
+        using var stream = new MemoryStream(encoded, 0, encoded.Length, writable: false);
+
+        long origin = stream.Position;
+        var info = Image.Identify(stream);
+        stream.Position = origin;
+
+        return info.Width;
+    }
+
+    private static int rentFirst(byte[] encoded)
+    {
+        // the removed path: rent a buffer the size of the whole encoded file, fill it, and read it twice.
+        byte[] rented = ArrayPool<byte>.Shared.Rent(encoded.Length);
+
+        try
+        {
+            using (var source = new MemoryStream(encoded, 0, encoded.Length, writable: false))
+            {
+                int read = 0;
+
+                while (read < encoded.Length)
+                {
+                    int count = source.Read(rented, read, encoded.Length - read);
+                    if (count <= 0)
+                        break;
+
+                    read += count;
+                }
+            }
+
+            var info = Image.Identify(rented.AsSpan(0, encoded.Length));
+
+            using var decodable = new MemoryStream(rented, 0, encoded.Length, writable: false);
+            return info.Width;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private static int copyFirst(byte[] encoded)
+    {
+        using var source = new ForwardOnlyStream(new MemoryStream(encoded, 0, encoded.Length, writable: false));
+        using var ms = new MemoryStream();
+
+        source.CopyTo(ms);
+
+        var info = Image.Identify(ms.GetBuffer().AsSpan(0, (int)ms.Length));
+
+        using var decodable = new MemoryStream(ms.GetBuffer(), 0, (int)ms.Length, writable: false);
+        return info.Width;
+    }
+
+    private static void report(string label, int concurrency, Action operation)
+    {
+        for (int i = 0; i < warmup; i++)
+            operation();
+
+        collect();
+
+        long allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        long lohBefore = GC.GetGCMemoryInfo().GenerationInfo[3].SizeAfterBytes;
+
+        var clock = Stopwatch.StartNew();
+
+        if (concurrency == 1)
+        {
+            for (int i = 0; i < iterations; i++)
+                operation();
+        }
+        else
+        {
+            Parallel.For(0, iterations, new ParallelOptions { MaxDegreeOfParallelism = concurrency }, _ => operation());
+        }
+
+        clock.Stop();
+
+        long allocated = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+
+        collect();
+
+        long loh = GC.GetGCMemoryInfo().GenerationInfo[3].SizeAfterBytes - lohBefore;
+
+        TestContext.Out.WriteLine(
+            $"{label,-26} {allocated / (double)iterations / 1024,10:N1} KiB each   "
+            + $"live LOH delta {loh / (1024.0 * 1024.0),6:N2} MB   "
+            + $"{clock.Elapsed.TotalMilliseconds,6:N0} ms total");
+    }
+
+    private static void collect()
+    {
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    }
+
+    /// <summary>
+    /// Stands in for an embedded resource or an archive entry: readable once, no length, no seeking.
+    /// </summary>
+    private class ForwardOnlyStream : Stream
+    {
+        private readonly Stream inner;
+
+        public ForwardOnlyStream(Stream inner)
+        {
+            this.inner = inner;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/ImageSharpImageLoaderTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ImageSharpImageLoaderTest.cs
@@ -163,6 +163,95 @@ public class ImageSharpImageLoaderTest
         }
     }
 
+    [Test]
+    public void DecodesFromSeekableStreamWithoutBufferingIt()
+    {
+        using var seekable = jpeg(1200, 800);
+        using var stream = new RewindCountingStream(seekable);
+
+        var raw = loader.Load(stream, ImageLoadOptions.FillTarget(new Vector2(300, 300)));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(raw.Width, Is.EqualTo(300));
+            Assert.That(raw.Height, Is.EqualTo(300));
+            // the header is identified in place and the stream rewound for the decode, rather than the
+            // whole encoded file being copied into a buffer that can be read twice.
+            Assert.That(stream.Rewinds, Is.GreaterThan(0));
+        }
+    }
+
+    [Test]
+    public void DecodesFromSeekableStreamAtNonZeroPosition()
+    {
+        // an image that does not begin at byte 0, so the rewind after the header read has to return to
+        // where the caller left the stream rather than to its start.
+        using var seekable = new MemoryStream();
+        seekable.Write(new byte[64]);
+
+        using (var source = jpeg(1200, 800))
+            source.CopyTo(seekable);
+
+        seekable.Position = 64;
+
+        var raw = loader.Load(seekable, ImageLoadOptions.FillTarget(new Vector2(300, 300)));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(raw.Width, Is.EqualTo(300));
+            Assert.That(raw.Height, Is.EqualTo(300));
+            Assert.That(raw.Data.Length, Is.EqualTo(raw.Width * raw.Height * 4));
+        }
+    }
+
+    /// <summary>
+    /// A seekable pass-through that counts how often it is asked to move backwards.
+    /// </summary>
+    private class RewindCountingStream : Stream
+    {
+        private readonly Stream inner;
+
+        public RewindCountingStream(Stream inner)
+        {
+            this.inner = inner;
+        }
+
+        public int Rewinds { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set
+            {
+                if (value < inner.Position)
+                    Rewinds++;
+
+                inner.Position = value;
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override void Flush() => inner.Flush();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long from = inner.Position;
+            long to = inner.Seek(offset, origin);
+
+            if (to < from)
+                Rewinds++;
+
+            return to;
+        }
+    }
+
     private class NonSeekableStream : Stream
     {
         private readonly Stream inner;

--- a/Sakura.Framework.Tests/Graphics/PixelBufferPoolTest.cs
+++ b/Sakura.Framework.Tests/Graphics/PixelBufferPoolTest.cs
@@ -1,0 +1,139 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Textures;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+[TestFixture]
+public class PixelBufferPoolTest
+{
+    private const int width = 400;
+    private const int height = 300;
+
+    /// <summary>
+    /// The exact shape the decode path uses, and the one that regressed: rent on a pool thread, release on a
+    /// different dedicated thread, repeatedly. Counts distinct arrays, so a miss cannot hide behind
+    /// equal-looking sizes.
+    /// </summary>
+    [Test]
+    public void ABufferReleasedOnAnotherThreadIsReusedByTheNextRental()
+    {
+        const int cycles = 20;
+
+        var seen = new HashSet<byte[]>();
+        var toRelease = new System.Collections.Concurrent.BlockingCollection<ImageRawData>();
+
+        var releaseThread = new Thread(() =>
+        {
+            foreach (var raw in toRelease.GetConsumingEnumerable())
+                raw.Dispose();
+        })
+        { IsBackground = true };
+
+        releaseThread.Start();
+
+        for (int i = 0; i < cycles; i++)
+        {
+            var raw = Task.Run(() => ImageRawData.Rent(width, height)).GetAwaiter().GetResult();
+
+            byte[]? array = raw.BackingArray;
+            Assert.That(array, Is.Not.Null);
+            seen.Add(array!);
+
+            // Hand it to the other thread and wait for it to come back to the pool before renting again,
+            // mirroring a decode that waits on its upload.
+            toRelease.Add(raw);
+
+            while (toRelease.Count > 0)
+                Thread.Sleep(1);
+
+            Thread.Sleep(2);
+        }
+
+        toRelease.CompleteAdding();
+        Assert.That(releaseThread.Join(TimeSpan.FromSeconds(10)), Is.True);
+
+        // ArrayPool<byte>.Shared measured between 2 and 40 distinct arrays for this shape across runs; a
+        // pool without a thread-static layer measured 2 or 3. A handful of slack for scheduling, but nowhere
+        // near one per rental.
+        Assert.That(seen, Has.Count.LessThanOrEqualTo(4),
+            $"a buffer released on another thread must be reused, got {seen.Count} distinct arrays for {cycles} rentals");
+    }
+
+    /// <summary>
+    /// The simplest property, and the one that must never regress: same thread, rent and release in a loop,
+    /// exactly one array.
+    /// </summary>
+    [Test]
+    public void SameThreadRentalsReuseOneBuffer()
+    {
+        var seen = new HashSet<byte[]>();
+
+        for (int i = 0; i < 20; i++)
+        {
+            var raw = ImageRawData.Rent(width, height);
+
+            seen.Add(raw.BackingArray!);
+            raw.Dispose();
+        }
+
+        Assert.That(seen, Has.Count.EqualTo(1));
+    }
+
+    /// <summary>
+    /// A rental larger than the pool's largest bucket must still succeed — it is simply not pooled — so an
+    /// unusually large image cannot fail to load.
+    /// </summary>
+    [Test]
+    public void AnOversizedRentalStillSucceeds()
+    {
+        // 5000x5000 RGBA is 100 MB, past the 64 MB the pool keeps buckets for.
+        using var raw = ImageRawData.Rent(5000, 5000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raw.IsValid, Is.True);
+            Assert.That(raw.Data.Length, Is.EqualTo(5000 * 5000 * 4));
+        });
+    }
+
+    /// <summary>
+    /// Disposal is idempotent across struct copies, which matters more with a dedicated pool than with the
+    /// shared one: returning the same array twice would hand it out to two owners at once.
+    /// </summary>
+    [Test]
+    public void DoubleDisposeDoesNotReturnTheSameArrayTwice()
+    {
+        var raw = ImageRawData.Rent(width, height);
+        var copy = raw;
+
+        byte[] array = raw.BackingArray!;
+
+        raw.Dispose();
+        copy.Dispose();
+
+        // If the array had been returned twice, the pool would hold it twice and hand it to both of these.
+        var first = ImageRawData.Rent(width, height);
+        var second = ImageRawData.Rent(width, height);
+
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.BackingArray, Is.SameAs(array), "the single return is reused");
+                Assert.That(second.BackingArray, Is.Not.SameAs(first.BackingArray), "and was not handed out twice");
+            });
+        }
+        finally
+        {
+            first.Dispose();
+            second.Dispose();
+        }
+    }
+}

--- a/Sakura.Framework.Tests/Graphics/UploadHeadroomTest.cs
+++ b/Sakura.Framework.Tests/Graphics/UploadHeadroomTest.cs
@@ -1,0 +1,276 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Logging;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+[TestFixture]
+public class UploadHeadroomTest
+{
+    private HeadlessTextureManager textureManager = null!;
+    private int originalLimit;
+    private int originalDecodes;
+    private TimeSpan originalTimeout;
+
+    /// <summary>
+    /// The outstanding count is process-global, so anything a test leaves queued would leak into the next
+    /// one. Every queueing renderer a test makes is registered here and fully drained on teardown.
+    /// </summary>
+    private readonly System.Collections.Generic.List<QueueingRenderer> queueingRenderers = new System.Collections.Generic.List<QueueingRenderer>();
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        textureManager = new HeadlessTextureManager();
+        originalLimit = TextureUploads.MaxOutstandingUploads;
+        originalDecodes = TextureUploads.MaxConcurrentDecodes;
+        originalTimeout = TextureUploads.UploadHeadroomTimeout;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // Drain before restoring the limit, so the outstanding count is back to zero for the next test.
+        foreach (var renderer in queueingRenderers)
+            renderer.DrainAll();
+
+        queueingRenderers.Clear();
+
+        TextureUploads.MaxOutstandingUploads = originalLimit;
+        TextureUploads.MaxConcurrentDecodes = originalDecodes;
+        TextureUploads.UploadHeadroomTimeout = originalTimeout;
+        textureManager.Dispose();
+
+        Assert.That(TextureUploads.OutstandingUploads, Is.Zero, "a test must not leak outstanding uploads");
+    }
+
+    private QueueingRenderer queueing()
+    {
+        var renderer = new QueueingRenderer(textureManager);
+        queueingRenderers.Add(renderer);
+        return renderer;
+    }
+
+    /// <summary>
+    /// Off by default. The in-app profile did not support enforcing it — the pool misses because renting and
+    /// returning happen on different threads, which no concurrency limit addresses. See
+    /// <c>ImageDecodeResidencyProbe.MeasureRentAndReturnThreadAffinity</c>.
+    /// </summary>
+    [Test]
+    public void TheDefaultIsOff()
+    {
+        Assert.That(TextureUploads.MaxOutstandingUploads, Is.Zero);
+    }
+
+    /// <summary>
+    /// The headless renderer runs uploads inline, so the slot is taken and given back within the call —
+    /// which is also why the whole suite does not deadlock on this gate.
+    /// </summary>
+    [Test]
+    public void AnUploadThatRunsImmediatelyReleasesItsSlot()
+    {
+        var renderer = new HeadlessRenderer(textureManager);
+
+        Assert.That(TextureUploads.OutstandingUploads, Is.Zero, "nothing outstanding to begin with");
+
+        Assert.That(create(renderer), Is.Not.Null);
+
+        Assert.That(TextureUploads.OutstandingUploads, Is.Zero, "and nothing left outstanding after");
+    }
+
+    /// <summary>
+    /// The gate proper: with one slot and one upload already queued and undrained, a second decode must
+    /// wait, and must proceed the moment the first upload runs.
+    /// </summary>
+    [Test]
+    public void ADecodeWaitsForHeadroomAndProceedsWhenTheQueueDrains()
+    {
+        TextureUploads.MaxOutstandingUploads = 1;
+        TextureUploads.UploadHeadroomTimeout = TimeSpan.FromSeconds(30);
+
+        var renderer = queueing();
+
+        // Fills the single slot; nothing drains it yet.
+        Assert.That(create(renderer), Is.Not.Null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(renderer.PendingCount, Is.EqualTo(1));
+            Assert.That(TextureUploads.OutstandingUploads, Is.EqualTo(1));
+        });
+
+        var second = Task.Run(() => create(renderer));
+
+        Assert.That(second.Wait(TimeSpan.FromMilliseconds(300)), Is.False,
+            "the second decode must block while the only slot is occupied");
+
+        renderer.DrainOne();
+
+        Assert.That(second.Wait(TimeSpan.FromSeconds(10)), Is.True,
+            "and must be released as soon as the upload runs");
+        Assert.That(second.Result, Is.Not.Null);
+    }
+
+    /// <summary>
+    /// Zero or less means unbounded, so a decode never waits however deep the queue is.
+    /// </summary>
+    [Test]
+    public void TheLimitCanBeDisabled()
+    {
+        TextureUploads.MaxOutstandingUploads = 0;
+        TextureUploads.UploadHeadroomTimeout = TimeSpan.FromSeconds(30);
+
+        var renderer = queueing();
+
+        for (int i = 0; i < 5; i++)
+            Assert.That(create(renderer), Is.Not.Null, $"decode {i} must not wait");
+
+        Assert.That(renderer.PendingCount, Is.EqualTo(5), "all five are queued and none drained");
+    }
+
+    /// <summary>
+    /// A queue nobody pumps must not wedge loading. The wait gives up and stops enforcing the limit until
+    /// something drains, so a stalled queue costs one timeout in total rather than one per decode —
+    /// degrading to the behaviour before this gate existed rather than hanging.
+    /// </summary>
+    [Test]
+    public void AQueueThatNeverDrainsDoesNotWedgeLoading()
+    {
+        TextureUploads.MaxOutstandingUploads = 1;
+        TextureUploads.UploadHeadroomTimeout = TimeSpan.FromMilliseconds(150);
+
+        var renderer = queueing();
+
+        Assert.That(create(renderer), Is.Not.Null);
+        Assert.That(TextureUploads.OutstandingUploads, Is.EqualTo(1));
+
+        var clock = System.Diagnostics.Stopwatch.StartNew();
+        Assert.That(onPoolThread(renderer), Is.Not.Null, "the decode must still complete");
+        clock.Stop();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(clock.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(100), "after waiting for headroom");
+            Assert.That(renderer.PendingCount, Is.EqualTo(2), "and its upload is queued like any other");
+        });
+
+        // The limit is no longer enforced, so the next decode is not charged the timeout a second time.
+        clock.Restart();
+        Assert.That(onPoolThread(renderer), Is.Not.Null);
+        clock.Stop();
+
+        Assert.That(clock.ElapsedMilliseconds, Is.LessThan(100), "a stalled queue costs one timeout, not one per decode");
+
+        // ...and draining re-arms it, rather than leaving the limit off for the rest of the process.
+        renderer.DrainOne();
+
+        Assert.That(TextureUploads.OutstandingUploads, Is.EqualTo(2), "two of the three are still queued");
+
+        var blocked = Task.Run(() => create(renderer));
+
+        Assert.That(blocked.Wait(TimeSpan.FromMilliseconds(50)), Is.False, "the limit is enforced again once the queue moves");
+
+        renderer.DrainAll();
+
+        Assert.That(blocked.Wait(TimeSpan.FromSeconds(10)), Is.True);
+    }
+
+    /// <summary>
+    /// The limit only applies to thread-pool callers. The upload queue is drained by the draw thread, so a
+    /// load running on a dedicated framework thread — the draw thread most of all — must never be made to
+    /// wait for uploads that only that thread can run.
+    /// </summary>
+    [Test]
+    public void ANonPoolThreadIsNeverMadeToWait()
+    {
+        TextureUploads.MaxOutstandingUploads = 1;
+        TextureUploads.UploadHeadroomTimeout = TimeSpan.FromSeconds(30);
+
+        var renderer = queueing();
+
+        // Occupy the only slot, from the pool so that it is genuinely subject to the limit.
+        Assert.That(onPoolThread(renderer), Is.Not.Null);
+        Assert.That(TextureUploads.OutstandingUploads, Is.EqualTo(1));
+
+        Texture? fromDedicatedThread = null;
+        var thread = new Thread(() => fromDedicatedThread = create(renderer)) { IsBackground = true };
+
+        thread.Start();
+
+        Assert.That(thread.Join(TimeSpan.FromSeconds(2)), Is.True,
+            "a dedicated thread must not block on the limit — it would be a 30 second wait if it did");
+        Assert.That(fromDedicatedThread, Is.Not.Null);
+    }
+
+    private static Texture? onPoolThread(IRenderer renderer)
+        => Task.Run(() => create(renderer)).GetAwaiter().GetResult();
+
+    private static Texture? create(IRenderer renderer)
+        => TextureUploads.FromStream(
+            new MemoryStream(new byte[16]),
+            new TextureCreationOptions(),
+            renderer,
+            new StubLoader(),
+            new SharedTextureStore(),
+            static _ => { });
+
+    /// <summary>
+    /// Produces a small but valid image so <see cref="TextureUploads.FromStream"/> reaches the upload,
+    /// which is the part under test.
+    /// </summary>
+    private class StubLoader : IImageLoader
+    {
+        public ImageRawData Load(Stream stream) => Load(stream, ImageLoadOptions.FullSize);
+
+        public ImageRawData Load(Stream stream, int maxDimension) => Load(stream, ImageLoadOptions.MaxDimension(maxDimension));
+
+        public ImageRawData Load(Stream stream, ImageLoadOptions options) => ImageRawData.Rent(4, 4);
+    }
+
+    /// <summary>
+    /// Stands in for a real backend: uploads are queued for a draw thread rather than run inline, so the
+    /// test controls exactly when a slot is released. Re-listing <see cref="IRenderer"/> re-implements
+    /// <see cref="IRenderer.ScheduleTextureUpload"/>, which <see cref="HeadlessRenderer"/> otherwise takes
+    /// from the interface's default (run immediately).
+    /// </summary>
+    private class QueueingRenderer : HeadlessRenderer, IRenderer
+    {
+        private readonly ConcurrentQueue<Action> pending = new ConcurrentQueue<Action>();
+
+        public QueueingRenderer(HeadlessTextureManager textureManager)
+            : base(textureManager)
+        {
+        }
+
+        public int PendingCount => pending.Count;
+
+        public void ScheduleTextureUpload(Action upload, long approximateBytes) => pending.Enqueue(upload);
+
+        public void DrainOne()
+        {
+            if (pending.TryDequeue(out var upload))
+                upload();
+        }
+
+        public void DrainAll()
+        {
+            while (pending.TryDequeue(out var upload))
+                upload();
+        }
+    }
+}

--- a/Sakura.Framework.Tests/Rendering/DrawNodeSnapshotTest.cs
+++ b/Sakura.Framework.Tests/Rendering/DrawNodeSnapshotTest.cs
@@ -87,6 +87,95 @@ public class DrawNodeSnapshotTest
         });
     }
 
+    /// <summary>
+    /// The node's vertex storage is grow-only: shrinking the source and growing it back to a size already
+    /// seen must reuse the same array. It used to reallocate on any change in either direction, and there
+    /// are three nodes per drawable, so an oscillating vertex count allocated on every frame it changed.
+    /// </summary>
+    [Test]
+    public void TestVertexStorageGrowsButNeverShrinks()
+    {
+        var path = new Path { Thickness = 2 };
+
+        for (int i = 0; i < 6; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        parent.Add(path);
+        path.Load();
+        path.LoadComplete();
+
+        var node = pathNode(frame(0));
+        int grownCapacity = node.VertexCapacity;
+
+        Assert.That(grownCapacity, Is.EqualTo(node.VertexCount), "the first fill sizes the array exactly");
+        Assert.That(grownCapacity, Is.GreaterThan(0));
+
+        // Shrink: the count follows the source down, the array must not be replaced.
+        path.ClearVertices();
+
+        for (int i = 0; i < 3; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        node = pathNode(frame(0));
+
+        var node1 = node;
+        Assert.Multiple(() =>
+        {
+            Assert.That(node1.VertexCount, Is.LessThan(grownCapacity), "fewer vertices are live");
+            Assert.That(node1.VertexCapacity, Is.EqualTo(grownCapacity), "but the array is kept");
+        });
+
+        // Grow back to a size already seen: still no reallocation.
+        path.ClearVertices();
+
+        for (int i = 0; i < 6; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        node = pathNode(frame(0));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(node.VertexCount, Is.EqualTo(grownCapacity), "back to the original count");
+            Assert.That(node.VertexCapacity, Is.EqualTo(grownCapacity), "and the array was never replaced");
+        }
+    }
+
+    /// <summary>
+    /// Only the live range is drawn, so a node whose backing array is larger than its count must not leak
+    /// the stale tail into <see cref="DrawNode.Vertices"/>.
+    /// </summary>
+    [Test]
+    public void TestVerticesExposesOnlyTheLiveRange()
+    {
+        var path = new Path { Thickness = 2 };
+
+        for (int i = 0; i < 6; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        parent.Add(path);
+        path.Load();
+        path.LoadComplete();
+
+        int fullCount = pathNode(frame(0)).VertexCount;
+
+        path.ClearVertices();
+
+        for (int i = 0; i < 3; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        var node = pathNode(frame(0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Vertices.Length, Is.EqualTo(node.VertexCount), "the span is the count, not the capacity");
+            Assert.That(node.Vertices.Length, Is.LessThan(fullCount));
+            Assert.That(node.VertexCapacity, Is.EqualTo(fullCount), "the spare capacity is still there, just not exposed");
+        });
+    }
+
+    private static DrawNode pathNode(DrawNode rootNode)
+        => ((ContainerDrawNode)((ContainerDrawNode)rootNode).Children.Single()).Children.OfType<DrawNode>().Last();
+
     [Test]
     public void TestNodeIsExactSnapshotOfDrawable()
     {
@@ -96,7 +185,7 @@ public class DrawNodeSnapshotTest
 
         // Every vertex must match the drawable's current vertices exactly — a snapshot,
         // not an interpolation of any previous state.
-        Assert.That(node.Vertices, Has.Length.EqualTo(box.SourceVertices.Length));
+        Assert.That(node.VertexCount, Is.EqualTo(box.SourceVertices.Length));
 
         for (int i = 0; i < node.Vertices.Length; i++)
         {

--- a/Sakura.Framework.Tests/Rendering/SourceVertexStorageTest.cs
+++ b/Sakura.Framework.Tests/Rendering/SourceVertexStorageTest.cs
@@ -1,0 +1,187 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Linq;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Rendering.Vertex;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+
+namespace Sakura.Framework.Tests.Rendering;
+
+/// <summary>
+/// The drawable side of vertex storage: how many vertices a drawable declares, and whether growing and
+/// shrinking that count reallocates. <see cref="DrawNode"/> snapshots exactly the declared count, so a
+/// drawable whose array is larger than its count must not leak the stale tail into the draw.
+/// </summary>
+[TestFixture]
+public class SourceVertexStorageTest
+{
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        root = new Container { Size = new Vector2(800, 600) };
+        root.Load();
+        root.LoadComplete();
+    }
+
+    private DrawNode nodeFor(Drawable drawable)
+    {
+        root.Add(drawable);
+        drawable.Load();
+        drawable.LoadComplete();
+
+        root.UpdateSubTree();
+
+        return ((ContainerDrawNode)root.GenerateDrawNodeSubtree(0)).Children.Last();
+    }
+
+    /// <summary>
+    /// A <see cref="Line"/> is two triangles, so its node must carry six vertices — not the four a plain
+    /// drawable declares.
+    /// </summary>
+    [Test]
+    public void ALineSnapshotsSixVertices()
+    {
+        var line = new Line
+        {
+            StartPoint = new Vector2(0, 0),
+            EndPoint = new Vector2(100, 100),
+            Thickness = 4
+        };
+
+        var node = nodeFor(line);
+
+        Assert.That(node.VertexCount, Is.EqualTo(6));
+    }
+
+    /// <summary>
+    /// A <see cref="Triangle"/> is one triangle, so three vertices.
+    /// </summary>
+    [Test]
+    public void ATriangleSnapshotsThreeVertices()
+    {
+        var triangle = new Triangle { Size = new Vector2(50, 50) };
+
+        var node = nodeFor(triangle);
+
+        Assert.That(node.VertexCount, Is.EqualTo(3));
+    }
+
+    /// <summary>
+    /// The drawable-side equivalent of the draw node's grow-only storage: a <see cref="Path"/> losing
+    /// segments and regaining them must not reallocate. It used to assign a right-sized array on any change,
+    /// so an oscillating vertex count allocated in both directions.
+    /// </summary>
+    [Test]
+    public void SourceVertexStorageGrowsButNeverShrinks()
+    {
+        var path = new Path { Thickness = 2 };
+
+        for (int i = 0; i < 6; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        var node = nodeFor(path);
+        int grownCount = node.VertexCount;
+
+        Assert.That(grownCount, Is.EqualTo((6 - 1) * 6));
+
+        // Shrink. The node's count must follow the source down...
+        path.ClearVertices();
+
+        for (int i = 0; i < 3; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        root.UpdateSubTree();
+        node = ((ContainerDrawNode)root.GenerateDrawNodeSubtree(0)).Children.Last();
+
+        Assert.That(node.VertexCount, Is.EqualTo((3 - 1) * 6), "the count follows the source, not the capacity");
+
+        // ...and back up to a size already seen.
+        path.ClearVertices();
+
+        for (int i = 0; i < 6; i++)
+            path.AddVertex(new Vector2(i * 10, i * 10));
+
+        root.UpdateSubTree();
+        node = ((ContainerDrawNode)root.GenerateDrawNodeSubtree(0)).Children.Last();
+
+        Assert.That(node.VertexCount, Is.EqualTo(grownCount));
+    }
+
+    /// <summary>
+    /// A drawable that sizes its array exactly, rather than opting into grow-only storage, must keep working
+    /// untouched — its count falls back to the array's length. Several drawables outside this repository do
+    /// exactly that, so the fallback is the compatibility guarantee, not an implementation detail.
+    /// </summary>
+    [Test]
+    public void ADrawableThatSizesItsArrayExactlyStillReportsTheRightCount()
+    {
+        var exact = new ExactlySizedDrawable(7);
+
+        var node = nodeFor(exact);
+
+        Assert.That(node.VertexCount, Is.EqualTo(7));
+    }
+
+    private partial class ExactlySizedDrawable : Drawable
+    {
+        private readonly int count;
+
+        public ExactlySizedDrawable(int count)
+        {
+            this.count = count;
+            Size = new Vector2(10, 10);
+        }
+
+        protected internal override VertexTopology Topology => VertexTopology.Triangles;
+
+        protected override void GenerateVertices()
+        {
+            // Deliberately the old pattern: assign a right-sized array and never touch SetVertexCount.
+            if (Vertices.Length != count)
+                Vertices = new Vertex[count];
+
+            for (int i = 0; i < count; i++)
+                Vertices[i] = new Vertex { Color = new Vector4(1, 1, 1, 1) };
+        }
+    }
+
+    /// <summary>
+    /// Whatever a drawable declares, the vertices reaching the node must be the ones it wrote — not the
+    /// zero-initialized contents of an array nobody filled, which would be invisible (alpha 0) rather than
+    /// obviously broken.
+    /// </summary>
+    [Test]
+    public void ALinesVerticesAreActuallyPopulated()
+    {
+        var line = new Line
+        {
+            StartPoint = new Vector2(0, 0),
+            EndPoint = new Vector2(100, 100),
+            Thickness = 4
+        };
+
+        var node = nodeFor(line);
+
+        bool anyVisible = false;
+
+        for (int i = 0; i < node.Vertices.Length; i++)
+        {
+            if (node.Vertices[i].Color.W > 0)
+                anyVisible = true;
+        }
+
+        Assert.That(anyVisible, Is.True, "every vertex reaching the node had alpha 0, so the line draws nothing");
+    }
+}

--- a/Sakura.Framework.Tests/Statistics/GlobalStatisticsOrderingTest.cs
+++ b/Sakura.Framework.Tests/Statistics/GlobalStatisticsOrderingTest.cs
@@ -1,0 +1,152 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Tests.Statistics;
+
+[TestFixture]
+public class GlobalStatisticsOrderingTest
+{
+    private readonly List<IGlobalStatistic> registered = new List<IGlobalStatistic>();
+
+    private const string group_a = "ZZTestGroupA";
+    private const string group_b = "ZZTestGroupB";
+
+    private GlobalStatistic<int> register(string group, string name)
+    {
+        var stat = GlobalStatistics.Get<int>(group, name);
+        registered.Add(stat);
+        return stat;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var stat in registered)
+            GlobalStatistics.Remove(stat);
+
+        registered.Clear();
+    }
+
+    [Test]
+    public void NamesAreOrderedWithinAGroup()
+    {
+        register(group_a, "Zebra");
+        register(group_a, "Apple");
+        register(group_a, "Mango");
+        register(group_a, "Cherry");
+        register(group_a, "Banana");
+        register(group_a, "Durian");
+
+        Assert.That(namesIn(group_a), Is.EqualTo(new[] { "Apple", "Banana", "Cherry", "Durian", "Mango", "Zebra" }));
+    }
+
+    [Test]
+    public void GroupsAreOrderedToo()
+    {
+        register(group_b, "Only");
+        register(group_a, "Only");
+
+        var groups = new List<string>();
+
+        foreach (var stat in GlobalStatistics.GetStatistics())
+        {
+            if ((stat.Group == group_a || stat.Group == group_b) && !groups.Contains(stat.Group))
+                groups.Add(stat.Group);
+        }
+
+        Assert.That(groups, Is.EqualTo(new[] { group_a, group_b }));
+    }
+
+    /// <summary>
+    /// The case the overlay actually hits: a statistic registers lazily, long after its group first appeared,
+    /// because the class holding it was only just touched. It has to land in its alphabetical place.
+    /// </summary>
+    [Test]
+    public void AStatisticRegisteredLaterIsStillOrdered()
+    {
+        register(group_a, "Apple");
+        register(group_a, "Banana");
+        register(group_a, "Cherry");
+        register(group_a, "Zebra");
+
+        Assert.That(namesIn(group_a), Is.EqualTo(new[] { "Apple", "Banana", "Cherry", "Zebra" }));
+
+        register(group_a, "Durian");
+        register(group_a, "Mango");
+
+        Assert.That(namesIn(group_a), Is.EqualTo(new[] { "Apple", "Banana", "Cherry", "Durian", "Mango", "Zebra" }));
+    }
+
+    [Test]
+    public void RemovingAStatisticKeepsTheRestOrdered()
+    {
+        register(group_a, "Apple");
+        register(group_a, "Banana");
+        var mango = register(group_a, "Mango");
+        register(group_a, "Cherry");
+        register(group_a, "Durian");
+        register(group_a, "Zebra");
+
+        GlobalStatistics.Remove(mango);
+        registered.Remove(mango);
+
+        Assert.That(namesIn(group_a), Is.EqualTo(new[] { "Apple", "Banana", "Cherry", "Durian", "Zebra" }));
+    }
+
+    /// <summary>
+    /// The whole point of caching the order: reading it must not allocate, because the overlay reads it every
+    /// frame. The previous implementation walked <c>ConcurrentDictionary.Values</c> per group per read, which
+    /// builds a snapshot collection each time — a 7-minute profile attributed over 15 MB to that.
+    /// </summary>
+    [Test]
+    public void RepeatedReadsDoNotAllocate()
+    {
+        register(group_a, "Apple");
+        register(group_a, "Zebra");
+
+        int seen = 0;
+        long allocated = -1;
+
+        // The registry is process-wide, so any other statistic registering — another fixture, a static
+        // initializer on another thread — invalidates the cache and costs this loop one rebuild. That is
+        // correct behavior, not the regression being guarded against, so a clean run is retried for rather
+        // than the assertion being loosened: a read that allocated *per call* could never produce a zero.
+        for (int attempt = 0; attempt < 5 && allocated != 0; attempt++)
+        {
+            // Prime, so the measured loop is the steady state rather than the rebuild.
+            foreach (var stat in GlobalStatistics.GetStatistics())
+                seen += stat.Name.Length;
+
+            long before = GC.GetTotalAllocatedBytes(precise: true);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (var stat in GlobalStatistics.GetStatistics())
+                    seen += stat.Name.Length;
+            }
+
+            allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+        }
+
+        Assert.That(seen, Is.GreaterThan(0));
+        Assert.That(allocated, Is.Zero, $"1000 reads allocated {allocated} bytes even after retries");
+    }
+
+    private static List<string> namesIn(string group)
+    {
+        var names = new List<string>();
+
+        foreach (var stat in GlobalStatistics.GetStatistics())
+        {
+            if (stat.Group == group)
+                names.Add(stat.Name);
+        }
+
+        return names;
+    }
+}

--- a/Sakura.Framework.Tests/Text/FontDataResidencyTest.cs
+++ b/Sakura.Framework.Tests/Text/FontDataResidencyTest.cs
@@ -81,6 +81,37 @@ public class FontDataResidencyTest
     }
 
     /// <summary>
+    /// The acceptance criterion, in the portable form: nothing font-sized reaches the large object heap.
+    /// The bundled test font is 111 KB, comfortably over the 85 KB LOH threshold, so a managed copy of it
+    /// would land there and show up here.
+    /// </summary>
+    [Test]
+    public void LoadingAFontPutsNothingOnTheLargeObjectHeap()
+    {
+        long expected = fontFileLength();
+
+        long before = liveLargeObjectHeapBytes();
+
+        load("NoLoh");
+
+        Assert.That(liveLargeObjectHeapBytes() - before, Is.LessThan(expected), "a pinned managed copy of the face would show up here");
+    }
+
+    /// <summary>
+    /// Live large-object-heap size, with the heap settled first so the figure reflects what is retained
+    /// rather than what happens to be uncollected.
+    /// </summary>
+    private static long liveLargeObjectHeapBytes()
+    {
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        // GenerationInfo index 3 is the large object heap.
+        return GC.GetGCMemoryInfo().GenerationInfo[3].SizeAfterBytes;
+    }
+
+    /// <summary>
     /// The statistic exists because the absence of any number for this is why a ~192 MB platform emoji
     /// font went unnoticed at startup.
     /// </summary>
@@ -124,6 +155,105 @@ public class FontDataResidencyTest
         Assert.DoesNotThrow(() => font.Dispose(), "the second dispose must be a no-op, not a double free");
         Assert.That(fontBytes, Is.EqualTo(before), "and must not subtract the block's size a second time");
     }
+
+    #region Mapped fonts
+
+    /// <summary>
+    /// Copies the bundled font out to a real file, since mapping needs one and the test resources are
+    /// embedded. Returns its path.
+    /// </summary>
+    private string materialiseFontOnDisk()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"mapped-{TestContext.CurrentContext.Test.Name}.ttf");
+
+        using (var source = fonts.GetStream(font_file)!)
+        using (var destination = File.Create(path))
+            source.CopyTo(destination);
+
+        return path;
+    }
+
+    /// <summary>
+    /// The whole point: a mapped face shapes text correctly. FreeType and HarfBuzz read the tables straight
+    /// out of the page cache, so if the pointer or the length were wrong this is where it would show.
+    /// </summary>
+    [Test]
+    public void AMappedFontShapesText()
+    {
+        string path = materialiseFontOnDisk();
+
+        try
+        {
+            store.AddFontFromFile(path, alias: "Mapped");
+
+            var shaped = store.Shape(FontUsage.Default.With(family: "Mapped"), "hello", 1f);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(shaped.Glyphs, Has.Count.EqualTo(5), "five glyphs from a mapped face");
+                Assert.That(shaped.Glyphs[0].Texture, Is.Not.Null, "and they rasterised");
+            });
+        }
+        finally
+        {
+            store.Dispose();
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// A mapped face is counted separately from allocated font memory, because file-backed pages are a
+    /// ceiling the OS may never fault in rather than memory the process has committed — putting them in
+    /// <c>Native Memory -> Total</c> would overstate a figure that is read against the process footprint.
+    /// </summary>
+    [Test]
+    public void AMappedFontIsCountedAsMappedRatherThanAllocated()
+    {
+        string path = materialiseFontOnDisk();
+
+        try
+        {
+            long allocatedBefore = fontBytes;
+            long mappedBefore = NativeFileMapping.MappedBytes;
+
+            store.AddFontFromFile(path, alias: "MappedCount");
+            store.Get(FontUsage.Default.With(family: "MappedCount"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(NativeFileMapping.MappedBytes - mappedBefore, Is.EqualTo(new FileInfo(path).Length), "the whole face, as a mapping");
+                Assert.That(fontBytes, Is.EqualTo(allocatedBefore), "and nothing copied into unmanaged memory");
+            });
+
+            store.Dispose();
+
+            Assert.That(NativeFileMapping.MappedBytes, Is.EqualTo(mappedBefore), "unmapped on dispose");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// An embedded resource has no filesystem path, so it still has to be copied — and must still work.
+    /// This is the routing, not a fallback for a failure.
+    /// </summary>
+    [Test]
+    public void AnEmbeddedFontStillLoadsByCopy()
+    {
+        long mappedBefore = NativeFileMapping.MappedBytes;
+
+        load("Embedded");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fontBytes, Is.GreaterThan(0), "copied into unmanaged memory");
+            Assert.That(NativeFileMapping.MappedBytes, Is.EqualTo(mappedBefore), "an embedded resource cannot be mapped");
+        });
+    }
+
+    #endregion
 
     /// <summary>
     /// The store reads fonts through a stream, and a stream that cannot report its length takes

--- a/Sakura.Framework.Tests/Text/FontDataResidencyTest.cs
+++ b/Sakura.Framework.Tests/Text/FontDataResidencyTest.cs
@@ -1,0 +1,181 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Text;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.IO;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Platform;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Tests.Text;
+
+/// <summary>
+/// Font data lives in unmanaged memory, not on the managed heap.
+/// </summary>
+[TestFixture]
+public class FontDataResidencyTest
+{
+    private const string font_file = "Comfortaa-Regular.ttf";
+
+    private HeadlessTextureManager textureManager = null!;
+    private RendererFontStore store = null!;
+    private Storage fonts = null!;
+
+    private static long fontBytes => NativeMemoryTracker.BytesFor(NativeMemoryCategory.Fonts);
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        textureManager = new HeadlessTextureManager();
+        store = new RendererFontStore(new HeadlessRenderer(textureManager));
+
+        fonts = new EmbeddedResourceStorage(typeof(TestApp).Assembly, "Sakura.Framework.Tests.Resources")
+            .GetStorageForDirectory("Fonts");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        store.Dispose();
+        textureManager.Dispose();
+    }
+
+    /// <summary>
+    /// The size of the font file on its own, for comparing against what the tracker reports.
+    /// </summary>
+    private long fontFileLength()
+    {
+        using var stream = fonts.GetStream(font_file)!;
+        return stream.Length;
+    }
+
+    /// <summary>
+    /// Forces the store's <see cref="System.Lazy{T}"/> to materialise, since loading is deferred until a
+    /// font is first asked for.
+    /// </summary>
+    private Font load(string alias)
+    {
+        store.AddFont(fonts, font_file, alias);
+        return store.Get(FontUsage.Default.With(family: alias));
+    }
+
+    [Test]
+    public void ALoadedFontIsAccountedAsUnmanagedFontMemory()
+    {
+        long before = fontBytes;
+
+        load("Residency");
+
+        Assert.That(fontBytes - before, Is.EqualTo(fontFileLength()), "every byte of the face, and no managed copy of it");
+    }
+
+    /// <summary>
+    /// The statistic exists because the absence of any number for this is why a ~192 MB platform emoji
+    /// font went unnoticed at startup.
+    /// </summary>
+    [Test]
+    public void TheFontsCategoryIsPublishedAsAStatistic()
+    {
+        load("Published");
+
+        Assert.That(GlobalStatistics.Get<long>("Native Memory", nameof(NativeMemoryCategory.Fonts)).Value,
+            Is.EqualTo(fontBytes));
+    }
+
+    [Test]
+    public void DisposingTheStoreReleasesTheFontData()
+    {
+        long before = fontBytes;
+
+        load("Released");
+        Assert.That(fontBytes, Is.GreaterThan(before));
+
+        store.Dispose();
+
+        Assert.That(fontBytes, Is.EqualTo(before), "the block is freed, not merely unpinned");
+    }
+
+    /// <summary>
+    /// A font registered under more than one key appears more than once in the store's cache values, so
+    /// the store's own teardown reaches it twice. <c>FT_Done_Face</c> on an already-destroyed face is a
+    /// double free rather than a no-op, and a second release of the byte block would be one too.
+    /// </summary>
+    [Test]
+    public void DisposingAFontTwiceReleasesItOnce()
+    {
+        long before = fontBytes;
+
+        var font = load("Doubled");
+        font.Dispose();
+
+        Assert.That(fontBytes, Is.EqualTo(before));
+
+        Assert.DoesNotThrow(() => font.Dispose(), "the second dispose must be a no-op, not a double free");
+        Assert.That(fontBytes, Is.EqualTo(before), "and must not subtract the block's size a second time");
+    }
+
+    /// <summary>
+    /// The store reads fonts through a stream, and a stream that cannot report its length takes
+    /// <see cref="NativeMemoryBuffer"/>'s grow-by-doubling path. That path is the one the old code handled
+    /// with <c>CopyTo(new MemoryStream())</c> plus <c>ToArray()</c>, which cost a font about 2.7x its own
+    /// size in transient large-object-heap traffic — inside a layout pass, not at startup.
+    /// </summary>
+    [Test]
+    public void AFontFromANonSeekableStreamStillLoadsExactly()
+    {
+        long expected = fontFileLength();
+
+        using var source = fonts.GetStream(font_file)!;
+        using var unseekable = new UnseekableStream(source);
+
+        var buffer = NativeMemoryBuffer.CreateFrom(unseekable, NativeMemoryCategory.Fonts);
+
+        Assert.That(buffer, Is.Not.Null);
+        Assert.That(buffer!.Length, Is.EqualTo(expected), "the growing path must land on the exact byte count");
+
+        buffer.Dispose();
+    }
+
+    /// <summary>
+    /// A stream that refuses to seek or report a length, which is what a compressed or network font source
+    /// looks like.
+    /// </summary>
+    private class UnseekableStream : Stream
+    {
+        private readonly Stream inner;
+
+        public UnseekableStream(Stream inner)
+        {
+            this.inner = inner;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/Sakura.Framework/Graphics/Audio/AudioVisualizer.cs
+++ b/Sakura.Framework/Graphics/Audio/AudioVisualizer.cs
@@ -156,10 +156,10 @@ public partial class AudioVisualizer : Drawable
 
     protected override void GenerateVertices()
     {
-        // Each bar is one quad (4 verts). Allocate/resize the shared vertex buffer.
-        int requiredVertices = bars_per_visualiser * 4;
-        if (Vertices.Length != requiredVertices)
-            Vertices = new Vertex[requiredVertices];
+        // Each bar is one quad (4 verts). The count is a constant today, so this never actually
+        // reallocated — grow-only anyway, so it stays correct if the bar count ever becomes dynamic.
+        const int required_vertices = bars_per_visualiser * 4;
+        SetVertexCount(required_vertices);
 
         var color = new Vector4(
             ColorExtensions.SrgbToLinear(Color.R),

--- a/Sakura.Framework/Graphics/Drawables/BezierCurve.cs
+++ b/Sakura.Framework/Graphics/Drawables/BezierCurve.cs
@@ -94,11 +94,8 @@ public partial class BezierCurve : Drawable
 
     protected override void GenerateVertices()
     {
-        int requiredVertices = segments * 6;
-        if (Vertices.Length != requiredVertices)
-        {
-            Vertices = new Vertex[requiredVertices];
-        }
+        const int required_vertices = segments * 6;
+        SetVertexCount(required_vertices);
 
         float rLinear = ColorExtensions.SrgbToLinear(Color.R);
         float gLinear = ColorExtensions.SrgbToLinear(Color.G);

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -215,6 +215,42 @@ public abstract partial class Drawable : IDependencyInjectionCandidate, IDisposa
     protected internal Vertex[] Vertices = new Vertex[4];
 
     /// <summary>
+    /// Set by <see cref="SetVertexCount"/>, or negative when this drawable has not opted into grow-only
+    /// vertex storage and its array is exactly the size it writes.
+    /// </summary>
+    private int explicitVertexCount = -1;
+
+    /// <summary>
+    /// How many entries of <see cref="Vertices"/> this drawable actually writes.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>Vertices.Length</c>, so a subclass that sizes the array exactly — by assigning a new
+    /// array whenever the count changes — needs no changes and keeps working. A subclass that calls
+    /// <see cref="SetVertexCount"/> instead gets grow-only storage, and then the array's length is a capacity
+    /// and this is the count. Do not mix the two on one drawable: an explicit count set once is not undone by
+    /// a later direct assignment to <see cref="Vertices"/>.
+    /// </remarks>
+    protected internal int VertexCount => explicitVertexCount >= 0 ? explicitVertexCount : Vertices.Length;
+
+    /// <summary>
+    /// Declares how many vertices this drawable writes, growing <see cref="Vertices"/> only when it is too
+    /// small to hold them.
+    /// </summary>
+    /// <remarks>
+    /// The alternative — assigning a right-sized array whenever the count changes — reallocates in
+    /// <em>both</em> directions, so a shape whose vertex count oscillates allocates on every change. This is
+    /// the same fix <see cref="Rendering.DrawNode.SetVertexCount"/> applies on the draw-node side; the two
+    /// are independent, and this is the one that runs once per drawable rather than once per buffered node.
+    /// </remarks>
+    protected void SetVertexCount(int count)
+    {
+        if (Vertices.Length < count)
+            Vertices = new Vertex[count];
+
+        explicitVertexCount = count;
+    }
+
+    /// <summary>
     /// How <see cref="Vertices"/> is interpreted by the renderer. The base drawable produces
     /// an indexed quad (4 vertices, ordered TL, TR, BR, BL); drawables that generate arbitrary
     /// triangle lists in <see cref="GenerateVertices"/> must override this to

--- a/Sakura.Framework/Graphics/Drawables/Line.cs
+++ b/Sakura.Framework/Graphics/Drawables/Line.cs
@@ -14,8 +14,6 @@ namespace Sakura.Framework.Graphics.Drawables;
 /// </summary>
 public partial class Line : Drawable
 {
-    protected new readonly Vertex[] Vertices = new Vertex[6];
-
     private Vector2 startPoint = Vector2.Zero;
     public Vector2 StartPoint
     {
@@ -67,6 +65,8 @@ public partial class Line : Drawable
 
     protected override void GenerateVertices()
     {
+        SetVertexCount(6);
+
         float rLinear = ColorExtensions.SrgbToLinear(Color.R);
         float gLinear = ColorExtensions.SrgbToLinear(Color.G);
         float bLinear = ColorExtensions.SrgbToLinear(Color.B);

--- a/Sakura.Framework/Graphics/Drawables/Path.cs
+++ b/Sakura.Framework/Graphics/Drawables/Path.cs
@@ -98,15 +98,11 @@ public partial class Path : Drawable
     {
         if (vertices.Count < 2)
         {
-            Vertices = Array.Empty<Vertex>();
+            SetVertexCount(0);
             return;
         }
 
-        int requiredVertices = (vertices.Count - 1) * 6;
-        if (Vertices.Length != requiredVertices)
-        {
-            Vertices = new Vertex[requiredVertices];
-        }
+        SetVertexCount((vertices.Count - 1) * 6);
 
         float rLinear = ColorExtensions.SrgbToLinear(Color.R);
         float gLinear = ColorExtensions.SrgbToLinear(Color.G);

--- a/Sakura.Framework/Graphics/Drawables/SpriteText.cs
+++ b/Sakura.Framework/Graphics/Drawables/SpriteText.cs
@@ -401,19 +401,14 @@ public partial class SpriteText : Drawable
         private GlyphBatch[] batches = Array.Empty<GlyphBatch>();
         private int batchCount;
 
-        private int textVertexCount;
-
         protected override void ApplyVertices(Drawable source)
         {
             var text = (SpriteText)source;
 
-            textVertexCount = text.currentVertexCount;
-
-            // make it grow only, draw only reads up to textVertexCount via the glyph batches
-            if (Vertices.Length < textVertexCount)
-                Vertices = new Vertex[textVertexCount];
-
-            Array.Copy(text.textVertices, Vertices, textVertexCount);
+            // The source buffer is itself grow-only, so it is sliced to the live count rather than copied
+            // whole. The node's storage is grow-only too (see DrawNode.SetVertexCount).
+            SetVertexCount(text.currentVertexCount);
+            text.textVertices.AsSpan(0, VertexCount).CopyTo(WritableVertices);
         }
 
         public override void ApplyState(Drawable source)
@@ -492,15 +487,14 @@ public partial class SpriteText : Drawable
 
         public override void Draw(IRenderer renderer)
         {
-            if (DrawAlpha <= 0 || textVertexCount == 0) return;
+            if (DrawAlpha <= 0 || VertexCount == 0) return;
 
             renderer.SetBlendMode(Blending);
 
             for (int i = 0; i < batchCount; i++)
             {
                 var batch = batches[i];
-                var slice = Vertices.AsSpan(batch.VertexStart, batch.VertexCount);
-                renderer.DrawQuads(slice, batch.Texture);
+                renderer.DrawQuads(Vertices.Slice(batch.VertexStart, batch.VertexCount), batch.Texture);
             }
         }
     }

--- a/Sakura.Framework/Graphics/Drawables/Triangle.cs
+++ b/Sakura.Framework/Graphics/Drawables/Triangle.cs
@@ -13,12 +13,12 @@ namespace Sakura.Framework.Graphics.Drawables;
 /// </summary>
 public partial class Triangle : Drawable
 {
-    protected new readonly Vertex[] Vertices = new Vertex[3];
-
     protected internal override VertexTopology Topology => VertexTopology.Triangles;
 
     protected override void GenerateVertices()
     {
+        SetVertexCount(3);
+
         float rLinear = ColorExtensions.SrgbToLinear(Color.R);
         float gLinear = ColorExtensions.SrgbToLinear(Color.G);
         float bLinear = ColorExtensions.SrgbToLinear(Color.B);

--- a/Sakura.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
@@ -27,6 +27,12 @@ public partial class GlobalStatisticsDisplay : FocusedOverlayContainer, IRemoveF
     private readonly Container contentContainer;
     private readonly Dictionary<string, FlowContainer> groupContainers = new Dictionary<string, FlowContainer>();
     private readonly Dictionary<IGlobalStatistic, SpriteText> statValueTexts = new Dictionary<IGlobalStatistic, SpriteText>();
+
+    /// <summary>
+    /// Each group's rows in display order, so a statistic that registers after its group was already built
+    /// can be put in its alphabetical place rather than appended.
+    /// </summary>
+    private readonly Dictionary<string, List<(string Name, Drawable Row)>> groupRows = new Dictionary<string, List<(string, Drawable)>>();
     private readonly SpriteText currentTimeText;
     private readonly SpriteText runningTimeText;
 
@@ -149,6 +155,20 @@ public partial class GlobalStatisticsDisplay : FocusedOverlayContainer, IRemoveF
         });
     }
 
+    /// <summary>
+    /// Puts a group's rows back into alphabetical order after one arrived out of turn.
+    /// </summary>
+    private static void reorderRows(FlowContainer groupFlow, List<(string Name, Drawable Row)> rows)
+    {
+        rows.Sort(static (a, b) => string.CompareOrdinal(a.Name, b.Name));
+
+        foreach (var row in rows)
+            groupFlow.Remove(row.Row, dispose: false);
+
+        foreach (var row in rows)
+            groupFlow.Add(row.Row);
+    }
+
     public override void Update()
     {
         base.Update();
@@ -213,6 +233,16 @@ public partial class GlobalStatisticsDisplay : FocusedOverlayContainer, IRemoveF
                 rowContainer.Add(valueTextElement);
                 statValueTexts[stat] = valueTextElement;
                 groupFlow.Add(rowContainer);
+
+                if (!groupRows.TryGetValue(stat.Group, out var rows))
+                    groupRows[stat.Group] = rows = new List<(string, Drawable)>();
+
+                rows.Add((stat.Name, rowContainer));
+
+                // Rows arrive in order, so the common case is that the one just appended already belongs
+                // last and there is nothing to do.
+                if (rows.Count > 1 && string.CompareOrdinal(stat.Name, rows[^2].Name) < 0)
+                    reorderRows(groupFlow, rows);
             }
 
             string newDisplayValue = stat.DisplayValue;

--- a/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
@@ -15,6 +15,7 @@ using Sakura.Framework.Graphics.Text;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Graphics.Transforms;
 using Sakura.Framework.Input;
+using Sakura.Framework.IO;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
@@ -235,7 +236,14 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
             + $"   fb {toMegabytes(NativeMemoryTracker.BytesFor(NativeMemoryCategory.FrameBuffers))}"
             + $"   video {toMegabytes(NativeMemoryTracker.BytesFor(NativeMemoryCategory.Video))}"
             + $"   audio {toMegabytes(NativeMemoryTracker.BytesFor(NativeMemoryCategory.Audio))}"
-            + $"   other {toMegabytes(NativeMemoryTracker.BytesFor(NativeMemoryCategory.Other))}";
+            + $"   fonts {toMegabytes(NativeMemoryTracker.BytesFor(NativeMemoryCategory.Fonts))}"
+            + $"   other {toMegabytes(NativeMemoryTracker.BytesFor(NativeMemoryCategory.Other))}"
+            // mapped font files are a ceiling of file-backed pages the OS may never fault in,
+            // so folding them into Native would overstate a figure whose
+            // whole job is to be read against the process footprint. Referencing it here also forces the
+            // statistic to register, so "Fonts -> Mapped Bytes" reads 0 rather than being absent when
+            // nothing has been mapped.
+            + $"   (mapped {toMegabytes(NativeFileMapping.MappedBytes)})";
 
         if (host.UpdateClock.CurrentTime - lastUpdateTime < 100)
             return;

--- a/Sakura.Framework/Graphics/Rendering/BufferedContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/BufferedContainerDrawNode.cs
@@ -101,9 +101,9 @@ public class BufferedContainerDrawNode : ContainerDrawNode
             if (Vertices.Length == 0)
                 return false;
 
-            foreach (var vertex in Vertices)
+            for (int i = 0; i < Vertices.Length; i++)
             {
-                var color = vertex.Color;
+                var color = Vertices[i].Color;
 
                 if (color.X != 1f || color.Y != 1f || color.Z != 1f || color.W != 1f)
                     return false;
@@ -259,32 +259,29 @@ public class BufferedContainerDrawNode : ContainerDrawNode
     {
         int radius = sigmaTexels > 0 ? Math.Min(max_blur_radius, (int)MathF.Ceiling(sigmaTexels * 3)) : 0;
 
-        runShaderPass(renderer, source, target, rect, blurShader!, shader =>
+        runShaderPass(renderer, source, target, rect, blurShader!, "BlurBlock", new Uniforms.BlurBlock
         {
-            shader.SetUniformBlock("BlurBlock", new Uniforms.BlurBlock
-            {
-                TexelSize = new Vector2(1f / source.Width, 1f / source.Height),
-                Direction = new Vector2(direction.X, direction.Y),
-                Sigma = sigmaTexels,
-                Radius = radius,
-            });
+            TexelSize = new Vector2(1f / source.Width, 1f / source.Height),
+            Direction = direction,
+            Sigma = sigmaTexels,
+            Radius = radius,
         });
     }
 
     private void grayscalePass(IRenderer renderer, IFrameBuffer source, IFrameBuffer target, RectangleF rect)
     {
-        runShaderPass(renderer, source, target, rect, grayscaleShader!, shader =>
-            shader.SetUniformBlock("GrayscaleBlock", new Uniforms.GrayscaleBlock
-            {
-                Strength = grayscaleStrength
-            }));
+        runShaderPass(renderer, source, target, rect, grayscaleShader!, "GrayscaleBlock", new Uniforms.GrayscaleBlock
+        {
+            Strength = grayscaleStrength
+        });
     }
 
     /// <summary>
     /// Draws a full-buffer quad from <paramref name="source"/> into <paramref name="target"/>
-    /// using a custom shader
+    /// using a custom shader, whose pass-specific uniform block is <paramref name="block"/>.
     /// </summary>
-    private static void runShaderPass(IRenderer renderer, IFrameBuffer source, IFrameBuffer target, RectangleF rect, IShader shader, Action<IShader> setUniforms)
+    private static void runShaderPass<TBlock>(IRenderer renderer, IFrameBuffer source, IFrameBuffer target, RectangleF rect, IShader shader, string blockName, in TBlock block)
+        where TBlock : unmanaged
     {
         renderer.BindFrameBuffer(target, rect);
         renderer.FlushBatch();
@@ -295,7 +292,7 @@ public class BufferedContainerDrawNode : ContainerDrawNode
             Projection = renderer.ProjectionMatrix
         });
         shader.SetUniform("u_Texture", 0);
-        setUniforms(shader);
+        shader.SetUniformBlock(blockName, in block);
 
         // Bind the source attachment to unit 0 for the pass. The backend texture is bound directly so
         // it bypasses the renderer's slot tracking (this is a raw, custom-shader pass).

--- a/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/ContainerDrawNode.cs
@@ -150,7 +150,7 @@ public class ContainerDrawNode : DrawNode
         Vector2 br = new Vector2(quadCenter.X + expandedHalf.X - skew, quadCenter.Y + expandedHalf.Y);
         Vector2 bl = new Vector2(quadCenter.X - expandedHalf.X - skew, quadCenter.Y + expandedHalf.Y);
 
-        var quad = new Vertex.Vertex[4];
+        Span<Vertex.Vertex> quad = stackalloc Vertex.Vertex[4];
         quad[0] = new Vertex.Vertex { Position = tl, TexCoords = new Vector2(0, 0), Color = new Vector4(1, 1, 1, 1) };
         quad[1] = new Vertex.Vertex { Position = tr, TexCoords = new Vector2(1, 0), Color = new Vector4(1, 1, 1, 1) };
         quad[2] = new Vertex.Vertex { Position = br, TexCoords = new Vector2(1, 1), Color = new Vector4(1, 1, 1, 1) };

--- a/Sakura.Framework/Graphics/Rendering/DrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/DrawNode.cs
@@ -86,8 +86,8 @@ public class DrawNode
     /// </summary>
     protected virtual void ApplyVertices(Drawable source)
     {
-        SetVertexCount(source.Vertices.Length);
-        source.Vertices.AsSpan().CopyTo(WritableVertices);
+        SetVertexCount(source.VertexCount);
+        source.Vertices.AsSpan(0, source.VertexCount).CopyTo(WritableVertices);
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Rendering/DrawNode.cs
+++ b/Sakura.Framework/Graphics/Rendering/DrawNode.cs
@@ -16,7 +16,34 @@ public class DrawNode
 
     public long InvalidationID { get; internal set; }
 
-    public Vertex.Vertex[] Vertices { get; protected set; } = Array.Empty<Vertex.Vertex>();
+    /// <summary>
+    /// Backing storage for <see cref="Vertices"/>. Grow-only, so its length is a capacity and says nothing
+    /// about how many vertices are live (that is <see cref="VertexCount"/>).
+    /// </summary>
+    private Vertex.Vertex[] vertices = Array.Empty<Vertex.Vertex>();
+
+    /// <summary>
+    /// How many vertices this node will draw.
+    /// </summary>
+    public int VertexCount { get; private set; }
+
+    /// <summary>
+    /// The node's live vertices. <c>Length</c> is the vertex count, not the capacity behind it.
+    /// </summary>
+    public ReadOnlySpan<Vertex.Vertex> Vertices => vertices.AsSpan(0, VertexCount);
+
+    /// <summary>
+    /// The same range, writable, for subclasses that fill their vertices themselves rather than copying
+    /// them from <see cref="Drawable.Vertices"/>.
+    /// </summary>
+    protected Span<Vertex.Vertex> WritableVertices => vertices.AsSpan(0, VertexCount);
+
+    /// <summary>
+    /// Capacity of the backing array. Exposed so a test can assert that a shrink then a regrow does not
+    /// reallocate; nothing in the draw path should care about it.
+    /// </summary>
+    internal int VertexCapacity => vertices.Length;
+
     public Texture? Texture { get; protected set; }
     public BlendingMode Blending { get; protected set; }
     public float DrawAlpha { get; protected set; }
@@ -43,15 +70,24 @@ public class DrawNode
     }
 
     /// <summary>
+    /// Sets how many vertices are live, growing the backing array only when it is too small.
+    /// </summary>
+    protected void SetVertexCount(int count)
+    {
+        if (vertices.Length < count)
+            vertices = new Vertex.Vertex[count];
+
+        VertexCount = count;
+    }
+
+    /// <summary>
     /// Snapshots the source drawable's vertices into this node.
     /// Subclasses with custom vertex storage can override this to copy from their own source.
     /// </summary>
     protected virtual void ApplyVertices(Drawable source)
     {
-        if (Vertices.Length != source.Vertices.Length)
-            Vertices = new Vertex.Vertex[source.Vertices.Length];
-
-        Array.Copy(source.Vertices, Vertices, source.Vertices.Length);
+        SetVertexCount(source.Vertices.Length);
+        source.Vertices.AsSpan().CopyTo(WritableVertices);
     }
 
     /// <summary>
@@ -60,7 +96,7 @@ public class DrawNode
     /// </summary>
     public virtual void Draw(IRenderer renderer)
     {
-        if (DrawAlpha <= 0 || Vertices.Length == 0)
+        if (DrawAlpha <= 0 || VertexCount == 0)
             return;
 
         stat_drawn_last_frame.Value++;

--- a/Sakura.Framework/Graphics/Text/Font.cs
+++ b/Sakura.Framework/Graphics/Text/Font.cs
@@ -130,7 +130,15 @@ public class Font : IDisposable
         public bool IsColorGlyph;
     }
 
-    public Font(string name, NativeMemoryBuffer fontData, TextureAtlas atlas)
+    /// <param name="name">The family name this face is registered under.</param>
+    /// <param name="fontData">
+    /// The face's raw bytes, outside the managed heap — either a <see cref="NativeMemoryBuffer"/> read into
+    /// unmanaged memory or a <see cref="NativeFileMapping"/> of the file itself. <b>Ownership transfers to
+    /// this font</b>, which releases it in <see cref="Dispose"/> once FreeType and HarfBuzz are done with
+    /// it, and releases it immediately if construction fails.
+    /// </param>
+    /// <param name="atlas">The atlas glyphs are rasterized into.</param>
+    public Font(string name, INativeBytes fontData, TextureAtlas atlas)
     {
         ArgumentNullException.ThrowIfNull(fontData);
 
@@ -256,7 +264,7 @@ public class Font : IDisposable
     /// <summary>
     /// The face's raw bytes, owned by this font and outliving every native object that reads them.
     /// </summary>
-    private readonly NativeMemoryBuffer fontData;
+    private readonly INativeBytes fontData;
 
     public ShapedText ProcessText(string text, float fontSize, float dpiScale = 1.0f, IEnumerable<Font>? fallbacks = null, FontVariation variation = default)
     {

--- a/Sakura.Framework/Graphics/Text/Font.cs
+++ b/Sakura.Framework/Graphics/Text/Font.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using FreeTypeSharp;
 using HarfBuzzSharp;
 using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.IO;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Statistic;
@@ -39,7 +40,13 @@ public class Font : IDisposable
     private readonly TextureAtlas atlas;
 
     private readonly FreeTypeLibrary library;
-    private readonly IntPtr faceHandle;
+    private IntPtr faceHandle;
+
+    /// <summary>
+    /// 1 once <see cref="Dispose"/> has run, claimed with an interlocked exchange so the second caller
+    /// cannot double-free the FreeType face.
+    /// </summary>
+    private int disposed;
 
     private readonly HarfBuzzSharp.Blob hbBlob;
     private readonly HarfBuzzSharp.Face hbFace;
@@ -123,27 +130,46 @@ public class Font : IDisposable
         public bool IsColorGlyph;
     }
 
-    public Font(string name, byte[] fontData, TextureAtlas atlas)
+    public Font(string name, NativeMemoryBuffer fontData, TextureAtlas atlas)
     {
+        ArgumentNullException.ThrowIfNull(fontData);
+
+        // Both native consumers below take a 32-bit length, and a face this large is not a real font.
+        if (fontData.Length > int.MaxValue)
+        {
+            fontData.Dispose();
+            throw new ArgumentOutOfRangeException(nameof(fontData), $"Font data is too large to load ({fontData.Length} bytes).");
+        }
+
         Name = name;
         this.atlas = atlas;
+        this.fontData = fontData;
+
+        int length = (int)fontData.Length;
+        IntPtr fontPtr = fontData.Pointer;
 
         library = new FreeTypeLibrary();
 
-        pinnedFontData = GCHandle.Alloc(fontData, GCHandleType.Pinned);
-        IntPtr fontPtr = pinnedFontData.AddrOfPinnedObject();
-
-        unsafe
+        try
         {
-            IntPtr facePtr = IntPtr.Zero;
-            FT_Error err = FT.FT_New_Memory_Face(library.Native, (byte*)fontPtr, fontData.Length, 0, (FT_FaceRec_**)&facePtr);
-            if (err != FT_Error.FT_Err_Ok) throw new Exception($"Failed to load font face: {err}");
-            faceHandle = facePtr;
-        }
+            unsafe
+            {
+                IntPtr facePtr = IntPtr.Zero;
+                FT_Error err = FT.FT_New_Memory_Face(library.Native, (byte*)fontPtr, length, 0, (FT_FaceRec_**)&facePtr);
+                if (err != FT_Error.FT_Err_Ok) throw new Exception($"Failed to load font face: {err}");
+                faceHandle = facePtr;
+            }
 
-        hbBlob = new Blob(fontPtr, fontData.Length, MemoryMode.ReadOnly);
-        hbFace = new Face(hbBlob, 0);
-        hbFont = new HarfBuzzSharp.Font(hbFace);
+            hbBlob = new Blob(fontPtr, length, MemoryMode.ReadOnly);
+            hbFace = new Face(hbBlob, 0);
+            hbFont = new HarfBuzzSharp.Font(hbFace);
+        }
+        catch
+        {
+            library.Dispose();
+            fontData.Dispose();
+            throw;
+        }
 
         // Detect variable fonts and read their axis table once at load time. Static fonts skip all
         // of this and behave exactly as before.
@@ -227,7 +253,10 @@ public class Font : IDisposable
         }
     }
 
-    private GCHandle pinnedFontData;
+    /// <summary>
+    /// The face's raw bytes, owned by this font and outliving every native object that reads them.
+    /// </summary>
+    private readonly NativeMemoryBuffer fontData;
 
     public ShapedText ProcessText(string text, float fontSize, float dpiScale = 1.0f, IEnumerable<Font>? fallbacks = null, FontVariation variation = default)
     {
@@ -706,8 +735,15 @@ public class Font : IDisposable
         }
     }
 
+    /// <summary>
+    /// Releases the FreeType face, the HarfBuzz objects and the face's unmanaged bytes, in that order.
+    /// Repeated calls are a no-op.
+    /// </summary>
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+            return;
+
         sharedBuffer.Dispose();
         hbFont.Dispose();
         hbFace.Dispose();
@@ -716,12 +752,14 @@ public class Font : IDisposable
         if (faceHandle != IntPtr.Zero)
         {
             unsafe { FT.FT_Done_Face((FT_FaceRec_*)faceHandle); }
+            faceHandle = IntPtr.Zero;
         }
 
         library.Dispose();
 
-        if (pinnedFontData.IsAllocated)
-            pinnedFontData.Free();
+        // FT_Done_Face and the HarfBuzz objects above all read the
+        // block right up until they are destroyed, so freeing it any earlier is a use-after-free.
+        fontData.Dispose();
     }
 }
 

--- a/Sakura.Framework/Graphics/Text/RendererFontStore.cs
+++ b/Sakura.Framework/Graphics/Text/RendererFontStore.cs
@@ -288,6 +288,22 @@ public class RendererFontStore : IFontStore
         {
             try
             {
+                // A filesystem-backed storage can be mapped rather than read, which is the cheap path.
+                // GetFileSystemPath returns null for anything else (an embedded resource, an archive), and
+                // those genuinely have to be copied. Same routing SF-13 uses for audio.
+                string? filePath = storage.GetFileSystemPath(filename);
+
+                if (filePath != null)
+                {
+                    var mapped = loadFontFromFile(name, filePath);
+
+                    if (mapped != null)
+                    {
+                        GlobalStatistics.Get<int>("Fonts", "Loaded Fonts").Value++;
+                        return mapped;
+                    }
+                }
+
                 using var stream = storage.GetStream(filename);
                 if (stream == null)
                 {
@@ -333,16 +349,13 @@ public class RendererFontStore : IFontStore
                     return null!;
                 }
 
-                var fontData = NativeMemoryBuffer.CreateFromFile(filePath, NativeMemoryCategory.Fonts);
+                var font = loadFontFromFile(name, filePath);
 
-                if (fontData == null)
+                if (font == null)
                 {
-                    Logger.Error($"Font file is empty: {filePath}");
+                    Logger.Error($"Font file could not be read: {filePath}");
                     return null!;
                 }
-
-                var font = new Font(name, fontData, atlas);
-                Logger.Debug($"Loaded font {name} from {filePath}");
 
                 GlobalStatistics.Get<int>("Fonts", "Loaded Fonts").Value++;
 
@@ -373,6 +386,36 @@ public class RendererFontStore : IFontStore
         }
         else
             Logger.Warning($"Cannot alias font '{alias}' to missing key '{existingKey}'.");
+    }
+
+    /// <summary>
+    /// Builds a face from a file on disk, mapping it rather than reading it where the platform allows.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Falls back to reading the file into unmanaged memory when mapping is unavailable — a filesystem that
+    /// does not support it, or a file held exclusively elsewhere. Mapping is an optimization, not a
+    /// contract.
+    /// </para>
+    /// </remarks>
+    /// <returns>The face, or null if the file could not be read at all.</returns>
+    private Font? loadFontFromFile(string name, string filePath)
+    {
+        INativeBytes? fontData = NativeFileMapping.CreateFrom(filePath);
+
+        if (fontData != null)
+            Logger.Debug($"Mapped font {name} from {filePath} ({fontData.Length / 1024} KB, no copy)");
+        else
+        {
+            fontData = NativeMemoryBuffer.CreateFromFile(filePath, NativeMemoryCategory.Fonts);
+
+            if (fontData == null)
+                return null;
+
+            Logger.Debug($"Read font {name} from {filePath} ({fontData.Length / 1024} KB into unmanaged memory)");
+        }
+
+        return new Font(name, fontData, atlas);
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Text/RendererFontStore.cs
+++ b/Sakura.Framework/Graphics/Text/RendererFontStore.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.IO;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Statistic;
@@ -332,7 +333,15 @@ public class RendererFontStore : IFontStore
                     return null!;
                 }
 
-                var font = new Font(name, File.ReadAllBytes(filePath), atlas);
+                var fontData = NativeMemoryBuffer.CreateFromFile(filePath, NativeMemoryCategory.Fonts);
+
+                if (fontData == null)
+                {
+                    Logger.Error($"Font file is empty: {filePath}");
+                    return null!;
+                }
+
+                var font = new Font(name, fontData, atlas);
                 Logger.Debug($"Loaded font {name} from {filePath}");
 
                 GlobalStatistics.Get<int>("Fonts", "Loaded Fonts").Value++;
@@ -366,30 +375,16 @@ public class RendererFontStore : IFontStore
             Logger.Warning($"Cannot alias font '{alias}' to missing key '{existingKey}'.");
     }
 
+    /// <summary>
+    /// Reads a font from a stream into unmanaged memory and builds the face from it.
+    /// </summary>
+    /// <exception cref="InvalidDataException">If the stream held no bytes.</exception>
     private Font loadFontFromStream(string name, Stream stream)
     {
-        return new Font(name, readAll(stream), atlas);
+        var fontData = NativeMemoryBuffer.CreateFrom(stream, NativeMemoryCategory.Fonts)
+                       ?? throw new InvalidDataException($"Font stream for '{name}' held no bytes.");
 
-        static byte[] readAll(Stream stream)
-        {
-            if (stream.CanSeek)
-            {
-                long remaining = stream.Length - stream.Position;
-
-                if (remaining > 0 && remaining <= Array.MaxLength)
-                {
-                    byte[] exact = GC.AllocateUninitializedArray<byte>((int)remaining);
-
-                    stream.ReadExactly(exact);
-                    return exact;
-                }
-            }
-
-            // non-seekable, or a length the stream declines to report
-            using var ms = new MemoryStream();
-            stream.CopyTo(ms);
-            return ms.ToArray();
-        }
+        return new Font(name, fontData, atlas);
     }
 
     public Font Get(FontUsage usage)

--- a/Sakura.Framework/Graphics/Textures/ImageRawData.cs
+++ b/Sakura.Framework/Graphics/Textures/ImageRawData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Threading;
+using Sakura.Framework.Statistic;
 
 namespace Sakura.Framework.Graphics.Textures;
 
@@ -31,6 +32,39 @@ namespace Sakura.Framework.Graphics.Textures;
 /// </remarks>
 public readonly struct ImageRawData : IDisposable
 {
+    /// <summary>
+    /// How many arrays each size bucket keeps for reuse.
+    /// </summary>
+    private const int max_buffers_per_bucket = 2;
+
+    // Tested in yuuki.
+    // 64 MB covers a 4K RGBA frame (33 MB) with room to spare. A larger request still succeeds, it is
+    // simply allocated fresh instead of pooled.
+    private const int max_pooled_length = 64 * 1024 * 1024;
+
+    /// <summary>
+    /// Pixel buffers come from a dedicated pool rather than <see cref="ArrayPool{T}.Shared"/>.
+    /// </summary>
+    private static readonly ArrayPool<byte> pixel_pool = ArrayPool<byte>.Create(max_pooled_length, max_buffers_per_bucket);
+
+    private static readonly GlobalStatistic<long> stat_live_bytes = GlobalStatistics.Get<long>("Textures", "Pixel Buffer Bytes (live)");
+    private static readonly GlobalStatistic<long> stat_peak_bytes = GlobalStatistics.Get<long>("Textures", "Pixel Buffer Bytes (peak)");
+
+    private static long liveBytes;
+
+    private static void accountRent(int bytes)
+    {
+        long live = Interlocked.Add(ref liveBytes, bytes);
+
+        stat_live_bytes.Value = live;
+
+        if (live > stat_peak_bytes.Value)
+            stat_peak_bytes.Value = live;
+    }
+
+    private static void accountRelease(int bytes)
+        => stat_live_bytes.Value = Interlocked.Add(ref liveBytes, -bytes);
+
     private readonly PixelOwner? owner;
 
     public int Width { get; }
@@ -75,7 +109,9 @@ public readonly struct ImageRawData : IDisposable
     public static ImageRawData Rent(int width, int height)
     {
         int length = checked(width * height * 4);
-        byte[] rented = ArrayPool<byte>.Shared.Rent(length);
+        byte[] rented = pixel_pool.Rent(length);
+
+        accountRent(rented.Length);
 
         return new ImageRawData(width, height, new PixelOwner(rented, length, pooled: true));
     }
@@ -115,6 +151,12 @@ public readonly struct ImageRawData : IDisposable
     /// A pooled array is handed out dirty, so a decoder must write every byte it intends to be read.
     /// </remarks>
     public Span<byte> GetWritableSpan() => owner == null ? default : owner.WritableSpan;
+
+    /// <summary>
+    /// The backing array, for tests asserting pool reuse across threads. Not part of the public contract —
+    /// read pixels through <see cref="Data"/>.
+    /// </summary>
+    internal byte[]? BackingArray => owner?.BackingArray;
 
     /// <summary>
     /// Releases the pixel memory, returning it to the pool if it was rented. Idempotent, and safe to
@@ -160,12 +202,21 @@ public readonly struct ImageRawData : IDisposable
             }
         }
 
+        /// <summary>
+        /// The backing array, for tests asserting that a rental returned on one thread is reused by a
+        /// rental on another. Nothing in the draw path should reach for this.
+        /// </summary>
+        internal byte[]? BackingArray => Volatile.Read(ref array);
+
         public void Release()
         {
             byte[]? claimed = Interlocked.Exchange(ref array, null);
 
-            if (claimed != null && pooled)
-                ArrayPool<byte>.Shared.Return(claimed);
+            if (claimed == null || !pooled)
+                return;
+
+            pixel_pool.Return(claimed);
+            accountRelease(claimed.Length);
         }
     }
 }

--- a/Sakura.Framework/Graphics/Textures/ImageSharpImageLoader.cs
+++ b/Sakura.Framework/Graphics/Textures/ImageSharpImageLoader.cs
@@ -2,7 +2,6 @@
 // See the LICENSE file for full license text.
 
 using System;
-using System.Buffers;
 using System.IO;
 using Sakura.Framework.Maths;
 using SixLabors.ImageSharp;
@@ -32,20 +31,27 @@ public class ImageSharpImageLoader : IImageLoader
         var target = options.TargetSize!.Value;
         bool crop = options.CropToFill;
 
-        var encoded = EncodedBuffer.Read(stream);
-
-        try
+        // A seekable source can be read twice, so read the header, rewind, and decode straight from it.
+        if (stream.CanSeek)
         {
-            var decoderOptions = new DecoderOptions { TargetSize = decodeSizeFor(encoded.Span, target, crop) };
+            long origin = stream.Position;
+            var decodeSize = decodeSizeFor(stream, target, crop);
+            stream.Position = origin;
 
-            using var encodedStream = encoded.AsStream();
-            using var image = Image.Load<Rgba32>(decoderOptions, encodedStream);
-
+            using var image = Image.Load<Rgba32>(new DecoderOptions { TargetSize = decodeSize }, stream);
             return finish(image, target, crop);
         }
-        finally
+
+        // Non-seekable (an embedded resource or an archive entry): the header read cannot be undone, so
+        // the bytes have to be buffered before the size hint can be computed.
+        var encoded = EncodedBuffer.Read(stream);
+        var buffered = new DecoderOptions { TargetSize = decodeSizeFor(encoded.Span, target, crop) };
+
+        using var encodedStream = encoded.AsStream();
+
         {
-            encoded.Dispose();
+            using var image = Image.Load<Rgba32>(buffered, encodedStream);
+            return finish(image, target, crop);
         }
     }
 
@@ -77,28 +83,48 @@ public class ImageSharpImageLoader : IImageLoader
     }
 
     /// <summary>
-    /// The size hint passed to the decoder, or <c>null</c> to decode at full resolution. Only ever
-    /// downscales (a source already at or below the target is never enlarged), and keeps enough
-    /// resolution for the region that will ultimately be displayed so <see cref="reduce"/> is a clean
-    /// final shrink
+    /// <see cref="decodeSizeFor(int,int,Vector2,bool)"/> for an already-buffered image.
     /// </summary>
     private static Size? decodeSizeFor(ReadOnlySpan<byte> encoded, Vector2 target, bool cropToFill)
     {
-        int tw = Math.Max(1, (int)MathF.Ceiling(target.X));
-        int th = Math.Max(1, (int)MathF.Ceiling(target.Y));
-
-        int sw, sh;
-
         try
         {
             var info = Image.Identify(encoded);
-            sw = info.Width;
-            sh = info.Height;
+            return decodeSizeFor(info.Width, info.Height, target, cropToFill);
         }
         catch
         {
             return null; // header unreadable, fall back to a full decode, reduce() still caps it
         }
+    }
+
+    /// <summary>
+    /// <see cref="decodeSizeFor(int,int,Vector2,bool)"/> for a stream, read in place. Leaves the stream
+    /// positioned wherever the header read ended, so the caller must rewind before decoding.
+    /// </summary>
+    private static Size? decodeSizeFor(Stream stream, Vector2 target, bool cropToFill)
+    {
+        try
+        {
+            var info = Image.Identify(stream);
+            return decodeSizeFor(info.Width, info.Height, target, cropToFill);
+        }
+        catch
+        {
+            return null; // header unreadable, fall back to a full decode, reduce() still caps it
+        }
+    }
+
+    /// <summary>
+    /// The size hint passed to the decoder, or <c>null</c> to decode at full resolution. Only ever
+    /// downscales (a source already at or below the target is never enlarged), and keeps enough
+    /// resolution for the region that will ultimately be displayed so <see cref="reduce"/> is a clean
+    /// final shrink
+    /// </summary>
+    private static Size? decodeSizeFor(int sw, int sh, Vector2 target, bool cropToFill)
+    {
+        int tw = Math.Max(1, (int)MathF.Ceiling(target.X));
+        int th = Math.Max(1, (int)MathF.Ceiling(target.Y));
 
         if (sw <= 0 || sh <= 0)
             return null;
@@ -168,21 +194,20 @@ public class ImageSharpImageLoader : IImageLoader
     }
 
     /// <summary>
-    /// A right-sized (and, where possible, pooled) copy of an encoded image's bytes, readable both as a
-    /// span (for <see cref="Image.Identify(ReadOnlySpan{byte})"/>) and as a non-copying stream (for the
-    /// decode itself).
+    /// An encoded image's bytes held in memory, readable both as a span (for
+    /// <see cref="Image.Identify(ReadOnlySpan{byte})"/>) and as a non-copying stream (for the decode
+    /// itself). Only for sources that cannot be read twice, a seekable stream is identified and decoded
+    /// in place instead.
     /// </summary>
-    private readonly struct EncodedBuffer : IDisposable
+    private readonly struct EncodedBuffer
     {
         private readonly byte[] array;
         private readonly int length;
-        private readonly bool pooled;
 
-        private EncodedBuffer(byte[] array, int length, bool pooled)
+        private EncodedBuffer(byte[] array, int length)
         {
             this.array = array;
             this.length = length;
-            this.pooled = pooled;
         }
 
         public ReadOnlySpan<byte> Span => array.AsSpan(0, length);
@@ -194,38 +219,11 @@ public class ImageSharpImageLoader : IImageLoader
 
         public static EncodedBuffer Read(Stream stream)
         {
-            if (stream.CanSeek)
-            {
-                long remaining = stream.Length - stream.Position;
-
-                if (remaining > 0 && remaining <= int.MaxValue)
-                {
-                    byte[] rented = ArrayPool<byte>.Shared.Rent((int)remaining);
-                    int read = 0;
-
-                    while (read < remaining)
-                    {
-                        int count = stream.Read(rented, read, (int)remaining - read);
-                        if (count <= 0)
-                            break;
-
-                        read += count;
-                    }
-
-                    return new EncodedBuffer(rented, read, pooled: true);
-                }
-            }
-
-            // non-seekable or unknown length: grow, then hand over the stream's own buffer (no copy)
+            // the length is not known ahead of time, so grow, then hand over the stream's own buffer
+            // rather than the ToArray() copy of it.
             using var ms = new MemoryStream();
             stream.CopyTo(ms);
-            return new EncodedBuffer(ms.GetBuffer(), (int)ms.Length, pooled: false);
-        }
-
-        public void Dispose()
-        {
-            if (pooled)
-                ArrayPool<byte>.Shared.Return(array);
+            return new EncodedBuffer(ms.GetBuffer(), (int)ms.Length);
         }
     }
 }

--- a/Sakura.Framework/Graphics/Textures/TextureUploads.cs
+++ b/Sakura.Framework/Graphics/Textures/TextureUploads.cs
@@ -2,9 +2,12 @@
 // See the LICENSE file for full license text.
 
 using System;
+using System.Buffers;
 using System.IO;
+using System.Threading;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Logging;
+using Sakura.Framework.Statistic;
 
 namespace Sakura.Framework.Graphics.Textures;
 
@@ -19,6 +22,137 @@ namespace Sakura.Framework.Graphics.Textures;
 /// </remarks>
 internal static class TextureUploads
 {
+    /// <summary>
+    /// Bounds how many image decodes run at once, process-wide.
+    /// </summary>
+    public static int MaxConcurrentDecodes
+    {
+        get => maxConcurrentDecodes;
+        set
+        {
+            int clamped = Math.Max(1, value);
+
+            lock (decode_gate_lock)
+            {
+                if (clamped == maxConcurrentDecodes)
+                    return;
+
+                maxConcurrentDecodes = clamped;
+
+                // SemaphoreSlim can only be released beyond its initial
+                // count, not resized, and a decode in flight still holds a permit on the old instance.
+                decodeGate = new SemaphoreSlim(clamped, clamped);
+            }
+        }
+    }
+
+    private static int maxConcurrentDecodes = 1;
+
+    private static readonly Lock decode_gate_lock = new Lock();
+
+    private static SemaphoreSlim decodeGate = new SemaphoreSlim(1, 1);
+
+    /// <summary>
+    /// How many decoded images may be waiting for their GPU upload before a new decode is made to wait.
+    /// Zero or less disables the limit.
+    /// </summary>
+    public static int MaxOutstandingUploads { get; set; }
+
+    /// <summary>
+    /// How long a decode waits for upload headroom before giving up and proceeding anyway.
+    /// </summary>
+    /// <remarks>
+    /// A memory optimization must never be able to wedge loading. If the draw thread is not draining the
+    /// queue (a minimized window, a renderer being disposed, a queue nobody pumps) waiting forever would
+    /// hang every texture load, so the wait is bounded and simply degrades to the previous behavior.
+    /// Settable so tests do not have to spend it.
+    /// </remarks>
+    internal static TimeSpan UploadHeadroomTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+    private static readonly object upload_headroom_lock = new object();
+
+    private static int outstandingUploads;
+
+    /// <summary>
+    /// Set when a wait for headroom timed out, and cleared by the next upload that completes. While it is
+    /// set the limit is not enforced, so a stalled queue costs one timeout in total rather than one per
+    /// decode.
+    /// </summary>
+    private static bool uploadQueueStalled;
+
+    private static readonly GlobalStatistic<int> stat_outstanding_uploads
+        = GlobalStatistics.Get<int>("Textures", "Uploads Awaiting Draw Thread");
+
+    /// <summary>
+    /// Decoded buffers currently rented and waiting for their upload to run.
+    /// </summary>
+    internal static int OutstandingUploads
+    {
+        get
+        {
+            lock (upload_headroom_lock)
+                return outstandingUploads;
+        }
+    }
+
+    /// <summary>
+    /// Blocks until fewer than <see cref="MaxOutstandingUploads"/> decoded buffers are awaiting upload.
+    /// Called before a decode rents anything, since waiting afterward would hold the very buffer it is
+    /// trying not to duplicate.
+    /// </summary>
+    private static void waitForUploadHeadroom()
+    {
+        int limit = MaxOutstandingUploads;
+
+        if (limit <= 0)
+            return;
+
+        // Only thread-pool callers are made to wait, and this is a correctness rule rather than a
+        // preference. The queue is drained by the draw thread, so anything waiting here depends on that
+        // thread making progress — and a synchronous load *on* the draw thread would then be waiting for
+        // uploads only it can run. The framework's own threads are dedicated (`new Thread`, see AppThread),
+        // so they are never pool threads, while every load that motivates this limit arrives through
+        // LoadComponentAsync on the pool. Erring this way costs some back-pressure on an unusual caller;
+        // erring the other way risks a stall on the one thread that must never stall.
+        if (!Thread.CurrentThread.IsThreadPoolThread)
+            return;
+
+        lock (upload_headroom_lock)
+        {
+            // A queue already known to be stalled is not waited on at all — see uploadQueueStalled.
+            while (!uploadQueueStalled && outstandingUploads >= limit)
+            {
+                if (Monitor.Wait(upload_headroom_lock, UploadHeadroomTimeout))
+                    continue;
+
+                // Nothing drained for a whole timeout, so stop enforcing the limit until something does.
+                // The count is deliberately *not* cleared: every queued upload still releases its slot if
+                // the draw thread comes back, so the count is the truth and clearing it would let far more
+                // rentals through than intended once draining resumes.
+                Logger.Log($"Texture upload queue did not drain within {UploadHeadroomTimeout.TotalMilliseconds:N0} ms "
+                           + $"with {outstandingUploads} upload(s) outstanding; not enforcing the limit until it does.",
+                    level: LogLevel.Debug);
+
+                uploadQueueStalled = true;
+                return;
+            }
+        }
+    }
+
+    private static void releaseUploadSlot()
+    {
+        lock (upload_headroom_lock)
+        {
+            outstandingUploads = Math.Max(0, outstandingUploads - 1);
+            stat_outstanding_uploads.Value = outstandingUploads;
+
+            // Something drained, so whatever the stall was, it is over.
+            uploadQueueStalled = false;
+
+            Monitor.PulseAll(upload_headroom_lock);
+        }
+    }
+
     /// <summary>
     /// Schedules an upload of pixel data the caller still owns, copying it into a pooled buffer that
     /// survives until the upload actually runs.
@@ -47,17 +181,65 @@ internal static class TextureUploads
     {
         long bytes = (long)raw.Width * raw.Height * 4;
 
-        renderer.ScheduleTextureUpload(() =>
+        // Counted from here rather than from the decode, because this is the point the buffer starts waiting
+        // on another thread. Released when the upload has actually run — see MaxOutstandingUploads.
+        lock (upload_headroom_lock)
         {
-            try
+            outstandingUploads++;
+            stat_outstanding_uploads.Value = outstandingUploads;
+        }
+
+        bool scheduled = false;
+
+        try
+        {
+            renderer.ScheduleTextureUpload(() =>
             {
-                nativeTexture.Upload(raw.Data);
-            }
-            finally
-            {
-                raw.Dispose();
-            }
-        }, bytes);
+                try
+                {
+                    nativeTexture.Upload(raw.Data);
+                }
+                finally
+                {
+                    raw.Dispose();
+                    releaseUploadSlot();
+                }
+            }, bytes);
+
+            scheduled = true;
+        }
+        finally
+        {
+            // If scheduling itself threw, the upload will never run and nothing else will release the slot.
+            if (!scheduled)
+                releaseUploadSlot();
+        }
+    }
+
+    /// <summary>
+    /// Runs one decode under <see cref="MaxConcurrentDecodes"/>.
+    /// </summary>
+    private static ImageRawData decode(IImageLoader imageLoader, Stream stream, TextureCreationOptions options)
+    {
+        // Before the gate, and before anything is rented: this waits for buffers already decoded to be
+        // uploaded and returned to the pool, so it must not itself be holding one or a permit to make one.
+        waitForUploadHeadroom();
+
+        SemaphoreSlim gate;
+
+        lock (decode_gate_lock)
+            gate = decodeGate;
+
+        gate.Wait();
+
+        try
+        {
+            return imageLoader.Load(stream, options.Decode);
+        }
+        finally
+        {
+            gate.Release();
+        }
     }
 
     /// <summary>
@@ -98,9 +280,11 @@ internal static class TextureUploads
 
         try
         {
-            // Deliberately outside the shared store's lock: decoding is slow, and holding a global lock
-            // across it would serialise every texture load in the process.
-            raw = imageLoader.Load(stream, options.Decode);
+            // Deliberately outside the shared store's lock: decoding is slow, and holding that lock across
+            // it would serialize every texture load behind an unrelated one. The gate below bounds decode
+            // concurrency without contending on the store — see MaxConcurrentDecodes for why bounding it
+            // at all is the point.
+            raw = decode(imageLoader, stream, options);
 
             if (!raw.IsValid || raw.Width <= 0 || raw.Height <= 0)
             {

--- a/Sakura.Framework/IO/INativeBytes.cs
+++ b/Sakura.Framework/IO/INativeBytes.cs
@@ -1,0 +1,23 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.IO;
+
+/// <summary>
+/// A run of bytes living outside the managed heap, exposed as a pointer that stays valid until this is
+/// disposed. Handed to native libraries that keep the pointer for as long as they hold the data.
+/// </summary>
+public interface INativeBytes : IDisposable
+{
+    /// <summary>
+    /// Pointer to the first byte, valid until <see cref="IDisposable.Dispose"/>.
+    /// </summary>
+    IntPtr Pointer { get; }
+
+    /// <summary>
+    /// Number of valid bytes at <see cref="Pointer"/>.
+    /// </summary>
+    long Length { get; }
+}

--- a/Sakura.Framework/IO/NativeFileMapping.cs
+++ b/Sakura.Framework/IO/NativeFileMapping.cs
@@ -1,0 +1,120 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Threading;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.IO;
+
+/// <summary>
+/// A read-only memory mapping of a file on disk, handed to native libraries as a plain pointer.
+/// </summary>
+public sealed class NativeFileMapping : INativeBytes
+{
+    /// <summary>
+    /// Total length of every live mapping.
+    /// </summary>
+    private static readonly GlobalStatistic<long> stat_mapped_bytes = GlobalStatistics.Get<long>("Fonts", "Mapped Bytes");
+
+    private static long mappedBytes;
+
+    /// <summary>
+    /// Total length of every mapping currently alive.
+    /// </summary>
+    public static long MappedBytes => Interlocked.Read(ref mappedBytes);
+
+    /// <summary>
+    /// Both held for this object's whole lifetime, and that is what keeps <see cref="Pointer"/> valid.
+    /// </summary>
+    private MemoryMappedFile? file;
+
+    private MemoryMappedViewAccessor? view;
+
+    private int disposed;
+
+    public IntPtr Pointer { get; private set; }
+
+    public long Length { get; private set; }
+
+    /// <summary>
+    /// The path this mapping was created from, for diagnostics.
+    /// </summary>
+    public string Path { get; }
+
+    private NativeFileMapping(string path, MemoryMappedFile file, MemoryMappedViewAccessor view, long length)
+    {
+        Path = path;
+        this.file = file;
+        this.view = view;
+        Length = length;
+
+        // A view can start before the requested offset to land on a page boundary; PointerOffset is the
+        // distance from the handle's base to the byte actually asked for. Zero for a view of a whole file,
+        // but reading it makes that an observation rather than an assumption.
+        Pointer = view.SafeMemoryMappedViewHandle.DangerousGetHandle() + (nint)view.PointerOffset;
+
+        stat_mapped_bytes.Value = Interlocked.Add(ref mappedBytes, length);
+    }
+
+    /// <summary>
+    /// Maps a file read-only in full.
+    /// </summary>
+    /// <param name="path">An absolute path to an existing file.</param>
+    /// <returns>
+    /// The mapping, or <c>null</c> if the file is missing, empty, or cannot be mapped — a caller that gets
+    /// null should fall back to reading the bytes, since mapping is an optimization and not the contract.
+    /// </returns>
+    public static NativeFileMapping? CreateFrom(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        MemoryMappedFile? file = null;
+
+        try
+        {
+            var info = new FileInfo(path);
+
+            if (!info.Exists || info.Length == 0)
+                return null;
+
+            // mapName must stay null: named mappings are Windows-only and throw on Unix.
+            file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+
+            var view = file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+            return new NativeFileMapping(path, file, view, info.Length);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            // Mapping can fail where a plain read would succeed (a filesystem that does not support it, a
+            // file held exclusively elsewhere), so this is a fallback signal rather than an error.
+            file?.Dispose();
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Releases the mapping. The pointer must not be read past this point, so every native object built on
+    /// it has to be destroyed first. Repeated calls are a no-op.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+            return;
+
+        Pointer = IntPtr.Zero;
+
+        view?.Dispose();
+        view = null;
+
+        file?.Dispose();
+        file = null;
+
+        stat_mapped_bytes.Value = Interlocked.Add(ref mappedBytes, -Length);
+
+        Length = 0;
+    }
+}

--- a/Sakura.Framework/IO/NativeMemoryBuffer.cs
+++ b/Sakura.Framework/IO/NativeMemoryBuffer.cs
@@ -15,7 +15,7 @@ namespace Sakura.Framework.IO;
 /// require a pointer which stays valid for as long as they hold it (BASS memory streams,
 /// FreeType faces, HarfBuzz blobs).
 /// </summary>
-public sealed class NativeMemoryBuffer : IDisposable
+public sealed class NativeMemoryBuffer : INativeBytes
 {
     /// <summary>
     /// Size of the transfer buffer used to copy a stream into unmanaged memory. Rented from

--- a/Sakura.Framework/Sakura.Framework.csproj
+++ b/Sakura.Framework/Sakura.Framework.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="ManagedBass.Fx" Version="4.0.2" />
     <PackageReference Include="ManagedBass.Mix" Version="4.0.2" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="Sakura.Framework.NativeLibraries" Version="2026.803.0" />
+    <PackageReference Include="Sakura.Framework.NativeLibraries" Version="2026.804.0" />
     <PackageReference Include="Sakura.Framework.SourceGenerators" Version="2026.708.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Sakura.Framework/Sakura.Framework.csproj
+++ b/Sakura.Framework/Sakura.Framework.csproj
@@ -13,7 +13,7 @@
     <Authors>HelloYeew</Authors>
     <Copyright>Copyright (c) 2026 HelloYeew</Copyright>
     <PackageReleaseNotes>Automated build</PackageReleaseNotes>
-    <PackageTags>sakura framework ui game cross-platform opengl sdl</PackageTags>
+    <PackageTags>sakura framework ui game cross-platform opengl metal direct3d sdl</PackageTags>
     <RepositoryUrl>https://github.com/HelloYeew/sakura</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Sakura.Framework/Statistic/GlobalStatistics.cs
+++ b/Sakura.Framework/Statistic/GlobalStatistics.cs
@@ -1,6 +1,7 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -10,6 +11,15 @@ public static class GlobalStatistics
 {
     private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, IGlobalStatistic>> statistics = new ConcurrentDictionary<string, ConcurrentDictionary<string, IGlobalStatistic>>();
 
+    /// <summary>
+    /// Every statistic, ordered by group and then by name, cached until the set of statistics changes.
+    /// </summary>
+    private static IGlobalStatistic[] ordered = Array.Empty<IGlobalStatistic>();
+
+    private static volatile bool orderedStale = true;
+
+    private static readonly object ordered_lock = new object();
+
     public static GlobalStatistic<T> Get<T>(string group, string name)
     {
         if (statistics.TryGetValue(group, out var existingGroupStats) && existingGroupStats.TryGetValue(name, out var existingStat))
@@ -17,6 +27,10 @@ public static class GlobalStatistics
 
         var groupStats = statistics.GetOrAdd(group, static _ => new ConcurrentDictionary<string, IGlobalStatistic>());
         var stat = groupStats.GetOrAdd(name, static (n, g) => new GlobalStatistic<T>(g, n), group);
+
+        // Only reached when the fast path missed, so this runs once per statistic rather than per lookup.
+        // Over-invalidating on a race just rebuilds once more, which is harmless.
+        orderedStale = true;
 
         return (GlobalStatistic<T>)stat;
     }
@@ -27,14 +41,41 @@ public static class GlobalStatistics
             stat.Clear();
     }
 
-    public static IEnumerable<IGlobalStatistic> GetStatistics()
+    /// <summary>
+    /// Every registered statistic, ordered by group and then by name.
+    /// </summary>
+    public static ReadOnlySpan<IGlobalStatistic> GetStatistics()
     {
-        foreach (var group in statistics.Values)
+        if (orderedStale)
+            rebuildOrdered();
+
+        return ordered;
+    }
+
+    private static void rebuildOrdered()
+    {
+        lock (ordered_lock)
         {
-            foreach (var stat in group.Values)
+            if (!orderedStale)
+                return;
+
+            var all = new List<IGlobalStatistic>();
+
+            foreach (var group in statistics)
             {
-                yield return stat;
+                foreach (var stat in group.Value.Values)
+                    all.Add(stat);
             }
+
+            all.Sort(static (a, b) =>
+            {
+                int byGroup = string.CompareOrdinal(a.Group, b.Group);
+                return byGroup != 0 ? byGroup : string.CompareOrdinal(a.Name, b.Name);
+            });
+
+            ordered = all.ToArray();
+
+            orderedStale = false;
         }
     }
 
@@ -55,6 +96,8 @@ public static class GlobalStatistics
             {
                 statistics.TryRemove(group, out _);
             }
+
+            orderedStale = true;
         }
     }
 }

--- a/Sakura.Framework/Statistic/NativeMemoryCategory.cs
+++ b/Sakura.Framework/Statistic/NativeMemoryCategory.cs
@@ -35,6 +35,11 @@ public enum NativeMemoryCategory
     Audio,
 
     /// <summary>
+    /// Font files held outside the managed heap for as long as FreeType and HarfBuzz read them.
+    /// </summary>
+    Fonts,
+
+    /// <summary>
     /// Unmanaged memory that does not fall into a category above.
     /// </summary>
     Other,


### PR DESCRIPTION
The goal of this PR mainly decrease more GC run and more allocation fix to make the unmanaged data more manageable. If your sakura program use a lot of raw data management (e.g. load image from file, use custom font etc.) you should see noticable improvement in performance on both GC count and memory usage) See each commit for details.
- Move font data out of managed heap to decrease GC
- Add native mapping to font to decrease allocation when font is really large (e.g. color emoji take like ~100 MB)
- More allocation improvement in draw node (mainly decrease gen0 memory usage)
- Optimize vertices array to grow-only with fix size
- Make `ImageSharpImageLoader` seekable decode path
- Add array pool to `ImageRawData` struct
- Add global texture max decode bound in texture upload to decrease parallel allocation