### PR TITLE
Add truncate support for `SpriteText`

### DIFF
--- a/Sakura.Framework.Tests/Graphics/SpriteTextTruncationTest.cs
+++ b/Sakura.Framework.Tests/Graphics/SpriteTextTruncationTest.cs
@@ -1,0 +1,214 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Allocation;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Text;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Platform;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// Truncation through <see cref="SpriteText"/> itself: that the properties feed the layout, that changing
+/// one re-measures, and that the drawable ends up no wider than its budget.
+/// </summary>
+[TestFixture]
+public class SpriteTextTruncationTest
+{
+    private readonly string longText = "The quick brown fox jumps over the lazy dog";
+
+    private HeadlessTextureManager textureManager = null!;
+    private RendererFontStore store = null!;
+    private DependencyContainer dependencies = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        textureManager = new HeadlessTextureManager();
+        store = new RendererFontStore(new HeadlessRenderer(textureManager));
+
+        var fonts = new EmbeddedResourceStorage(typeof(TestApp).Assembly, "Sakura.Framework.Tests.Resources")
+            .GetStorageForDirectory("Fonts");
+
+        store.AddFont(fonts, "Comfortaa-Regular.ttf", alias: "Sprite");
+
+        dependencies = new DependencyContainer();
+        dependencies.CacheAs<IFontStore>(store);
+        dependencies.CacheAs<IWindow>(new HeadlessWindow());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        store.Dispose();
+        textureManager.Dispose();
+    }
+
+    private static FontUsage usage => FontUsage.Default.With(family: "Sprite", size: 16f);
+
+    private SpriteText sprite(string text = "The quick brown fox jumps over the lazy dog")
+    {
+        var textSprite = new SpriteText
+        {
+            Text = text,
+            Font = usage
+        };
+
+        DependencyActivator.Inject(textSprite, dependencies);
+        return textSprite;
+    }
+
+    private float fullWidth => store.Shape(usage, longText, 1f).BoundingBox.X;
+
+    [Test]
+    public void TruncationIsOffByDefault()
+    {
+        var text = sprite();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text.Truncate, Is.False);
+            Assert.That(text.MaxWidth, Is.EqualTo(float.PositiveInfinity));
+            Assert.That(text.IsTruncated, Is.False);
+            Assert.That(text.DisplayedText, Is.EqualTo(longText));
+        });
+    }
+
+    [Test]
+    public void AMaxWidthWithoutTruncateChangesNothing()
+    {
+        var text = sprite();
+        text.MaxWidth = 50;
+
+        Assert.That(text.IsTruncated, Is.False);
+        Assert.That(text.ContentSize.X, Is.EqualTo(fullWidth).Within(0.01f), "the sprite still measures its full text");
+    }
+
+    [Test]
+    public void TruncatingKeepsTheSpriteWithinItsBudget()
+    {
+        float budget = fullWidth / 2f;
+
+        var text = sprite();
+        text.Truncate = true;
+        text.MaxWidth = budget;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text.IsTruncated, Is.True);
+            Assert.That(text.ContentSize.X, Is.LessThanOrEqualTo(budget));
+            Assert.That(text.Width, Is.LessThanOrEqualTo(budget), "Size follows the truncated content");
+            Assert.That(text.DisplayedText, Does.EndWith(TextTruncation.DEFAULT_ELLIPSIS));
+            Assert.That(text.Text, Is.EqualTo(longText), "the source text is left as the caller set it");
+        });
+    }
+
+    [Test]
+    public void TextThatFitsIsNotTruncated()
+    {
+        var text = sprite("Hi");
+        text.Truncate = true;
+        text.MaxWidth = fullWidth;
+
+        Assert.That(text.IsTruncated, Is.False);
+        Assert.That(text.DisplayedText, Is.EqualTo("Hi"));
+    }
+
+    /// <summary>
+    /// Each of these setters has to invalidate the layout, or the sprite keeps showing a stale measurement.
+    /// </summary>
+    [Test]
+    public void WideningTheBudgetReMeasures()
+    {
+        var text = sprite();
+        text.Truncate = true;
+        text.MaxWidth = fullWidth * 0.3f;
+
+        string narrow = text.DisplayedText;
+        float narrowWidth = text.ContentSize.X;
+
+        text.MaxWidth = fullWidth * 0.7f;
+
+        Assert.That(text.DisplayedText.Length, Is.GreaterThan(narrow.Length));
+        Assert.That(text.ContentSize.X, Is.GreaterThan(narrowWidth));
+        Assert.That(text.ContentSize.X, Is.LessThanOrEqualTo(fullWidth * 0.7f));
+    }
+
+    [Test]
+    public void ChangingTheEllipsisReMeasures()
+    {
+        var text = sprite();
+        text.Truncate = true;
+        text.MaxWidth = fullWidth / 2f;
+
+        string withDefault = text.DisplayedText;
+
+        text.Ellipsis = "...";
+
+        Assert.That(text.DisplayedText, Does.EndWith("..."));
+        Assert.That(text.DisplayedText, Is.Not.EqualTo(withDefault));
+        Assert.That(text.ContentSize.X, Is.LessThanOrEqualTo(fullWidth / 2f));
+    }
+
+    [Test]
+    public void DisablingTruncationRestoresTheFullText()
+    {
+        var text = sprite();
+        text.Truncate = true;
+        text.MaxWidth = fullWidth / 2f;
+
+        Assert.That(text.IsTruncated, Is.True);
+
+        text.Truncate = false;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text.IsTruncated, Is.False);
+            Assert.That(text.DisplayedText, Is.EqualTo(longText));
+            Assert.That(text.ContentSize.X, Is.EqualTo(fullWidth).Within(0.01f));
+        });
+    }
+
+    [Test]
+    public void ANewTextIsTruncatedToo()
+    {
+        var text = sprite("Hi");
+        text.Truncate = true;
+        text.MaxWidth = fullWidth / 2f;
+
+        Assert.That(text.IsTruncated, Is.False);
+
+        text.Text = longText;
+
+        Assert.That(text.IsTruncated, Is.True);
+        Assert.That(text.ContentSize.X, Is.LessThanOrEqualTo(fullWidth / 2f));
+    }
+
+    [Test]
+    public void AnEmptyEllipsisCutsWithNoMarker()
+    {
+        var text = sprite();
+        text.Truncate = true;
+        text.MaxWidth = fullWidth / 2f;
+        text.Ellipsis = string.Empty;
+
+        Assert.That(text.DisplayedText, Does.Not.Contain(TextTruncation.DEFAULT_ELLIPSIS));
+        Assert.That(longText, Does.StartWith(text.DisplayedText));
+        Assert.That(text.ContentSize.X, Is.LessThanOrEqualTo(fullWidth / 2f));
+    }
+
+    [Test]
+    public void ABudgetTooSmallForTheEllipsisShowsNothing()
+    {
+        var text = sprite();
+        text.Truncate = true;
+        text.MaxWidth = 1;
+
+        Assert.That(text.IsTruncated, Is.True);
+        Assert.That(text.DisplayedText, Is.Empty);
+        Assert.That(text.ContentSize.X, Is.Zero);
+    }
+}

--- a/Sakura.Framework.Tests/Text/TextTruncationTest.cs
+++ b/Sakura.Framework.Tests/Text/TextTruncationTest.cs
@@ -1,0 +1,363 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Text;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Platform;
+
+namespace Sakura.Framework.Tests.Text;
+
+/// <summary>
+/// Tests truncation against real font metrics. The headless font store measures everything as zero, so
+/// these drive a <see cref="RendererFontStore"/> over a headless renderer with a bundled font — the same
+/// setup the shaping-cache tests use.
+/// </summary>
+[TestFixture]
+public class TextTruncationTest
+{
+    private const string long_text = "The quick brown fox jumps over the lazy dog";
+
+    private HeadlessTextureManager textureManager = null!;
+    private RendererFontStore store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        textureManager = new HeadlessTextureManager();
+        store = new RendererFontStore(new HeadlessRenderer(textureManager));
+
+        var fonts = new EmbeddedResourceStorage(typeof(TestApp).Assembly, "Sakura.Framework.Tests.Resources")
+            .GetStorageForDirectory("Fonts");
+
+        store.AddFont(fonts, "Comfortaa-Regular.ttf", alias: "Truncated");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        store.Dispose();
+        textureManager.Dispose();
+    }
+
+    private static FontUsage usage(float size = 16f) => FontUsage.Default.With(family: "Truncated", size: size);
+
+    private float width(string text) => store.Shape(usage(), text, 1f).BoundingBox.X;
+
+    private TextTruncation.Result apply(string text, float maxWidth, string ellipsis = TextTruncation.DEFAULT_ELLIPSIS)
+        => TextTruncation.Apply(store, usage(), text, 1f, maxWidth, ellipsis);
+
+    [Test]
+    public void TextThatFitsIsUntouched()
+    {
+        float full = width(long_text);
+
+        var result = apply(long_text, full + 10);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Truncated, Is.False);
+            Assert.That(result.Text, Is.EqualTo(long_text));
+            Assert.That(result.Shaped.BoundingBox.X, Is.EqualTo(full).Within(0.01f));
+        });
+    }
+
+    [Test]
+    public void ExactFitIsNotTruncated()
+    {
+        float full = width(long_text);
+
+        var result = apply(long_text, full);
+
+        Assert.That(result.Truncated, Is.False, "a budget equal to the measured width is not an overflow");
+        Assert.That(result.Text, Is.EqualTo(long_text));
+    }
+
+    [Test]
+    public void UnlimitedBudgetIsANoOp()
+    {
+        var result = apply(long_text, float.PositiveInfinity);
+
+        Assert.That(result.Truncated, Is.False);
+        Assert.That(result.Text, Is.EqualTo(long_text));
+    }
+
+    [Test]
+    public void LongTextIsShortenedWithAnEllipsis()
+    {
+        float budget = width(long_text) / 2f;
+
+        var result = apply(long_text, budget);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Truncated, Is.True);
+            Assert.That(result.Text, Does.EndWith(TextTruncation.DEFAULT_ELLIPSIS));
+            Assert.That(result.Text, Is.Not.EqualTo(long_text));
+            Assert.That(result.Shaped.BoundingBox.X, Is.LessThanOrEqualTo(budget));
+        });
+    }
+
+    [Test]
+    public void KeptTextIsAPrefixOfTheSource()
+    {
+        var result = apply(long_text, width(long_text) / 3f);
+
+        string kept = result.Text[..^TextTruncation.DEFAULT_ELLIPSIS.Length];
+
+        Assert.That(long_text, Does.StartWith(kept), $"'{kept}' is not the start of the source text");
+    }
+
+    /// <summary>
+    /// The point of fitting: what is kept must be the longest that fits, not merely something that does.
+    /// Swept across many budgets on purpose — at any single budget a result one character short can
+    /// coincide with the correct one, because a cut landing on whitespace trims back to the same string.
+    /// </summary>
+    [Test]
+    public void ResultIsAlwaysTheLongestThatFits()
+    {
+        float full = width(long_text);
+
+        for (int i = 1; i < 60; i++)
+        {
+            float budget = full * i / 60f;
+            var result = apply(long_text, budget);
+
+            if (!result.Truncated)
+                continue;
+
+            // The next cut that composes a genuinely longer string than the one we got.
+            string longer = null;
+
+            for (int cut = result.Text.Length; cut <= long_text.Length; cut++)
+            {
+                string candidate = string.Concat(long_text.AsSpan(0, cut).TrimEnd(), TextTruncation.DEFAULT_ELLIPSIS);
+
+                if (candidate.Length > result.Text.Length)
+                {
+                    longer = candidate;
+                    break;
+                }
+            }
+
+            if (longer == null)
+                continue;
+
+            Assert.That(width(longer), Is.GreaterThan(budget),
+                $"budget {budget:F2} returned '{result.Text}' but '{longer}' would also have fit");
+        }
+    }
+
+    [Test]
+    public void AWiderBudgetKeepsMoreText()
+    {
+        float full = width(long_text);
+
+        string narrow = apply(long_text, full * 0.3f).Text;
+        string wide = apply(long_text, full * 0.6f).Text;
+
+        Assert.That(wide.Length, Is.GreaterThan(narrow.Length));
+        Assert.That(long_text, Does.StartWith(wide[..^TextTruncation.DEFAULT_ELLIPSIS.Length]));
+    }
+
+    [Test]
+    public void TrailingWhitespaceIsTrimmedBeforeTheEllipsis()
+    {
+        // A budget that lands the cut inside the run of spaces.
+        const string spaced = "Hello     world";
+        float budget = width("Hello  " + TextTruncation.DEFAULT_ELLIPSIS);
+
+        var result = apply(spaced, budget);
+
+        Assert.That(result.Truncated, Is.True);
+        Assert.That(result.Text, Does.Not.Match(@"\s" + TextTruncation.DEFAULT_ELLIPSIS + "$"), "whitespace was left in front of the ellipsis");
+    }
+
+    [Test]
+    public void ABudgetThatOnlyFitsTheEllipsisKeepsNoText()
+    {
+        float budget = width(TextTruncation.DEFAULT_ELLIPSIS);
+
+        var result = apply(long_text, budget);
+
+        Assert.That(result.Truncated, Is.True);
+        Assert.That(result.Text, Is.EqualTo(TextTruncation.DEFAULT_ELLIPSIS));
+        Assert.That(result.Shaped.BoundingBox.X, Is.LessThanOrEqualTo(budget));
+    }
+
+    [Test]
+    public void NothingIsDrawnWhenEvenTheEllipsisDoesNotFit()
+    {
+        float budget = width(TextTruncation.DEFAULT_ELLIPSIS) / 2f;
+
+        var result = apply(long_text, budget);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Truncated, Is.True);
+            Assert.That(result.Text, Is.Empty);
+            Assert.That(result.Shaped.Glyphs, Is.Empty);
+        });
+    }
+
+    [TestCase(0f)]
+    [TestCase(-5f)]
+    public void ANonPositiveBudgetKeepsNothing(float budget)
+    {
+        var result = apply(long_text, budget);
+
+        Assert.That(result.Truncated, Is.True);
+        Assert.That(result.Text, Is.Empty);
+    }
+
+    [Test]
+    public void EmptyTextIsNeverTruncated()
+    {
+        var result = apply(string.Empty, 5f);
+
+        Assert.That(result.Truncated, Is.False);
+        Assert.That(result.Text, Is.Empty);
+    }
+
+    [Test]
+    public void ACustomEllipsisIsUsed()
+    {
+        var result = apply(long_text, width(long_text) / 2f, "...");
+
+        Assert.That(result.Text, Does.EndWith("..."));
+        Assert.That(result.Text, Does.Not.Contain(TextTruncation.DEFAULT_ELLIPSIS));
+    }
+
+    [Test]
+    public void AnEmptyEllipsisCutsWithNoMarker()
+    {
+        float budget = width(long_text) / 2f;
+
+        var result = apply(long_text, budget, string.Empty);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Truncated, Is.True);
+            Assert.That(long_text, Does.StartWith(result.Text));
+            Assert.That(result.Text, Is.Not.Empty);
+            Assert.That(result.Shaped.BoundingBox.X, Is.LessThanOrEqualTo(budget));
+        });
+    }
+
+    /// <summary>
+    /// A result may never contain half of a surrogate pair, whatever the budget. Measured against the
+    /// real color-emoji font so the emoji carry their true (wide) advances.
+    /// </summary>
+    /// <remarks>
+    /// This pins the invariant, not the mechanism: an implementation cutting on raw UTF-16 indices
+    /// passes this too, because a lone surrogate measures the same as the whole pair here, so the fit
+    /// search still settles past the pair. See the note on <see cref="TextTruncation"/> for why cuts are
+    /// taken from cluster boundaries regardless.
+    /// </remarks>
+    [Test]
+    public void SurrogatePairsAreNotSplit()
+    {
+        const string emoji = "a👍b👍c👍d👍e👍f👍g👍h";
+
+        var frameworkFonts = new EmbeddedResourceStorage(typeof(App).Assembly, "Sakura.Framework.Resources")
+            .GetStorageForDirectory("Fonts");
+        store.AddFont(frameworkFonts, "NotoColorEmoji-Regular.ttf", alias: "TruncatedEmoji");
+
+        var emojiUsage = FontUsage.Default.With(family: "TruncatedEmoji", size: 24f);
+        float full = store.Shape(emojiUsage, emoji, 1f).BoundingBox.X;
+
+        Assume.That(full, Is.GreaterThan(0), "the emoji font measured nothing");
+
+        for (int step = 1; step < 40; step++)
+        {
+            var result = TextTruncation.Apply(store, emojiUsage, emoji, 1f, full * step / 40f);
+            string text = result.Text;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (char.IsHighSurrogate(text[i]))
+                {
+                    Assert.That(i + 1, Is.LessThan(text.Length), $"high surrogate left dangling at {i} in '{text}'");
+                    Assert.That(char.IsLowSurrogate(text[i + 1]), Is.True, $"broken pair at {i} in '{text}'");
+                    i++;
+                }
+                else
+                {
+                    Assert.That(char.IsLowSurrogate(text[i]), Is.False, $"orphan low surrogate at {i} in '{text}'");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every result must respect the budget, whatever the budget is.
+    /// </summary>
+    [Test]
+    public void NoBudgetIsEverExceeded()
+    {
+        float full = width(long_text);
+
+        for (int i = 0; i <= 40; i++)
+        {
+            float budget = full * i / 20f;
+            var result = apply(long_text, budget);
+
+            Assert.That(result.Shaped.BoundingBox.X, Is.LessThanOrEqualTo(budget).Within(0.01f),
+                $"budget {budget:F2} overflowed by '{result.Text}'");
+        }
+    }
+
+    [Test]
+    public void ShapedResultMatchesTheReturnedText()
+    {
+        var result = apply(long_text, width(long_text) / 2f);
+
+        Assert.That(result.Shaped, Is.SameAs(store.Shape(usage(), result.Text, 1f)),
+            "the returned shaping is the one for the returned text");
+    }
+
+    /// <summary>
+    /// A store that cannot measure (the headless one) must not cause text to disappear.
+    /// </summary>
+    [Test]
+    public void AStoreThatMeasuresNothingLeavesTextAlone()
+    {
+        using var headlessTextures = new HeadlessTextureManager();
+        var headless = new HeadlessFontStore(headlessTextures);
+
+        var result = TextTruncation.Apply(headless, usage(), long_text, 1f, 10f);
+
+        Assert.That(result.Truncated, Is.False);
+        Assert.That(result.Text, Is.EqualTo(long_text));
+    }
+
+    [Test]
+    public void FittingCostsALogarithmicNumberOfShapings()
+    {
+        // Warm the cache for the full text so only fitting is measured.
+        store.Shape(usage(), long_text, 1f);
+
+        long before = Sakura.Framework.Statistic.GlobalStatistics.Get<long>("Fonts", "Text Shapes").Value;
+
+        apply(long_text, width(long_text) / 2f);
+
+        long shapings = Sakura.Framework.Statistic.GlobalStatistics.Get<long>("Fonts", "Text Shapes").Value - before;
+
+        // 43 characters: walking back one cluster at a time would cost ~20 shapings, a binary search
+        // over the cut points at most ceil(log2(44)) = 6.
+        Assert.That(shapings, Is.LessThanOrEqualTo(6), $"fitting took {shapings} shapings");
+    }
+
+    [Test]
+    public void RepeatedApplicationIsStable()
+    {
+        float budget = width(long_text) / 2f;
+
+        string first = apply(long_text, budget).Text;
+        string second = apply(long_text, budget).Text;
+
+        Assert.That(second, Is.EqualTo(first));
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Text/TestSpriteText.cs
+++ b/Sakura.Framework.Tests/Visuals/Text/TestSpriteText.cs
@@ -113,6 +113,17 @@ public partial class TestSpriteText : TestScene
                         Origin = Anchor.TopLeft,
                         Text = "English, สวัสดี, こんにちは, مرحبا, 😡!",
                         Font = new FontUsage("NotoSans", size: 24, weight: "Bold", italics: false)
+                    },
+
+                    // Truncated to a width budget (see TestSpriteTextTruncation for the full coverage)
+                    new SpriteText
+                    {
+                        Anchor = Anchor.TopLeft,
+                        Origin = Anchor.TopLeft,
+                        Text = "This line is far too long to fit and is truncated with an ellipsis",
+                        Font = new FontUsage("NotoSans", size: 24, weight: "Regular", italics: false),
+                        Truncate = true,
+                        MaxWidth = 320
                     }
                 }
             }

--- a/Sakura.Framework.Tests/Visuals/Text/TestSpriteTextTruncation.cs
+++ b/Sakura.Framework.Tests/Visuals/Text/TestSpriteTextTruncation.cs
@@ -1,0 +1,162 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Extensions.ObjectExtensions;
+using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Text;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Testing;
+
+namespace Sakura.Framework.Tests.Visuals.Text;
+
+/// <summary>
+/// Truncation as seen through <see cref="SpriteText"/>
+/// </summary>
+public partial class TestSpriteTextTruncation : TestScene
+{
+    private const string long_text = "The quick brown fox jumps over the lazy dog";
+
+    private const float budget = 220;
+
+    private SpriteText truncating = null!;
+    private Box guide = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        AddStep("Add truncating sprite", () =>
+        {
+            Clear();
+
+            Add(new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    // Marks the budget so overflow is obvious by eye.
+                    guide = new Box
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Size = new Vector2(budget, 40),
+                        Color = Color.DarkSlateBlue
+                    },
+                    truncating = new SpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = long_text,
+                        Font = FontUsage.Default.With(size: 24),
+                        Truncate = true,
+                        MaxWidth = budget
+                    }
+                }
+            });
+        });
+
+        AddSliderStep("Max width", 20f, 600f, budget, value =>
+        {
+            if (truncating.IsNull())
+                return;
+
+            truncating.MaxWidth = value;
+            guide.Width = value;
+        });
+    }
+
+    [Test]
+    public void TestLongTextIsTruncatedToMaxWidth()
+    {
+        AddAssert("stays within the budget", () =>
+        {
+            if (truncating.ContentSize.X == 0)
+                return true;
+
+            return truncating.ContentSize.X <= budget;
+        });
+
+        AddAssert("reports truncation and shows an ellipsis", () =>
+        {
+            if (truncating.ContentSize.X == 0)
+                return true;
+
+            return truncating.IsTruncated
+                   && truncating.DisplayedText.EndsWith(TextTruncation.DEFAULT_ELLIPSIS)
+                   && truncating.Text == long_text;
+        });
+    }
+
+    [Test]
+    public void TestShortTextIsLeftAlone()
+    {
+        AddStep("Set short text", () => truncating.Text = "Short");
+
+        AddAssert("not truncated", () => !truncating.IsTruncated && truncating.DisplayedText == "Short");
+    }
+
+    [Test]
+    public void TestDisablingTruncationRestoresTheFullText()
+    {
+        AddStep("Disable truncation", () => truncating.Truncate = false);
+
+        AddAssert("full text is displayed", () => !truncating.IsTruncated && truncating.DisplayedText == long_text);
+
+        AddStep("Re-enable truncation", () => truncating.Truncate = true);
+
+        AddAssert("back within the budget", () => truncating.ContentSize.X == 0 || truncating.ContentSize.X <= budget);
+    }
+
+    [Test]
+    public void TestWideningTheBudgetKeepsMoreText()
+    {
+        string narrow = null!;
+
+        AddStep("Narrow budget", () =>
+        {
+            truncating.MaxWidth = 120;
+            guide.Width = 120;
+            narrow = truncating.DisplayedText;
+        });
+
+        AddStep("Wider budget", () =>
+        {
+            truncating.MaxWidth = 320;
+            guide.Width = 320;
+        });
+
+        AddAssert("more text survives", () =>
+        {
+            if (truncating.ContentSize.X == 0)
+                return true;
+
+            return truncating.DisplayedText.Length > narrow.Length && truncating.ContentSize.X <= 320;
+        });
+    }
+
+    [Test]
+    public void TestCustomEllipsis()
+    {
+        AddStep("Use three dots", () => truncating.Ellipsis = "...");
+
+        AddAssert("three dots are used", () =>
+        {
+            if (truncating.ContentSize.X == 0)
+                return true;
+
+            return truncating.DisplayedText.EndsWith("...") && truncating.ContentSize.X <= budget;
+        });
+    }
+
+    [Test]
+    public void TestUnlimitedMaxWidthDoesNothing()
+    {
+        AddStep("Clear the budget", () => truncating.MaxWidth = float.PositiveInfinity);
+
+        AddAssert("full text is displayed", () => !truncating.IsTruncated && truncating.DisplayedText == long_text);
+    }
+}

--- a/Sakura.Framework/Graphics/Drawables/SpriteText.cs
+++ b/Sakura.Framework/Graphics/Drawables/SpriteText.cs
@@ -65,6 +65,97 @@ public partial class SpriteText : Drawable
         }
     }
 
+    private bool truncate;
+    private float maxWidth = float.PositiveInfinity;
+    private string ellipsis = TextTruncation.DEFAULT_ELLIPSIS;
+    private string displayedText = string.Empty;
+
+    /// <summary>
+    /// Whether text wider than <see cref="MaxWidth"/> is shortened to fit, with <see cref="Ellipsis"/>
+    /// standing in for what was dropped. Has no effect while <see cref="MaxWidth"/> is unlimited.
+    /// </summary>
+    /// <remarks>
+    /// This sprite still sizes itself to its content, truncating is what keeps that content inside the
+    /// budget. It does not wrap, the text stays on one line.
+    /// </remarks>
+    public bool Truncate
+    {
+        get => truncate;
+        set
+        {
+            if (truncate == value)
+                return;
+
+            truncate = value;
+            layoutInvalidated = true;
+            Invalidate(InvalidationFlags.DrawInfo);
+        }
+    }
+
+    /// <summary>
+    /// The width budget in local pixels used when <see cref="Truncate"/> is set. Unlimited by default.
+    /// </summary>
+    public float MaxWidth
+    {
+        get => maxWidth;
+        set
+        {
+            if (maxWidth.Equals(value))
+                return;
+
+            maxWidth = value;
+            layoutInvalidated = true;
+            Invalidate(InvalidationFlags.DrawInfo);
+        }
+    }
+
+    /// <summary>
+    /// Appended to shortened text. Defaults to a single "…". Set it to an empty string to cut with no
+    /// marker at all.
+    /// </summary>
+    public string Ellipsis
+    {
+        get => ellipsis;
+        set
+        {
+            value ??= string.Empty;
+
+            if (ellipsis == value)
+                return;
+
+            ellipsis = value;
+            layoutInvalidated = true;
+            Invalidate(InvalidationFlags.DrawInfo);
+        }
+    }
+
+    /// <summary>
+    /// The text actually shaped and drawn: <see cref="Text"/> unless it was shortened, in which case a
+    /// prefix of it plus <see cref="Ellipsis"/>.
+    /// </summary>
+    public string DisplayedText
+    {
+        get
+        {
+            ensureLayout();
+            return displayedText;
+        }
+    }
+
+    /// <summary>
+    /// Whether <see cref="Text"/> did not fit <see cref="MaxWidth"/> and was shortened.
+    /// </summary>
+    public bool IsTruncated
+    {
+        get
+        {
+            ensureLayout();
+            return isTruncated;
+        }
+    }
+
+    private bool isTruncated;
+
     /// <summary>
     /// The measured size of this sprite. Reading any size component forces a layout pass so the
     /// returned value reflects the current <see cref="Text"/> immediately (callers commonly read
@@ -163,7 +254,22 @@ public partial class SpriteText : Drawable
             // caches the result, and only it knows when one has been invalidated by a font being
             // registered, a fallback family changing, or the glyph atlas being cleared. The result is
             // shared with every other drawable showing the same text at the same size, so it is read-only.
-            shapedText = fontStore.Shape(fontUsage, Text, dpiScale);
+            if (truncate)
+            {
+                // Measures the full text first and only re-shapes when it overflows, so a sprite that
+                // fits pays exactly what it did before.
+                var truncation = TextTruncation.Apply(fontStore, fontUsage, Text, dpiScale, maxWidth, ellipsis);
+                shapedText = truncation.Shaped;
+                displayedText = truncation.Text;
+                isTruncated = truncation.Truncated;
+            }
+            else
+            {
+                shapedText = fontStore.Shape(fontUsage, Text, dpiScale);
+                displayedText = Text;
+                isTruncated = false;
+            }
+
             // Assign the backing field directly; the ContentSize getter forces layout, which we're
             // already inside of (guarded by computingLayout).
             contentSize = new Vector2(shapedText.BoundingBox.X, shapedText.BoundingBox.Y);
@@ -349,6 +455,10 @@ public partial class SpriteText : Drawable
     /// Gets the local position of a character at the specified index.
     /// Useful for positioning a caret or IME composition text.
     /// </summary>
+    /// <remarks>
+    /// The index runs over <see cref="DisplayedText"/>, which differs from <see cref="Text"/> while
+    /// <see cref="IsTruncated"/> — a caret should not be driven from a truncating sprite.
+    /// </remarks>
     public Vector2 GetCharacterPosition(int index)
     {
         // Parents (e.g. a text box positioning its caret) update before this drawable does,

--- a/Sakura.Framework/Graphics/Text/TextTruncation.cs
+++ b/Sakura.Framework/Graphics/Text/TextTruncation.cs
@@ -1,0 +1,136 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+
+namespace Sakura.Framework.Graphics.Text;
+
+/// <summary>
+/// Shortens text that does not fit a width budget, appending an ellipsis to what is left.
+/// </summary>
+public static class TextTruncation
+{
+    /// <summary>
+    /// The ellipsis used when a caller does not specify one: U+2026 HORIZONTAL ELLIPSIS.
+    /// </summary>
+    public const string DEFAULT_ELLIPSIS = "…";
+
+    /// <summary>
+    /// The outcome of a truncation pass.
+    /// </summary>
+    public readonly struct Result
+    {
+        /// <summary>
+        /// The shaping of <see cref="Text"/> ready to hand to a drawable, no re-shaping needed.
+        /// </summary>
+        public ShapedText Shaped { get; init; }
+
+        /// <summary>
+        /// The text that <see cref="Shaped"/> covers: the source text when it fit, otherwise a prefix
+        /// of it plus the ellipsis.
+        /// </summary>
+        public string Text { get; init; }
+
+        /// <summary>
+        /// Whether the source text had to be shortened.
+        /// </summary>
+        public bool Truncated { get; init; }
+    }
+
+    /// <summary>
+    /// Measures <paramref name="text"/> and, if it is wider than <paramref name="maxWidth"/>, returns
+    /// the longest prefix that fits once <paramref name="ellipsis"/> is appended. Trailing whitespace
+    /// on the prefix is dropped so the ellipsis sits against the last visible character.
+    /// </summary>
+    /// <param name="store">The store used to shape and therefore measure candidates.</param>
+    /// <param name="usage">The font to measure with.</param>
+    /// <param name="text">The text to fit.</param>
+    /// <param name="dpiScale">Physical-to-logical pixel ratio, as passed to <see cref="IFontStore.Shape"/>.</param>
+    /// <param name="maxWidth">
+    /// The budget in logical pixels — the same space <see cref="ShapedText.BoundingBox"/> is measured
+    /// in. Positive infinity (or NaN) means unlimited, and the text is returned untouched.
+    /// </param>
+    /// <param name="ellipsis">
+    /// Appended to a shortened result. Pass an empty string for a hard cut with no marker.
+    /// </param>
+    public static Result Apply(IFontStore store, FontUsage usage, string text, float dpiScale, float maxWidth, string ellipsis = DEFAULT_ELLIPSIS)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+
+        text ??= string.Empty;
+        ellipsis ??= string.Empty;
+
+        var full = store.Shape(usage, text, dpiScale);
+
+        // Unlimited budget, already fits, or a store that does not measure (the headless one reports
+        // zero for everything) — in every case the text is used as-is.
+        if (float.IsNaN(maxWidth) || float.IsPositiveInfinity(maxWidth) || full.BoundingBox.X <= maxWidth)
+            return new Result { Shaped = full, Text = text, Truncated = false };
+
+        if (maxWidth <= 0)
+            return new Result { Shaped = ShapedText.Empty, Text = string.Empty, Truncated = true };
+
+        var cuts = clusterBoundaries(full, text);
+
+        // Largest cut whose text still fits with the ellipsis attached. cuts[0] is 0, i.e. the
+        // ellipsis on its own, so a budget that only fits the ellipsis is covered by the same search.
+        int lo = 0;
+        int hi = cuts.Count - 1;
+        Result best = default;
+        bool found = false;
+
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) / 2;
+            string candidate = compose(text, cuts[mid], ellipsis);
+            var shaped = store.Shape(usage, candidate, dpiScale);
+
+            if (shaped.BoundingBox.X <= maxWidth)
+            {
+                best = new Result { Shaped = shaped, Text = candidate, Truncated = true };
+                found = true;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        // Not even the ellipsis alone fits, so nothing is drawn rather than something that overflows.
+        if (!found)
+            return new Result { Shaped = ShapedText.Empty, Text = string.Empty, Truncated = true };
+
+        return best;
+    }
+
+    /// <summary>
+    /// The lengths <paramref name="text"/> may be cut at, ascending: zero, the start of every shaped
+    /// cluster, and the whole string. Taken from the shaper rather than from UTF-16 indices so a
+    /// cluster spanning several code units stays whole. Positions repeat and run right-to-left for
+    /// some scripts, hence the de-duplicating sort.
+    /// </summary>
+    private static List<int> clusterBoundaries(ShapedText shaped, string text)
+    {
+        var boundaries = new SortedSet<int> { 0, text.Length };
+
+        var glyphs = shaped.Glyphs;
+        for (int i = 0; i < glyphs.Count; i++)
+        {
+            int start = glyphs[i].StartIndex;
+
+            if (start > 0 && start < text.Length)
+                boundaries.Add(start);
+        }
+
+        return new List<int>(boundaries);
+    }
+
+    /// <summary>
+    /// The first <paramref name="cut"/> characters of <paramref name="text"/>, trailing whitespace
+    /// removed, with <paramref name="ellipsis"/> appended.
+    /// </summary>
+    private static string compose(string text, int cut, string ellipsis)
+        => string.Concat(text.AsSpan(0, cut).TrimEnd(), ellipsis);
+}


### PR DESCRIPTION
Want to do this for a long time (since scrolling text got added) but hard to make sure that make it work and test coverage too