### PR TITLE
Add video pool to texture preview overlay

### DIFF
--- a/Sakura.Framework.Tests/Graphics/ContainerMaskScaleTest.cs
+++ b/Sakura.Framework.Tests/Graphics/ContainerMaskScaleTest.cs
@@ -246,6 +246,8 @@ public class ContainerMaskScaleTest
 
         public void DrawEdgeEffect(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius, float edgeRadius, Vector2 offset, Color color, bool glow, bool hollow, ReadOnlySpan<VertexData> quadVertices) { }
 
+        public void ApplyCurrentClip(Span<VertexData> vertices) { }
+
         // unused members
         public Texture WhitePixel => throw new NotSupportedException();
         public Matrix4x4 ProjectionMatrix => default;

--- a/Sakura.Framework.Tests/Graphics/TextureBindTrackerTest.cs
+++ b/Sakura.Framework.Tests/Graphics/TextureBindTrackerTest.cs
@@ -1,0 +1,134 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Tests.Graphics;
+
+/// <summary>
+/// <see cref="TextureBindCounter"/> reports the last <em>completed</em> frame, from counters that roll
+/// themselves forward lazily rather than being swept at each frame boundary.
+/// </summary>
+[TestFixture]
+public class TextureBindTrackerTest
+{
+    private TextureBindCounter counter = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        counter = new TextureBindCounter();
+
+        // Other fixtures draw through the headless renderer and share the process-wide frame index, so
+        // start from a known boundary rather than assuming one.
+        TextureBindTracker.EndFrame();
+    }
+
+    private static void record(TextureBindCounter target, int times)
+    {
+        for (int i = 0; i < times; i++)
+            target.Record();
+    }
+
+    [Test]
+    public void ACounterStartsAtZero()
+    {
+        Assert.That(counter.LastFrame, Is.Zero);
+    }
+
+    /// <summary>
+    /// Binds are only reported once their frame has closed, so the number a reader sees never changes
+    /// under it mid-frame.
+    /// </summary>
+    [Test]
+    public void BindsAreReportedOnlyOnceTheirFrameIsComplete()
+    {
+        record(counter, 3);
+        Assert.That(counter.LastFrame, Is.Zero, "the frame is still in progress");
+
+        TextureBindTracker.EndFrame();
+        Assert.That(counter.LastFrame, Is.EqualTo(3));
+    }
+
+    /// <summary>
+    /// The reading that costs nothing: a texture that stops being bound reports its last frame while that
+    /// frame is the previous one, then zero, without anything having to visit it.
+    /// </summary>
+    [Test]
+    public void ACounterThatStopsBeingBoundFallsToZero()
+    {
+        record(counter, 2);
+        TextureBindTracker.EndFrame();
+
+        Assert.That(counter.LastFrame, Is.EqualTo(2));
+
+        TextureBindTracker.EndFrame();
+        Assert.That(counter.LastFrame, Is.Zero, "a whole frame passed without a bind");
+
+        TextureBindTracker.EndFrame();
+        Assert.That(counter.LastFrame, Is.Zero, "and it stays there");
+    }
+
+    /// <summary>
+    /// The case the roll-forward exists for: the first bind of a new frame must move the completed total
+    /// aside rather than adding to it, so a reader that arrives mid-frame still sees the finished figure.
+    /// </summary>
+    [Test]
+    public void RebindingInANewFrameKeepsTheCompletedFrameReadable()
+    {
+        record(counter, 4);
+        TextureBindTracker.EndFrame();
+
+        record(counter, 1);
+        Assert.That(counter.LastFrame, Is.EqualTo(4), "the new frame's bind must not leak into the completed total");
+
+        record(counter, 6);
+        Assert.That(counter.LastFrame, Is.EqualTo(4));
+
+        TextureBindTracker.EndFrame();
+        Assert.That(counter.LastFrame, Is.EqualTo(7));
+    }
+
+    /// <summary>
+    /// A counter that sat out several frames and then gets bound again reports zero for the frame before,
+    /// not the stale total from whenever it was last drawn.
+    /// </summary>
+    [Test]
+    public void ReturningAfterAGapDoesNotResurrectTheOldTotal()
+    {
+        record(counter, 5);
+        TextureBindTracker.EndFrame();
+        TextureBindTracker.EndFrame();
+        TextureBindTracker.EndFrame();
+
+        record(counter, 1);
+        Assert.That(counter.LastFrame, Is.Zero);
+    }
+
+    /// <summary>
+    /// The frame total is the sum over every texture, and is published on the same boundary.
+    /// </summary>
+    [Test]
+    public void TheFrameTotalSumsEveryCounter()
+    {
+        var other = new TextureBindCounter();
+
+        record(counter, 2);
+        record(other, 3);
+
+        TextureBindTracker.EndFrame();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GlobalStatistics.Get<int>("Renderer", "Texture Binds (Last Frame)").Value, Is.EqualTo(5));
+            Assert.That(counter.LastFrame, Is.EqualTo(2));
+            Assert.That(other.LastFrame, Is.EqualTo(3));
+        });
+
+        TextureBindTracker.EndFrame();
+
+        Assert.That(GlobalStatistics.Get<int>("Renderer", "Texture Binds (Last Frame)").Value, Is.Zero, "the total resets with the frame");
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestVideoSprite.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestVideoSprite.cs
@@ -3,8 +3,12 @@
 
 using NUnit.Framework;
 using Sakura.Framework.Allocation;
+using Sakura.Framework.Extensions.DrawableExtensions;
 using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Containers;
+using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Graphics.Video;
 using Sakura.Framework.Maths;
@@ -148,7 +152,7 @@ public partial class TestVideoSprite : TestScene
         AddAssert("Showing a frame after rapid seeks", () => videoSprite.Alpha == 1f);
         AddAssert("Not stuck buffering", () => !videoSprite.Buffering);
     }
-    
+
     [Test]
     public void TestSeekThenPlaybackContinues()
     {
@@ -196,6 +200,49 @@ public partial class TestVideoSprite : TestScene
         AddStep("Force Dispose", () => videoSprite.Dispose());
 
         AddWaitStep("Wait to ensure no background crashes", 500);
+    }
+
+    [Test]
+    public void TestFadeOverBufferedContainer()
+    {
+        Container videoContainer = null!;
+
+        AddStep("Add blurred backdrop and video", () =>
+        {
+            Add(new BufferedContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                FrameBufferScale = new Vector2(0.5f),
+                BlurSigma = new Vector2(8f),
+                Child = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Color = Color.Red
+                }
+            });
+
+            Add(videoContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = videoSprite = new VideoSprite(videoStore.GetDecoder("test.avi"))
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = TextureFillMode.Fill
+                }
+            });
+        });
+
+        AddAssert("VideoSprite is loaded", () => videoSprite.IsLoaded);
+        AddWaitStep("Let a frame arrive", 500);
+
+        AddStep("Fade video out", () => videoContainer.FadeOut(2000));
+        AddWaitStep("Watch the fade", 2500);
+        AddAssert("Video container is fully faded", () => videoContainer.Alpha == 0f);
+
+        AddStep("Fade video back in", () => videoContainer.FadeIn(2000));
+        AddWaitStep("Watch the fade", 2500);
     }
 
     [Test]

--- a/Sakura.Framework.Tests/Visuals/Drawables/TestVideoSprite.cs
+++ b/Sakura.Framework.Tests/Visuals/Drawables/TestVideoSprite.cs
@@ -8,7 +8,6 @@ using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
-using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Graphics.Video;
 using Sakura.Framework.Maths;

--- a/Sakura.Framework/Graphics/Containers/EdgeEffectParameters.cs
+++ b/Sakura.Framework/Graphics/Containers/EdgeEffectParameters.cs
@@ -82,4 +82,6 @@ public struct EdgeEffectParameters : IEquatable<EdgeEffectParameters>
     public static bool operator ==(EdgeEffectParameters left, EdgeEffectParameters right) => left.Equals(right);
 
     public static bool operator !=(EdgeEffectParameters left, EdgeEffectParameters right) => !left.Equals(right);
+
+    public override string ToString() => $"EdgeEffectParameters(Color={Color}, Offset={Offset}, Type={Type}, Radius={Radius}, Roundness={Roundness}, Hollow={Hollow})";
 }

--- a/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
@@ -11,9 +11,11 @@ using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Drawables;
 using Sakura.Framework.Graphics.Primitives;
+using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Text;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Graphics.Transforms;
+using Sakura.Framework.Graphics.Video;
 using Sakura.Framework.Input;
 using Sakura.Framework.IO;
 using Sakura.Framework.Logging;
@@ -40,6 +42,40 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
     private int lastTextureCount = -1;
     private int lastVideoCount = -1;
     private double lastUpdateTime;
+
+    private IRenderer renderer = null!;
+
+    /// <summary>
+    /// Shader for the video pool previews, shared by every preview card. Compiled once on the draw
+    /// thread, written there and read on the update thread, same as <see cref="VideoSprite"/> does.
+    /// </summary>
+    private IShader? videoShader;
+
+    /// <summary>
+    /// Whether the compiler of <see cref="videoShader"/> has already been scheduled, so a refresh while
+    /// it is still in flight does not queue another one.
+    /// </summary>
+    private bool videoShaderRequested;
+
+    /// <summary>
+    /// Whether the cards currently on screen were built with <see cref="videoShader"/> available.
+    /// Cards created before the compiler finished cannot draw a frame, so a refresh is forced once it is.
+    /// </summary>
+    private bool builtWithVideoShader;
+
+    /// <summary>
+    /// The upload-state labels of the live video pool cards, kept up to date on the throttled tick.
+    /// Everything else about a card is fixed when it is built. However, a playing video flips these several
+    /// times a second — a label that only changed when the pool's size did would sit there
+    /// contradicting the preview right next to it.
+    /// </summary>
+    private readonly List<(SpriteText Label, IVideoTexture Texture)> videoStateLabels = new List<(SpriteText, IVideoTexture)>();
+
+    /// <summary>
+    /// The "Uploaded: n / total" label of each video pool summary card, kept up to date alongside
+    /// <see cref="videoStateLabels"/>.
+    /// </summary>
+    private readonly List<(SpriteText Label, List<IVideoTexture> Pool)> videoPoolLabels = new List<(SpriteText, List<IVideoTexture>)>();
 
     [Resolved]
     private ITextureManager textureManager { get; set; }
@@ -205,6 +241,8 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
     public override void LoadComplete()
     {
         base.LoadComplete();
+
+        renderer = host.Renderer;
         refreshTextures();
     }
 
@@ -250,13 +288,16 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
 
         lastUpdateTime = host.UpdateClock.CurrentTime;
 
+        updateVideoLabels();
+
         int currentTextureUpdates = GlobalStatistics.Get<int>("Textures", "Texture Updates").Value;
         int currentAtlasPageCount = fontStore.Atlas != null ? fontStore.Atlas.GetAllPages().Count() : 0;
         int currentTextureAtlasPageCount = textureManager.Atlas?.PageCount ?? 0;
         int currentTextureCount = textureManager.GetAllTextures().Count();
         int currentVideoCount = textureManager.GetAllVideoTextures().Count();
 
-        if (currentTextureUpdates != lastTextureUpdates || currentAtlasPageCount != lastAtlasPageCount || currentTextureAtlasPageCount != lastTextureAtlasPageCount || currentTextureCount != lastTextureCount || currentVideoCount != lastVideoCount)
+        if (currentTextureUpdates != lastTextureUpdates || currentAtlasPageCount != lastAtlasPageCount || currentTextureAtlasPageCount != lastTextureAtlasPageCount || currentTextureCount != lastTextureCount || currentVideoCount != lastVideoCount
+            || builtWithVideoShader != (videoShader != null))
         {
             lastTextureUpdates = currentTextureUpdates;
             lastAtlasPageCount = currentAtlasPageCount;
@@ -269,9 +310,46 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
 
     private static string toMegabytes(long bytes) => $"{bytes / 1024.0 / 1024.0:0.0} MB";
 
+    /// <summary>
+    /// Compiles the preview shader the first time there is a video pool to preview, so an app that never
+    /// plays a video doesn't need to compile it.
+    /// </summary>
+    private void ensureVideoShader()
+    {
+        if (videoShader != null || videoShaderRequested)
+            return;
+
+        videoShaderRequested = true;
+        renderer.ScheduleToDrawThread(() => videoShader = VideoTexturePreview.CreateShader(renderer));
+    }
+
+    /// <summary>
+    /// Re-reads the upload state of every pooled video texture a card is showing. The previews
+    /// themselves follow their texture on their own and need nothing from here.
+    /// </summary>
+    private void updateVideoLabels()
+    {
+        foreach (var (label, videoTexture) in videoStateLabels)
+        {
+            var state = describeVideoState(videoTexture);
+            label.Text = state.Text;
+            label.Color = state.Color;
+        }
+
+        foreach (var (label, pool) in videoPoolLabels)
+        {
+            int uploaded = pool.Count(vt => vt.UploadComplete);
+            label.Text = $"Uploaded: {uploaded} / {pool.Count}";
+            label.Color = uploaded == pool.Count ? Color.LimeGreen : Color.Yellow;
+        }
+    }
+
     private void refreshTextures()
     {
         flowContainer.Clear();
+        videoStateLabels.Clear();
+        videoPoolLabels.Clear();
+        builtWithVideoShader = videoShader != null;
 
         var fontAtlas = fontStore.Atlas;
 
@@ -289,13 +367,18 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
 
         if (videoTextures.Count > 0)
         {
+            ensureVideoShader();
+
             var groups = videoTextures
                 .GroupBy(vt => (vt.Width, vt.Height));
 
             foreach (var group in groups)
             {
-                int groupUploaded = group.Count(vt => vt.UploadComplete);
-                flowContainer.Add(createVideoPoolCard(group.Key.Width, group.Key.Height, group.Count(), groupUploaded));
+                var pooled = group.ToList();
+                flowContainer.Add(createVideoPoolCard(group.Key.Width, group.Key.Height, pooled));
+
+                for (int i = 0; i < pooled.Count; i++)
+                    flowContainer.Add(createVideoTextureCard(pooled[i], i, pooled.Count));
             }
         }
 
@@ -349,10 +432,47 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
     }
 
     /// <summary>
-    /// Creates an info-only card for a video texture.
+    /// A state line for one pooled video texture, describing whether its preview can show anything.
     /// </summary>
-    private Drawable createVideoPoolCard(int width, int height, int total, int uploaded)
+    private (string Text, Color Color) describeVideoState(IVideoTexture videoTexture)
     {
+        if (videoShader == null)
+            return ("compiling preview shader", Color.LightGray);
+
+        if (videoTexture.IsDisposed)
+            return ("disposed", Color.Red);
+
+        // A pooled texture between frames keeps the last frame uploaded into it, so this is only really
+        // seen before the first frame of a video arrives.
+        if (!videoTexture.UploadComplete)
+            return ("awaiting upload", Color.Yellow);
+
+        return ("holding a frame", Color.LimeGreen);
+    }
+
+    /// <summary>
+    /// Creates an info-only summary card for one video texture pool. The individual textures in the
+    /// pool follow it as <see cref="createVideoTextureCard"/> previews.
+    /// </summary>
+    private Drawable createVideoPoolCard(int width, int height, List<IVideoTexture> pool)
+    {
+        int total = pool.Count;
+        int uploaded = pool.Count(vt => vt.UploadComplete);
+
+        // The YUV planes, not width * height * 4: a video texture is three single-channel planes, so it
+        // costs 1.5 bytes per pixel. The same figure the "video" total in the native memory line is built
+        // from, so the two agree.
+        long bytes = NativeTextureMemory.BytesForVideoPlanes(width, height);
+
+        var uploadedText = new SpriteText
+        {
+            Text = $"Uploaded: {uploaded} / {total}",
+            Font = FontUsage.Default.With(size: 12),
+            Color = uploaded == total ? Color.LimeGreen : Color.Yellow
+        };
+
+        videoPoolLabels.Add((uploadedText, pool));
+
         return new Container
         {
             Anchor = Anchor.TopLeft,
@@ -383,15 +503,124 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
                         },
                         new SpriteText
                         {
-                            Text = $"Pool size: {total}",
+                            Text = $"{width}x{height}, {toMegabytes(bytes)} each",
                             Font = FontUsage.Default.With(size: 12),
                             Color = Color.LightGray
                         },
                         new SpriteText
                         {
-                            Text = $"Uploaded: {uploaded} / {total}",
+                            Text = $"Pool size: {total} ({toMegabytes(bytes * total)})",
                             Font = FontUsage.Default.With(size: 12),
-                            Color = uploaded == total ? Color.LimeGreen : Color.Yellow
+                            Color = Color.LightGray
+                        },
+                        uploadedText
+                    }
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Creates a card previewing the frame a single pooled video texture is currently holding.
+    /// The preview is live: it keeps following the texture as new frames are uploaded into it, so it
+    /// does not need a refresh to update.
+    /// </summary>
+    private Container createVideoTextureCard(IVideoTexture videoTexture, int index, int total)
+    {
+        const float card_size = 256;
+        const float padding = 5;
+        const float spacing = 5;
+        const float title_height = 20;
+        const float state_height = 14;
+
+        var state = describeVideoState(videoTexture);
+
+        var stateText = new SpriteText
+        {
+            Anchor = Anchor.TopLeft,
+            Origin = Anchor.TopLeft,
+            Text = state.Text,
+            Font = FontUsage.Default.With(size: 10),
+            Color = state.Color
+        };
+
+        videoStateLabels.Add((stateText, videoTexture));
+
+        // Whatever the two labels and the gaps around them leave over. Unlike a texture card's sprite,
+        // the letterbox behind a preview is opaque, so an area that overflowed the card would be
+        // visible on top of the card below it.
+        var area = new Vector2(card_size - padding * 2, card_size - padding * 2 - title_height - state_height - spacing * 2);
+
+        // A video frame lives in YUV planes rather than a Texture, so FillMode has no aspect ratio to
+        // letterbox against — scale the preview to the frame's aspect within the card by hand.
+        float areaAspect = area.X / area.Y;
+        float frameAspect = videoTexture.Height > 0 ? (float)videoTexture.Width / videoTexture.Height : areaAspect;
+
+        var previewSize = frameAspect > areaAspect
+            ? new Vector2(1, areaAspect / frameAspect)
+            : new Vector2(frameAspect / areaAspect, 1);
+
+        return new Container
+        {
+            Anchor = Anchor.TopLeft,
+            Origin = Anchor.TopLeft,
+            Size = new Vector2(card_size),
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Color = Color.DarkGray,
+                    Alpha = 0.5f
+                },
+                new FlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(1),
+                    Spacing = new Vector2(0, spacing),
+                    Padding = new MarginPadding(padding),
+                    Direction = FlowDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new SpriteText
+                        {
+                            Anchor = Anchor.TopLeft,
+                            Origin = Anchor.TopLeft,
+                            Text = $"Video Pool Texture {index + 1}/{total} ({videoTexture.Width}x{videoTexture.Height}, {toMegabytes(NativeTextureMemory.BytesForVideoPlanes(videoTexture.Width, videoTexture.Height))})",
+                            Font = FontUsage.Default.With(size: 10),
+                            Color = Color.White,
+                            // Nothing masks a card, so a title too long for one would draw over its neighbour.
+                            Truncate = true,
+                            MaxWidth = card_size - padding * 2
+                        },
+                        stateText,
+                        new Container
+                        {
+                            Anchor = Anchor.TopLeft,
+                            Origin = Anchor.TopLeft,
+                            Size = area,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Color = Color.Black,
+                                    Alpha = 0.5f
+                                },
+                                new VideoTexturePreview(videoTexture, videoShader)
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = previewSize
+                                }
+                            }
                         }
                     }
                 }
@@ -399,7 +628,7 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
         };
     }
 
-    private Drawable createTextureCard(string title, Texture texture)
+    private Container createTextureCard(string title, Texture texture)
     {
         var state = describeState(texture);
 
@@ -488,4 +717,20 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
     protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
 
     protected override void PopOut() => this.FadeOut(200, Easing.OutQuint);
+
+    protected override void Dispose(bool isDisposing)
+    {
+        if (IsDisposed) return;
+
+        // The preview cards borrow this shader, they never own it — releasing it here is the only
+        // disposal, and it must happen on the draw thread.
+        if (videoShader != null)
+        {
+            var shader = videoShader;
+            videoShader = null;
+            renderer?.ScheduleToDrawThread(shader.Dispose);
+        }
+
+        base.Dispose(isDisposing);
+    }
 }

--- a/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
+++ b/Sakura.Framework/Graphics/Performance/TextureViewerDisplay.cs
@@ -77,6 +77,12 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
     /// </summary>
     private readonly List<(SpriteText Label, List<IVideoTexture> Pool)> videoPoolLabels = new List<(SpriteText, List<IVideoTexture>)>();
 
+    /// <summary>
+    /// The per-frame bind label of every card, refreshed on the throttled tick like the video state
+    /// labels. A bind count changes every frame, so these can never be baked in at card-build time.
+    /// </summary>
+    private readonly List<(SpriteText Label, TextureBindCounter Counter)> bindLabels = new List<(SpriteText, TextureBindCounter)>();
+
     [Resolved]
     private ITextureManager textureManager { get; set; }
 
@@ -289,6 +295,7 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
         lastUpdateTime = host.UpdateClock.CurrentTime;
 
         updateVideoLabels();
+        updateBindLabels();
 
         int currentTextureUpdates = GlobalStatistics.Get<int>("Textures", "Texture Updates").Value;
         int currentAtlasPageCount = fontStore.Atlas != null ? fontStore.Atlas.GetAllPages().Count() : 0;
@@ -344,11 +351,48 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
         }
     }
 
+    /// <summary>
+    /// Re-reads how often each card's texture was bound during the last completed frame.
+    /// </summary>
+    private void updateBindLabels()
+    {
+        foreach (var (label, counter) in bindLabels)
+        {
+            int binds = counter.LastFrame;
+
+            label.Text = $"{binds} bind{(binds == 1 ? "" : "s")} last frame";
+            label.Color = binds > 0 ? Color.LightGray : Color.Gray;
+        }
+    }
+
+    /// <summary>
+    /// A card's bind label, registered so <see cref="updateBindLabels"/> keeps it current. Returns null
+    /// when there is nothing to count against, which is what an atlas slice or a dimension-only proxy is.
+    /// </summary>
+    private SpriteText? createBindLabel(TextureBindCounter? counter)
+    {
+        if (counter == null)
+            return null;
+
+        var label = new SpriteText
+        {
+            Anchor = Anchor.TopLeft,
+            Origin = Anchor.TopLeft,
+            Font = FontUsage.Default.With(size: 10),
+            Color = Color.Gray,
+            Text = "0 binds last frame"
+        };
+
+        bindLabels.Add((label, counter));
+        return label;
+    }
+
     private void refreshTextures()
     {
         flowContainer.Clear();
         videoStateLabels.Clear();
         videoPoolLabels.Clear();
+        bindLabels.Clear();
         builtWithVideoShader = videoShader != null;
 
         var fontAtlas = fontStore.Atlas;
@@ -529,9 +573,10 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
     {
         const float card_size = 256;
         const float padding = 5;
-        const float spacing = 5;
+        const float spacing = 4;
         const float title_height = 20;
         const float state_height = 14;
+        const float bind_height = 14;
 
         var state = describeVideoState(videoTexture);
 
@@ -546,10 +591,9 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
 
         videoStateLabels.Add((stateText, videoTexture));
 
-        // Whatever the two labels and the gaps around them leave over. Unlike a texture card's sprite,
-        // the letterbox behind a preview is opaque, so an area that overflowed the card would be
-        // visible on top of the card below it.
-        var area = new Vector2(card_size - padding * 2, card_size - padding * 2 - title_height - state_height - spacing * 2);
+        var bindText = createBindLabel(videoTexture.Binds)!;
+
+        var area = new Vector2(card_size - padding * 2, card_size - padding * 2 - title_height - state_height - bind_height - spacing * 3);
 
         // A video frame lives in YUV planes rather than a Texture, so FillMode has no aspect ratio to
         // letterbox against — scale the preview to the frame's aspect within the card by hand.
@@ -598,6 +642,7 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
                             MaxWidth = card_size - padding * 2
                         },
                         stateText,
+                        bindText,
                         new Container
                         {
                             Anchor = Anchor.TopLeft,
@@ -633,6 +678,7 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
         var state = describeState(texture);
 
         const float title_height = 20;
+        const float bind_height = 14;
         float stateHeight = state == null ? 0 : 14;
 
         var labels = new List<Drawable>
@@ -659,11 +705,16 @@ public partial class TextureViewerDisplay : FocusedOverlayContainer, IRemoveFrom
             });
         }
 
+        var bindLabel = createBindLabel(texture.BackendTexture?.Binds);
+
+        if (bindLabel != null)
+            labels.Add(bindLabel);
+
         labels.Add(new Container
         {
             Anchor = Anchor.TopLeft,
             Origin = Anchor.TopLeft,
-            Size = new Vector2(256, 256 - title_height - stateHeight),
+            Size = new Vector2(256, 256 - title_height - stateHeight - (bindLabel == null ? 0 : bind_height)),
             Child = new Sprite
             {
                 Anchor = Anchor.Centre,

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
@@ -662,9 +662,16 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         rebindFrameState();
     }
 
-    /// <summary>
-    /// Pushes a clip region
-    /// </summary>
+    public void ApplyCurrentClip(Span<SakuraVertex> vertices)
+    {
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            vertices[i].ClipData = currentClip.ClipData;
+            vertices[i].ClipShearX = currentClip.ShearX;
+            vertices[i].ClipRadius = currentClip.Radius;
+        }
+    }
+
     public void PushMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius)
     {
         clipStack.Push(currentClip);

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
@@ -527,6 +527,8 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
 
         rootNode?.Draw(this);
 
+        TextureBindTracker.EndFrame();
+
         // VSync -> sync interval 1, no flags. Uncapped -> interval 0, tear (if the output supports it)
         // rather than stall on a flip-model swapchain. AllowTearing is illegal with interval > 0.
         if (presentSyncInterval == 0)

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Texture.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Texture.cs
@@ -32,6 +32,8 @@ public sealed class D3D11Texture : INativeTexture
     public int Height { get; }
     public bool Available { get; private set; }
 
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
     internal ID3D11ShaderResourceView ShaderResourceView => srv;
     internal ID3D11RenderTargetView RenderTargetView => rtv;
 
@@ -138,6 +140,7 @@ public sealed class D3D11Texture : INativeTexture
     public void Bind(int slot = 0)
     {
         var view = srv;
+        var bound = this;
 
         // Fall back to the white pixel when this texture hasn't been uploaded yet.
         if (!Available || view == null)
@@ -146,10 +149,14 @@ public sealed class D3D11Texture : INativeTexture
             if (white == null || ReferenceEquals(white, this))
                 return;
             view = white.srv;
+            bound = white;
         }
 
-        if (view != null)
-            context.PSSetShaderResource((uint)slot, view);
+        if (view == null)
+            return;
+
+        bound.Binds.Record();
+        context.PSSetShaderResource((uint)slot, view);
     }
 
     public void Dispose()

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11VideoTexture.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11VideoTexture.cs
@@ -53,6 +53,8 @@ public sealed class D3D11VideoTexture : INativeVideoTexture
     public bool Available => Volatile.Read(ref available);
     private bool available;
 
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
     private bool disposed;
 
     /// <summary>
@@ -119,6 +121,8 @@ public sealed class D3D11VideoTexture : INativeVideoTexture
     /// </summary>
     public void BindPlanes(bool tiling)
     {
+        Binds.Record();
+
         var sampler = tiling ? repeatSampler : clampSampler;
 
         context.PSSetShaderResources(0, new[] { ySrv, uSrv, vSrv });

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -665,6 +665,16 @@ public class GLRenderer : IGLRenderer, IDisposable
             SetBlendMode(previousBlend);
     }
 
+    public void ApplyCurrentClip(Span<SakuraVertex> vertices)
+    {
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            vertices[i].ClipData = currentClip.ClipData;
+            vertices[i].ClipShearX = currentClip.ShearX;
+            vertices[i].ClipRadius = currentClip.Radius;
+        }
+    }
+
     public void PushMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius)
     {
         clipStack.Push(currentClip);

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -30,9 +30,7 @@ public class GLRenderer : IGLRenderer, IDisposable
     private static readonly GlobalStatistic<int> stat_draw_calls = GlobalStatistics.Get<int>("Renderer", "Draw Calls");
     private static readonly GlobalStatistic<int> stat_vertices_drawn = GlobalStatistics.Get<int>("Renderer", "Vertices Drawn");
     private static readonly GlobalStatistic<int> stat_shader_binds = GlobalStatistics.Get<int>("Renderer", "Shader Binds");
-    private static readonly GlobalStatistic<int> stat_texture_binds = GlobalStatistics.Get<int>("Renderer", "Texture Binds");
 
-    private static readonly GlobalStatistic<int> stat_texture_binds_last_frame = GlobalStatistics.Get<int>("Renderer", "Texture Binds (Last Frame)");
     private static readonly GlobalStatistic<int> stat_slot_exhaustion_flushes = GlobalStatistics.Get<int>("Renderer", "Slot Exhaustion Flushes");
     private static readonly GlobalStatistic<int> stat_state_change_flushes = GlobalStatistics.Get<int>("Renderer", "State Change Flushes");
     private static readonly GlobalStatistic<int> stat_buffer_full_flushes = GlobalStatistics.Get<int>("Renderer", "Buffer Full Flushes");
@@ -359,7 +357,6 @@ public class GLRenderer : IGLRenderer, IDisposable
         stat_draw_calls.Value = 0;
         stat_vertices_drawn.Value = 0;
         stat_shader_binds.Value = 0;
-        stat_texture_binds.Value = 0;
 
         stat_slot_exhaustion_flushes.Value = 0;
         stat_state_change_flushes.Value = 0;
@@ -407,7 +404,7 @@ public class GLRenderer : IGLRenderer, IDisposable
 
         // Publish a stable snapshot of this frame's totals for cross-thread consumers (e.g. the
         // texture viewer). Done after the final batch flush so all binds for the frame are counted.
-        stat_texture_binds_last_frame.Value = stat_texture_binds.Value;
+        TextureBindTracker.EndFrame();
 
         insertFrameFence();
     }
@@ -544,10 +541,10 @@ public class GLRenderer : IGLRenderer, IDisposable
         if (boundTextureCount < textureSlotCount)
         {
             int slot = boundTextureCount;
+            // GLTexture.Bind counts the bind itself, so every backend's figure comes from the same place.
             glTexture.Bind(slot);
             boundTextureHandles[slot] = handle;
             boundTextureCount++;
-            stat_texture_binds.Value++;
             return slot;
         }
 
@@ -559,7 +556,6 @@ public class GLRenderer : IGLRenderer, IDisposable
         glTexture.Bind(0);
         boundTextureHandles[0] = handle;
         boundTextureCount = 1;
-        stat_texture_binds.Value++;
         return 0;
     }
 

--- a/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/HeadlessRenderer.cs
@@ -154,6 +154,10 @@ public class HeadlessRenderer : IRenderer
         throw new NotImplementedException();
     }
 
+    public void ApplyCurrentClip(Span<Vertex.Vertex> vertices)
+    {
+    }
+
     public void PopMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<Vertex.Vertex> maskVertices = default)
     {
 

--- a/Sakura.Framework/Graphics/Rendering/IRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/IRenderer.cs
@@ -51,6 +51,11 @@ public interface IRenderer
 
     void PushMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius);
 
+    /// <summary>
+    /// Stamps the mask currently pushed on this renderer onto <paramref name="vertices"/>.
+    /// </summary>
+    void ApplyCurrentClip(Span<Vertex.Vertex> vertices);
+
     void PopMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius, float borderThickness, Color borderColor, ReadOnlySpan<Vertex.Vertex> maskVertices = default);
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
@@ -392,6 +392,16 @@ public sealed class MetalRenderer : IMetalRenderer
     /// AABB, accounting for horizontal shear) with any parent mask, and the result becomes the active
     /// clip carried into subsequent vertices by <see cref="DrawVertices"/>.
     /// </summary>
+    public void ApplyCurrentClip(Span<SakuraVertex> vertices)
+    {
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            vertices[i].ClipData = currentClip.ClipData;
+            vertices[i].ClipShearX = currentClip.ShearX;
+            vertices[i].ClipRadius = currentClip.Radius;
+        }
+    }
+
     public void PushMask(Vector2 maskCenter, Vector2 maskHalfSize, float shearX, float cornerRadius)
     {
         clipStack.Push(currentClip);

--- a/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
@@ -327,6 +327,9 @@ public sealed class MetalRenderer : IMetalRenderer
 
         rootNode?.Draw(this);
 
+        // Metal draws immediately, so every bind for the frame has already been issued by here.
+        TextureBindTracker.EndFrame();
+
         SakuraMetalNative.sakura_metal_end_frame(device);
     }
 

--- a/Sakura.Framework/Graphics/Textures/GLTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/GLTexture.cs
@@ -24,6 +24,8 @@ public class GLTexture : INativeTexture
 
     public bool Available { get; private set; }
 
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
     private readonly GL gl;
     private bool disposed;
 
@@ -110,10 +112,15 @@ public class GLTexture : INativeTexture
         if (!Available || disposed || GLHandle == 0)
         {
             if (WhitePixel != null)
+            {
+                WhitePixel.Binds.Record();
                 gl.BindTexture(TextureTarget.Texture2D, WhitePixel.GLHandle);
+            }
+
             return;
         }
 
+        Binds.Record();
         gl.BindTexture(TextureTarget.Texture2D, GLHandle);
 
         if (mipmapsDirty)

--- a/Sakura.Framework/Graphics/Textures/HeadlessNativeTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/HeadlessNativeTexture.cs
@@ -18,6 +18,12 @@ public sealed class HeadlessNativeTexture : INativeTexture
     public bool Available { get; private set; } = true;
 
     /// <summary>
+    /// Note: it's always zero since the headless rasterizer samples <see cref="Surface"/> straight from the CPU and never
+    /// binds anything, so there is nothing to count.
+    /// </summary>
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
+    /// <summary>
     /// CPU pixels backing this texture when <see cref="Rendering.HeadlessRenderer"/> pixel capture is on,
     /// otherwise null. Only framebuffer color attachments carry one; a texture without a surface samples
     /// as opaque white, which is enough for the compositing questions capture exists to answer.

--- a/Sakura.Framework/Graphics/Textures/HeadlessNativeVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/HeadlessNativeVideoTexture.cs
@@ -15,6 +15,11 @@ internal sealed class HeadlessNativeVideoTexture : INativeVideoTexture
     public int Height { get; }
     public bool Available => false;
 
+    /// <summary>
+    /// Note: it's always zero since nothing is bound headlessly, so there is nothing to count.
+    /// </summary>
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
     public HeadlessNativeVideoTexture(int width, int height)
     {
         Width = width;

--- a/Sakura.Framework/Graphics/Textures/INativeTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/INativeTexture.cs
@@ -23,6 +23,12 @@ public interface INativeTexture : IDisposable
     bool Available { get; }
 
     /// <summary>
+    /// How often this texture has been bound, per frame. Implementations record a bind from
+    /// <see cref="Bind"/> (see <see cref="TextureBindTracker"/>).
+    /// </summary>
+    TextureBindCounter Binds { get; }
+
+    /// <summary>
     /// Uploads the full texture data. Must be called on the draw/render thread.
     /// Data is expected in RGBA8 format, row-major.
     /// </summary>

--- a/Sakura.Framework/Graphics/Textures/INativeVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/INativeVideoTexture.cs
@@ -21,6 +21,13 @@ public interface INativeVideoTexture : IDisposable
     bool Available { get; }
 
     /// <summary>
+    /// How often this texture has been bound, per frame. One <see cref="BindPlanes"/> counts once, not
+    /// once per plane: the three planes are always bound together, so counting each would only ever
+    /// report tripling the same number. See <see cref="TextureBindTracker"/>.
+    /// </summary>
+    TextureBindCounter Binds { get; }
+
+    /// <summary>
     /// Binds the Y, U, V planes to the appropriate texture slots for the current backend.
     /// For OpenGL: activates TextureUnit.Texture0/1/2 and binds each plane.
     /// For Metal: records the plane textures on the current render command encoder.

--- a/Sakura.Framework/Graphics/Textures/IVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/IVideoTexture.cs
@@ -17,4 +17,27 @@ public interface IVideoTexture
     /// True once the GPU upload for the current frame is complete.
     /// </summary>
     bool UploadComplete { get; }
+
+    /// <summary>
+    /// True once this texture has been disposed. Its GPU planes are gone (or queued to go) once this
+    /// is set, so nothing may bind them. The preview in
+    /// <see cref="Sakura.Framework.Graphics.Performance.TextureViewerDisplay"/> can outlive a pool by
+    /// up to one refresh, and checks this before drawing.
+    /// </summary>
+    bool IsDisposed { get; }
+
+    /// <summary>
+    /// The YUV -> RGB conversion matrix (3x3) matching the colorspace of the frames uploaded into this
+    /// texture, or <see langword="null"/> if no frame has been uploaded yet. Stamped on by the decoder
+    /// as it hands each frame over, so anything holding only the texture can convert it without
+    /// reaching back into the decoder.
+    /// </summary>
+    float[]? ConversionMatrix { get; }
+
+    /// <summary>
+    /// Binds the Y, U, and V planes to the texture slots the video shader samples.
+    /// Must be called on the render thread. See <see cref="INativeVideoTexture.BindPlanes"/> for
+    /// <paramref name="tiling"/>.
+    /// </summary>
+    void BindPlanes(bool tiling);
 }

--- a/Sakura.Framework/Graphics/Textures/IVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/IVideoTexture.cs
@@ -14,6 +14,12 @@ public interface IVideoTexture
     int Height { get; }
 
     /// <summary>
+    /// How often this texture's planes have been bound, per frame.
+    /// See <see cref="INativeVideoTexture.Binds"/>.
+    /// </summary>
+    TextureBindCounter Binds { get; }
+
+    /// <summary>
     /// True once the GPU upload for the current frame is complete.
     /// </summary>
     bool UploadComplete { get; }

--- a/Sakura.Framework/Graphics/Textures/MetalTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/MetalTexture.cs
@@ -30,6 +30,8 @@ public sealed class MetalTexture : INativeTexture
     public int Height { get; }
     public bool Available { get; private set; }
 
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
     /// <summary>
     /// Shared 1×1 white fallback, set once by <see cref="Rendering.Metal.MetalRenderer"/> at startup.
     /// Bound in place of any texture that isn't <see cref="Available"/> yet (or has been disposed), so
@@ -105,16 +107,22 @@ public sealed class MetalTexture : INativeTexture
         nint h = handle;
 
         // fallback to white pixel, matching GLTexture.Bind behavior
+        var bound = this;
+
         if (!Available || h == nint.Zero)
         {
             var white = WhitePixel;
             if (white == null || ReferenceEquals(white, this))
                 return;
             h = white.handle;
+            bound = white;
         }
 
-        if (h != nint.Zero)
-            SakuraMetalNative.sakura_metal_set_fragment_texture(device, h, slot);
+        if (h == nint.Zero)
+            return;
+
+        bound.Binds.Record();
+        SakuraMetalNative.sakura_metal_set_fragment_texture(device, h, slot);
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Textures/MetalVideoTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/MetalVideoTexture.cs
@@ -30,6 +30,8 @@ public sealed class MetalVideoTexture : INativeVideoTexture
     public bool Available => Volatile.Read(ref available);
     private bool available;
 
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
     public int Width { get; }
     public int Height { get; }
 
@@ -70,6 +72,8 @@ public sealed class MetalVideoTexture : INativeVideoTexture
     /// </summary>
     public void BindPlanes(bool tiling)
     {
+        Binds.Record();
+
         int repeat = tiling ? 1 : 0;
         SakuraMetalNative.sakura_metal_set_fragment_texture_wrap(device, yHandle, 0, repeat);
         SakuraMetalNative.sakura_metal_set_fragment_texture_wrap(device, uHandle, 1, repeat);

--- a/Sakura.Framework/Graphics/Textures/TextureBindTracker.cs
+++ b/Sakura.Framework/Graphics/Textures/TextureBindTracker.cs
@@ -1,0 +1,111 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Graphics.Textures;
+
+/// <summary>
+/// Counts GPU texture binds, both in total and per texture, for the frame currently being drawn and the
+/// one before it.
+/// </summary>
+public static class TextureBindTracker
+{
+    private static readonly GlobalStatistic<int> stat_binds = GlobalStatistics.Get<int>("Renderer", "Texture Binds");
+    private static readonly GlobalStatistic<int> stat_binds_last_frame = GlobalStatistics.Get<int>("Renderer", "Texture Binds (Last Frame)");
+
+    /// <summary>
+    /// Which frame is being drawn. Incremented by <see cref="EndFrame"/> and used by
+    /// <see cref="TextureBindCounter"/> to tell this frame's binds from the previous frame's without
+    /// having to sweep every live texture at each frame boundary.
+    /// </summary>
+    internal static long FrameIndex;
+
+    private static int binds;
+
+    /// <summary>
+    /// Records one bind against the frame total. Called by <see cref="TextureBindCounter.Record"/>, which
+    /// is what a backend's <see cref="INativeTexture.Bind"/> calls (never call this directly, or the
+    /// total and the per-texture counts stop agreeing)
+    /// </summary>
+    internal static void RecordBind()
+    {
+        binds++;
+        stat_binds.Value = binds;
+    }
+
+    /// <summary>
+    /// Closes the current frame by publishing its total as the last-frame figure and starts the next one.
+    /// Called by each renderer at the end of its draw, after the last draw call for the frame has
+    /// been issued (on GL, after the final batch flush, or the batched binds would land in the next
+    /// frame's count).
+    /// </summary>
+    public static void EndFrame()
+    {
+        stat_binds_last_frame.Value = binds;
+        binds = 0;
+        FrameIndex++;
+    }
+}
+
+/// <summary>
+/// One texture's bind count. Every <see cref="INativeTexture"/> and <see cref="INativeVideoTexture"/>
+/// owns one and reports it to the texture viewer.
+/// </summary>
+public sealed class TextureBindCounter
+{
+    /// <summary>
+    /// The frame <see cref="count"/> was accumulated during
+    /// </summary>
+    private long stampedFrame = -1;
+
+    /// <summary>
+    /// Binds during <see cref="stampedFrame"/>.
+    /// </summary>
+    private int count;
+
+    /// <summary>
+    /// Binds during the frame before <see cref="stampedFrame"/>, if it was the frame right before it.
+    /// </summary>
+    private int previousCount;
+
+    /// <summary>
+    /// Records one bind of this texture, against both this counter and the frame total. Draw thread only.
+    /// </summary>
+    internal void Record()
+    {
+        long frame = TextureBindTracker.FrameIndex;
+
+        if (stampedFrame != frame)
+        {
+            // Whatever was counted under the old stamp is finished. It only describes the previous frame
+            // if that stamp was the previous frame. Anything older means this texture went a whole frame
+            // without being bound.
+            previousCount = stampedFrame == frame - 1 ? count : 0;
+            count = 0;
+            stampedFrame = frame;
+        }
+
+        count++;
+        TextureBindTracker.RecordBind();
+    }
+
+    /// <summary>
+    /// How many times this texture was bound during the last completed frame. Safe to read from any
+    /// thread.
+    /// </summary>
+    public int LastFrame
+    {
+        get
+        {
+            long frame = TextureBindTracker.FrameIndex;
+
+            // Already bound this frame, so the roll-forward has run, and the completed total moved aside.
+            if (stampedFrame == frame)
+                return previousCount;
+
+            // Not bound yet this frame, so the running count is still the completed frame.
+            return stampedFrame == frame - 1 ? count : 0;
+        }
+    }
+}

--- a/Sakura.Framework/Graphics/Textures/VideoGLTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/VideoGLTexture.cs
@@ -29,6 +29,8 @@ public sealed class VideoGLTexture : INativeVideoTexture
     public bool Available => Volatile.Read(ref available);
     private bool available;
 
+    public TextureBindCounter Binds { get; } = new TextureBindCounter();
+
     public int Width { get; }
     public int Height { get; }
 
@@ -60,6 +62,8 @@ public sealed class VideoGLTexture : INativeVideoTexture
     /// </summary>
     public void BindPlanes(bool tiling)
     {
+        Binds.Record();
+
         int wrap = tiling ? (int)TextureWrapMode.Repeat : (int)TextureWrapMode.ClampToEdge;
 
         bindPlane(TextureUnit.Texture0, YHandle, wrap);

--- a/Sakura.Framework/Graphics/Video/VideoDecoder.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDecoder.cs
@@ -725,11 +725,11 @@ public unsafe class VideoDecoder : IDisposable
             if (!texturePoolWarmed)
             {
                 texturePoolWarmed = true;
-                var capturedW = width;
-                var capturedH = height;
+                int capturedW = width;
+                int capturedH = height;
                 renderer.ScheduleToDrawThread(() =>
                 {
-                    while (availableTextures.Count < max_pending_frames)
+                    for (int i = 0; i < max_pending_frames; i++)
                         availableTextures.Enqueue(new VideoTexture(renderer, textureManager, capturedW, capturedH));
                 });
             }
@@ -763,7 +763,8 @@ public unsafe class VideoDecoder : IDisposable
         int height = frame.Pointer->height;
 
         var upload = new VideoTextureUpload(frame);
-        tex.SetData(upload);
+
+        tex.SetData(upload, GetConversionMatrix());
 
         // Texture is a dimension-only proxy — no GL handles, no Video namespace import needed.
         // VideoSprite reads NativeTexture directly for rendering.

--- a/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
@@ -50,6 +50,8 @@ internal class VideoDrawNode : DrawNode
         bool isD3D11 = renderer is Rendering.Direct3D11.ID3D11Renderer;
         if (!isGL && !isMetal && !isD3D11)
             return;
+        
+        renderer.SetBlendMode(Blending);
 
         renderer.FlushBatch();
 

--- a/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
@@ -50,7 +50,7 @@ internal class VideoDrawNode : DrawNode
         bool isD3D11 = renderer is Rendering.Direct3D11.ID3D11Renderer;
         if (!isGL && !isMetal && !isD3D11)
             return;
-        
+
         renderer.SetBlendMode(Blending);
 
         renderer.FlushBatch();

--- a/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDrawNode.cs
@@ -16,11 +16,11 @@ namespace Sakura.Framework.Graphics.Video;
 /// </summary>
 internal class VideoDrawNode : DrawNode
 {
-    private VideoTexture? videoTexture;
+    private IVideoTexture? videoTexture;
     private float[]? yuvMatrix;
     private IShader? videoShader;
 
-    public void ApplyVideoState(VideoTexture? tex, float[]? matrix, IShader? shader)
+    public void ApplyVideoState(IVideoTexture? tex, float[]? matrix, IShader? shader)
     {
         videoTexture = tex;
         yuvMatrix = matrix;
@@ -36,6 +36,12 @@ internal class VideoDrawNode : DrawNode
             return;
 
         if (!videoTexture.UploadComplete)
+            return;
+
+        // The texture may have been disposed since this node's state was applied (a pool torn down
+        // while the texture viewer still shows a preview of it). Its planes are destroyed on this
+        // thread, so checking here is enough to never bind a dead handle.
+        if (videoTexture.IsDisposed)
             return;
 
         // TODO: This is still really bad????
@@ -65,6 +71,8 @@ internal class VideoDrawNode : DrawNode
 
         if (yuvMatrix != null)
             videoShader.SetUniformBlock("VideoBlock", VideoBlock.FromMat3(yuvMatrix));
+
+        renderer.ApplyCurrentClip(WritableVertices);
 
         if (renderer is IGLRenderer glRenderer)
             glRenderer.DrawVerticesRaw(Vertices);

--- a/Sakura.Framework/Graphics/Video/VideoSprite.cs
+++ b/Sakura.Framework/Graphics/Video/VideoSprite.cs
@@ -356,7 +356,7 @@ public partial class VideoSprite : Drawable
     {
         if (IsDisposed) return;
 
-        if (decoder.IsNull())
+        if (decoder.IsNotNull())
         {
             decoder.ReturnFrames(availableFrames);
             availableFrames.Clear();

--- a/Sakura.Framework/Graphics/Video/VideoTexture.cs
+++ b/Sakura.Framework/Graphics/Video/VideoTexture.cs
@@ -32,6 +32,19 @@ public sealed class VideoTexture : IVideoTexture
     public bool UploadComplete => Volatile.Read(ref uploadComplete);
     private bool uploadComplete;
 
+    /// <summary>
+    /// True once <see cref="Dispose"/> has run. The native planes are disposed on the draw thread, so a
+    /// draw-thread reader that checks this can never bind a destroyed plane.
+    /// </summary>
+    public bool IsDisposed => Volatile.Read(ref isDisposed);
+
+    /// <summary>
+    /// The YUV -> RGB matrix for the frames uploaded here, stamped on by
+    /// <see cref="SetData"/>. Null until the first frame arrives.
+    /// </summary>
+    public float[]? ConversionMatrix => Volatile.Read(ref conversionMatrix);
+    private float[]? conversionMatrix;
+
     private volatile VideoTextureUpload? pendingUpload;
 
     private readonly ITextureManager textureManager;
@@ -49,9 +62,19 @@ public sealed class VideoTexture : IVideoTexture
     /// <summary>
     /// Stores a pending upload. Called from the decode thread — no render-thread calls.
     /// </summary>
-    public void SetData(VideoTextureUpload upload)
+    /// <param name="upload">The frame to upload on the next render-thread flush.</param>
+    /// <param name="conversionMatrix">
+    /// The YUV→RGB matrix for this frame's colorspace, exposed as <see cref="ConversionMatrix"/> so a
+    /// consumer holding only this texture can convert it. Ignored when null, keeping whatever the last
+    /// frame set.
+    /// </param>
+    public void SetData(VideoTextureUpload upload, float[]? conversionMatrix = null)
     {
         Volatile.Write(ref uploadComplete, false);
+
+        if (conversionMatrix != null)
+            Volatile.Write(ref this.conversionMatrix, conversionMatrix);
+
         pendingUpload = upload;
     }
 
@@ -90,7 +113,7 @@ public sealed class VideoTexture : IVideoTexture
     public void Dispose()
     {
         if (isDisposed) return;
-        isDisposed = true;
+        Volatile.Write(ref isDisposed, true);
 
         pendingUpload?.Dispose();
         pendingUpload = null;

--- a/Sakura.Framework/Graphics/Video/VideoTexture.cs
+++ b/Sakura.Framework/Graphics/Video/VideoTexture.cs
@@ -25,6 +25,8 @@ public sealed class VideoTexture : IVideoTexture
     public int Width  => NativeTexture.Width;
     public int Height => NativeTexture.Height;
 
+    public TextureBindCounter Binds => NativeTexture.Binds;
+
     /// <summary>
     /// True once the render thread has flushed the pending upload.
     /// Written via <see cref="Volatile"/> — safe to read from any thread.

--- a/Sakura.Framework/Graphics/Video/VideoTexturePreview.cs
+++ b/Sakura.Framework/Graphics/Video/VideoTexturePreview.cs
@@ -1,0 +1,45 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Textures;
+
+namespace Sakura.Framework.Graphics.Video;
+
+/// <summary>
+/// Draws whatever frame an <see cref="IVideoTexture"/> currently holds, with no decoder and no
+/// playback clock behind it. Used by
+/// <see cref="Sakura.Framework.Graphics.Performance.TextureViewerDisplay"/> to preview the contents of
+/// a video texture pool.
+/// </summary>
+public partial class VideoTexturePreview : Drawable
+{
+    private readonly IVideoTexture videoTexture;
+    private readonly IShader? videoShader;
+
+    /// <summary>
+    /// Compiles the shader a preview draws with. Must be called on the draw thread.
+    /// </summary>
+    public static IShader CreateShader(IRenderer renderer) => renderer.CreateShader(renderer.ShaderStorage, "video.vert", "video.frag");
+
+    /// <param name="videoTexture">The texture to preview. Borrowed, not owned.</param>
+    /// <param name="videoShader">
+    /// A shader from <see cref="CreateShader"/>, owned by the caller. When null (it has not finished
+    /// compiling yet), nothing is drawn.
+    /// </param>
+    public VideoTexturePreview(IVideoTexture videoTexture, IShader? videoShader)
+    {
+        this.videoTexture = videoTexture;
+        this.videoShader = videoShader;
+    }
+
+    protected override DrawNode CreateDrawNode() => new VideoDrawNode();
+
+    public override DrawNode GenerateDrawNodeSubtree(int frameIndex)
+    {
+        var node = base.GenerateDrawNodeSubtree(frameIndex) as VideoDrawNode;
+        node?.ApplyVideoState(videoTexture, videoTexture.ConversionMatrix, videoShader);
+        return node!;
+    }
+}


### PR DESCRIPTION
<img width="1534" height="1272" alt="image" src="https://github.com/user-attachments/assets/84042ad5-12a5-4b6e-9c5f-063edbdd202b" />

After make binding work noticing that Metal and D3D have more lot of binding count than OpenGL (that it should be like that), will apply more batching later.