### PR TITLE
Implement texture batching in Metal and D3D11 renderer

### DIFF
--- a/Sakura.Framework/Graphics/Rendering/Batches/TriangleBatch.cs
+++ b/Sakura.Framework/Graphics/Rendering/Batches/TriangleBatch.cs
@@ -11,15 +11,14 @@ using SakuraVertex = Sakura.Framework.Graphics.Rendering.Vertex.Vertex;
 namespace Sakura.Framework.Graphics.Rendering.Batches;
 
 /// <summary>
-/// An indexed batch for rendering quads and triangle lists in submission order.
-/// Quads contribute 4 vertices + 6 indices (a 33% vertex-bandwidth saving over raw
-/// triangle pairs); arbitrary triangle lists contribute sequential indices.
-/// Buffers are orphaned on every flush so the GPU never stalls waiting on a region
-/// it is still reading from the previous draw.
+/// The OpenGL half of an indexed batch: the VAO/VBO/EBO, the static quad index buffer, and the
+/// upload + <c>DrawElements</c> that consumes a <see cref="VertexBatch"/>. The CPU-side accumulation
+/// itself lives in <see cref="VertexBatch"/> and is shared with the other backends.
+/// Buffers are orphaned on every flush so the GPU never stalls waiting on a region it is still
+/// reading from the previous draw.
 /// </summary>
 public class TriangleBatch : IDisposable
 {
-    private static readonly GlobalStatistic<int> stat_buffer_full_flushes = GlobalStatistics.Get<int>("Renderer", "Buffer Full Flushes");
     private static readonly GlobalStatistic<int> stat_draw_calls = GlobalStatistics.Get<int>("Renderer", "Draw Calls");
     private static readonly GlobalStatistic<int> stat_vertices_drawn = GlobalStatistics.Get<int>("Renderer", "Vertices Drawn");
 
@@ -30,12 +29,8 @@ public class TriangleBatch : IDisposable
 
     private readonly uint quadEbo;
 
-    private bool batchHasNonQuad;
+    private readonly VertexBatch batch;
 
-    private readonly SakuraVertex[] vertices;
-    private readonly uint[] indices;
-    private int vertexCount;
-    private int indexCount;
     private readonly int vertexSize;
     private readonly int maxVertices;
     private readonly int maxIndices;
@@ -45,11 +40,9 @@ public class TriangleBatch : IDisposable
         this.gl = gl;
         vertexSize = Marshal.SizeOf<SakuraVertex>();
         this.maxVertices = maxVertices;
-        // Quads use 6 indices per 4 vertices (1.5×); triangle lists use 1 index per vertex.
-        maxIndices = maxVertices * 3 / 2;
 
-        vertices = new SakuraVertex[this.maxVertices];
-        indices = new uint[maxIndices];
+        batch = new VertexBatch(maxVertices, () => Draw());
+        maxIndices = batch.MaxIndices;
 
         vao = gl.GenVertexArray();
         vbo = gl.GenBuffer();
@@ -100,8 +93,10 @@ public class TriangleBatch : IDisposable
 
         // Fill the static quad index buffer once. Done with no VAO bound so it doesn't disturb the
         // VAO's element-buffer binding, Draw() explicitly binds whichever EBO it needs each flush.
+        //
+        // This stays GL-specific: the shared piece is the accumulation, not the index strategy.
         int maxQuads = maxVertices / 4;
-        var quadIndices = new uint[maxQuads * 6];
+        uint[] quadIndices = new uint[maxQuads * 6];
         for (int q = 0; q < maxQuads; q++)
         {
             uint baseIndex = (uint)(q * 4);
@@ -120,69 +115,17 @@ public class TriangleBatch : IDisposable
         gl.BindBuffer(BufferTargetARB.ElementArrayBuffer, 0);
     }
 
-    private void ensureCapacity(int vertexSpace, int indexSpace)
-    {
-        if (vertexCount + vertexSpace > maxVertices || indexCount + indexSpace > maxIndices)
-        {
-            stat_buffer_full_flushes.Value++;
-            Draw();
-        }
-    }
-
     /// <summary>
     /// Adds a quad of exactly 4 vertices ordered top-left, top-right, bottom-right, bottom-left.
     /// </summary>
     public void AddQuad(ReadOnlySpan<SakuraVertex> quad, float textureIndex = 0f, Vector4? clipData = null, float clipShearX = 0f, float clipRadius = 0f)
-    {
-        ensureCapacity(4, 6);
-
-        Vector4 actualClipData = clipData ?? new Vector4(0, 0, -1, -1);
-
-        uint baseIndex = (uint)vertexCount;
-
-        for (int i = 0; i < 4; i++)
-        {
-            var v = quad[i];
-            v.TexIndex = textureIndex;
-            v.ClipData = actualClipData;
-            v.ClipShearX = clipShearX;
-            v.ClipRadius = clipRadius;
-            vertices[vertexCount++] = v;
-        }
-
-        indices[indexCount++] = baseIndex;
-        indices[indexCount++] = baseIndex + 1;
-        indices[indexCount++] = baseIndex + 2;
-        indices[indexCount++] = baseIndex + 2;
-        indices[indexCount++] = baseIndex + 3;
-        indices[indexCount++] = baseIndex;
-    }
+        => batch.AddQuad(quad, textureIndex, clipData, clipShearX, clipRadius);
 
     /// <summary>
     /// Adds an arbitrary triangle list (sequentially indexed).
     /// </summary>
     public void AddRange(ReadOnlySpan<SakuraVertex> newVertices, float textureIndex = 0f, Vector4? clipData = null, float clipShearX = 0f, float clipRadius = 0f)
-    {
-        // Triangle-list vertices break the quad alignment, so this flush must use the dynamic index buffer.
-        batchHasNonQuad = true;
-
-        // If no clip rect is provided, use an invalid rect so let shader ignore it
-        Vector4 actualClipData = clipData ?? new Vector4(0, 0, -1, -1);
-
-        foreach (var vertex in newVertices)
-        {
-            ensureCapacity(1, 1);
-
-            var v = vertex;
-            v.TexIndex = textureIndex;
-            v.ClipData = actualClipData;
-            v.ClipShearX = clipShearX;
-            v.ClipRadius = clipRadius;
-
-            indices[indexCount++] = (uint)vertexCount;
-            vertices[vertexCount++] = v;
-        }
-    }
+        => batch.AddRange(newVertices, textureIndex, clipData, clipShearX, clipRadius);
 
     /// <summary>
     /// Uploads the provided vertices directly into the VBO and issues a non-indexed
@@ -216,6 +159,9 @@ public class TriangleBatch : IDisposable
     /// </summary>
     public unsafe int Draw()
     {
+        int indexCount = batch.IndexCount;
+        int vertexCount = batch.VertexCount;
+
         if (indexCount == 0)
         {
             return 0;
@@ -229,18 +175,18 @@ public class TriangleBatch : IDisposable
         gl.BindBuffer(BufferTargetARB.ArrayBuffer, vbo);
         gl.BufferData(BufferTargetARB.ArrayBuffer, (nuint)(maxVertices * vertexSize), null, BufferUsageARB.DynamicDraw);
 
-        fixed (SakuraVertex* ptr = vertices)
+        fixed (SakuraVertex* ptr = batch.Vertices)
         {
             gl.BufferSubData(BufferTargetARB.ArrayBuffer, 0, (nuint)(vertexCount * vertexSize), ptr);
         }
 
-        if (batchHasNonQuad)
+        if (batch.HasNonQuad)
         {
             // upload the CPU-built indices into the dynamic buffer.
             gl.BindBuffer(BufferTargetARB.ElementArrayBuffer, ebo);
             gl.BufferData(BufferTargetARB.ElementArrayBuffer, (nuint)(maxIndices * sizeof(uint)), null, BufferUsageARB.DynamicDraw);
 
-            fixed (uint* ptr = indices)
+            fixed (uint* ptr = batch.Indices)
             {
                 gl.BufferSubData(BufferTargetARB.ElementArrayBuffer, 0, (nuint)(indexCount * sizeof(uint)), ptr);
             }
@@ -257,11 +203,8 @@ public class TriangleBatch : IDisposable
         stat_draw_calls.Value++;
         stat_vertices_drawn.Value += vertexCount;
 
-        int count = vertexCount;
-        vertexCount = 0;
-        indexCount = 0;
-        batchHasNonQuad = false;
-        return count;
+        batch.Reset();
+        return vertexCount;
     }
 
     private bool disposed;

--- a/Sakura.Framework/Graphics/Rendering/Batches/VertexBatch.cs
+++ b/Sakura.Framework/Graphics/Rendering/Batches/VertexBatch.cs
@@ -1,0 +1,201 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Statistic;
+using SakuraVertex = Sakura.Framework.Graphics.Rendering.Vertex.Vertex;
+
+namespace Sakura.Framework.Graphics.Rendering.Batches;
+
+/// <summary>
+/// Backend-agnostic CPU-side accumulation of a draw batch: the vertex array, the optional index
+/// array, and the per-vertex texture-slot / clip stamping every backend needs. Knows nothing about
+/// any graphics API — the owning renderer supplies a flush callback that uploads and draws whatever
+/// has accumulated, and this type calls it when the batch runs out of room.
+/// </summary>
+/// <remarks>
+/// Two shapes, chosen at construction:
+/// <list type="bullet">
+/// <item><description><b>Indexed</b> (OpenGL, Direct3D11): a quad contributes 4 vertices + 6
+/// indices, a 33% vertex-bandwidth saving over raw triangle pairs. Triangle lists contribute
+/// sequential indices and set <see cref="HasNonQuad"/>, which tells the backend it cannot use a
+/// static quad index buffer for this flush.</description></item>
+/// <item><description><b>Non-indexed</b> (Metal): a quad is expanded to 6 vertices on the way in,
+/// and no index array exists at all, because the native bridge draws triangle lists.</description></item>
+/// </list>
+/// </remarks>
+public sealed class VertexBatch
+{
+    private static readonly GlobalStatistic<int> stat_buffer_full_flushes = GlobalStatistics.Get<int>("Renderer", "Buffer Full Flushes");
+
+    /// <summary>
+    /// Clip rect meaning "no active clip" to the fragment shader's <c>applyClipping</c>.
+    /// </summary>
+    private static readonly Vector4 no_clip = new Vector4(0, 0, -1, -1);
+
+    private readonly SakuraVertex[] vertices;
+    private readonly uint[] indices;
+
+    /// <summary>
+    /// Uploads and draws whatever has accumulated, then <see cref="Reset"/>s this batch. Invoked when
+    /// an add would overflow the arrays; the owning renderer also calls its own flush directly for
+    /// state changes (blend mode, render target, texture-slot exhaustion, …).
+    /// </summary>
+    private readonly Action flush;
+
+    private int vertexCount;
+    private int indexCount;
+
+    /// <summary>
+    /// Whether this batch is indexed. Non-indexed batches expand quads to triangles on the way in and
+    /// leave <see cref="IndexCount"/> at zero.
+    /// </summary>
+    public bool Indexed { get; }
+
+    /// <summary>
+    /// Capacity of the vertex array. A single add never exceeds it (quads are at most 6 vertices,
+    /// triangle lists are added a triangle at a time).
+    /// </summary>
+    public int MaxVertices { get; }
+
+    /// <summary>
+    /// Capacity of the index array; zero when <see cref="Indexed"/> is false.
+    /// </summary>
+    public int MaxIndices { get; }
+
+    public int VertexCount => vertexCount;
+    public int IndexCount => indexCount;
+
+    public bool IsEmpty => vertexCount == 0;
+
+    /// <summary>
+    /// Whether anything in this batch broke quad alignment (i.e. came in through
+    /// <see cref="AddRange"/>). An indexed backend must upload <see cref="Indices"/> for such a flush
+    /// instead of relying on a static quad index buffer.
+    /// </summary>
+    public bool HasNonQuad { get; private set; }
+
+    public ReadOnlySpan<SakuraVertex> Vertices => vertices.AsSpan(0, vertexCount);
+
+    public ReadOnlySpan<uint> Indices => Indexed ? indices.AsSpan(0, indexCount) : ReadOnlySpan<uint>.Empty;
+
+    /// <param name="maxVertices">Vertex capacity before an add forces a flush.</param>
+    /// <param name="flush">Uploads + draws the accumulated batch and calls <see cref="Reset"/>.</param>
+    /// <param name="indexed">See the shapes described on the type.</param>
+    public VertexBatch(int maxVertices, Action flush, bool indexed = true)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxVertices, 6);
+        ArgumentNullException.ThrowIfNull(flush);
+
+        MaxVertices = maxVertices;
+        Indexed = indexed;
+        this.flush = flush;
+
+        // Quads use 6 indices per 4 vertices (1.5×); triangle lists use 1 index per vertex.
+        MaxIndices = indexed ? maxVertices * 3 / 2 : 0;
+
+        vertices = new SakuraVertex[maxVertices];
+        indices = indexed ? new uint[MaxIndices] : Array.Empty<uint>();
+    }
+
+    /// <summary>
+    /// Flushes if the requested space would not fit, so the caller can add unconditionally afterwards.
+    /// </summary>
+    private void ensureCapacity(int vertexSpace, int indexSpace)
+    {
+        if (vertexCount + vertexSpace > MaxVertices || indexCount + indexSpace > MaxIndices)
+        {
+            stat_buffer_full_flushes.Value++;
+            flush();
+        }
+    }
+
+    /// <summary>
+    /// Adds a quad of exactly 4 vertices ordered top-left, top-right, bottom-right, bottom-left.
+    /// </summary>
+    public void AddQuad(ReadOnlySpan<SakuraVertex> quad, float textureIndex = 0f, Vector4? clipData = null, float clipShearX = 0f, float clipRadius = 0f)
+    {
+        Vector4 actualClipData = clipData ?? no_clip;
+
+        if (!Indexed)
+        {
+            // No index buffer to fan the four corners out with, so write the two triangles directly,
+            // in the same winding the indexed path uses (TL, TR, BR / BR, BL, TL).
+            ensureCapacity(6, 0);
+
+            add(quad[0], textureIndex, actualClipData, clipShearX, clipRadius);
+            add(quad[1], textureIndex, actualClipData, clipShearX, clipRadius);
+            add(quad[2], textureIndex, actualClipData, clipShearX, clipRadius);
+            add(quad[2], textureIndex, actualClipData, clipShearX, clipRadius);
+            add(quad[3], textureIndex, actualClipData, clipShearX, clipRadius);
+            add(quad[0], textureIndex, actualClipData, clipShearX, clipRadius);
+            return;
+        }
+
+        ensureCapacity(4, 6);
+
+        uint baseIndex = (uint)vertexCount;
+
+        for (int i = 0; i < 4; i++)
+            add(quad[i], textureIndex, actualClipData, clipShearX, clipRadius);
+
+        indices[indexCount++] = baseIndex;
+        indices[indexCount++] = baseIndex + 1;
+        indices[indexCount++] = baseIndex + 2;
+        indices[indexCount++] = baseIndex + 2;
+        indices[indexCount++] = baseIndex + 3;
+        indices[indexCount++] = baseIndex;
+    }
+
+    /// <summary>
+    /// Adds an arbitrary triangle list (sequentially indexed when <see cref="Indexed"/>).
+    /// </summary>
+    public void AddRange(ReadOnlySpan<SakuraVertex> newVertices, float textureIndex = 0f, Vector4? clipData = null, float clipShearX = 0f, float clipRadius = 0f)
+    {
+        // Triangle-list vertices break the quad alignment, so this flush must use the dynamic index
+        // buffer rather than a static quad pattern.
+        HasNonQuad = true;
+
+        Vector4 actualClipData = clipData ?? no_clip;
+
+        // Added a triangle at a time so a capacity flush can never split one across two draws (which
+        // would leave a draw with a vertex count that isn't a multiple of three, silently dropping the
+        // remainder).
+        for (int i = 0; i < newVertices.Length; i += 3)
+        {
+            int group = Math.Min(3, newVertices.Length - i);
+            ensureCapacity(group, Indexed ? group : 0);
+
+            for (int j = 0; j < group; j++)
+            {
+                if (Indexed)
+                    indices[indexCount++] = (uint)vertexCount;
+
+                add(newVertices[i + j], textureIndex, actualClipData, clipShearX, clipRadius);
+            }
+        }
+    }
+
+    private void add(in SakuraVertex vertex, float textureIndex, Vector4 clipData, float clipShearX, float clipRadius)
+    {
+        ref var v = ref vertices[vertexCount++];
+
+        v = vertex;
+        v.TexIndex = textureIndex;
+        v.ClipData = clipData;
+        v.ClipShearX = clipShearX;
+        v.ClipRadius = clipRadius;
+    }
+
+    /// <summary>
+    /// Drops everything accumulated so far. Called by the owning renderer's flush once the batch has
+    /// been handed to the GPU.
+    /// </summary>
+    public void Reset()
+    {
+        vertexCount = 0;
+        indexCount = 0;
+        HasNonQuad = false;
+    }
+}

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Renderer.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Sakura.Framework.Graphics.Rendering.Batches;
 using Sakura.Framework.Graphics.Rendering.Uniforms;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.IO;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
+using Sakura.Framework.Statistic;
 using Sakura.Framework.Timing;
 using Vortice.Direct3D;
 using Vortice.Direct3D11;
@@ -27,6 +29,36 @@ namespace Sakura.Framework.Graphics.Rendering.Direct3D11;
 /// </summary>
 public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
 {
+    private static readonly GlobalStatistic<int> stat_draw_calls = GlobalStatistics.Get<int>("Renderer", "Draw Calls");
+    private static readonly GlobalStatistic<int> stat_vertices_drawn = GlobalStatistics.Get<int>("Renderer", "Vertices Drawn");
+    private static readonly GlobalStatistic<int> stat_slot_exhaustion_flushes = GlobalStatistics.Get<int>("Renderer", "Slot Exhaustion Flushes");
+    private static readonly GlobalStatistic<int> stat_state_change_flushes = GlobalStatistics.Get<int>("Renderer", "State Change Flushes");
+
+    /// <summary>
+    /// The live renderer instance, for static notifications (texture deletion). Effectively a
+    /// singleton, only one D3D11 renderer exists per process.
+    /// </summary>
+    private static D3D11Renderer instance;
+
+    /// <summary>
+    /// Must be called whenever a texture's shader resource view is released. COM addresses are
+    /// recycled, so a new SRV can land on the address of a dead one and if the slot mirror still maps
+    /// that address to a slot, the renderer would skip the bind and draw with whatever now occupies it.
+    /// Draw thread only, same as the release itself.
+    /// </summary>
+    internal static void NotifyTextureDeleted(nint handle)
+    {
+        var renderer = instance;
+        if (renderer == null || handle == nint.Zero)
+            return;
+
+        for (int i = 0; i < renderer.boundTextureHandles.Length; i++)
+        {
+            if (renderer.boundTextureHandles[i] == handle)
+                renderer.boundTextureHandles[i] = -1; // never matches a live SRV
+        }
+    }
+
     private ID3D11Device device;
     private ID3D11DeviceContext context;
 
@@ -69,10 +101,29 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     private const int projection_cb_slot = 0;
     private const int mask_cb_slot = 1;
 
-    // Matches u_Textures[] in shader.frag. D3D11 still draws one texture at slot 0 and forces
-    // TexIndex 0; the remaining slots are padded with the white SRV purely so the shader's declared
-    // array is fully bound.
+    // Matches u_Textures[] in shader.frag: the batch assigns a slot per distinct texture and stamps the
+    // index into every vertex. All 16 are padded with the white SRV at frame start so the shader's
+    // declared array is fully bound whatever the batch ends up using.
     private const int texture_slot_count = 16;
+
+    /// <summary>
+    /// Vertex capacity of <see cref="batch"/>, matching the GL batch (12000 vertices), i.e., 3000 quads
+    /// (indexed, 4 vertices each) before a capacity flush.
+    /// </summary>
+    private const int max_batch_vertices = 1000 * 12;
+
+    /// <summary>
+    /// CPU mirror of the pixel stage's shader-resource slots, dense from 0. The pixel-stage bindings
+    /// survive a draw and a render-target switch, so this only needs clearing when something binds
+    /// behind the renderer's back (the raw custom-shader passes, and <see cref="rebindFrameState"/>).
+    /// </summary>
+    private readonly nint[] boundTextureHandles = new nint[texture_slot_count];
+    private int boundTextureCount;
+
+    /// <summary>
+    /// The frame's pending geometry, indexed (see <see cref="quadIndexBuffer"/>).
+    /// </summary>
+    private VertexBatch batch;
 
     private D3D11Shader mainShader;
     private D3D11Shader currentShader;
@@ -90,7 +141,23 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     private ID3D11Buffer vertexBuffer;
     private int vertexBufferCapacity;
 
-    // White-pixel SRVs bound to all 8 texture slots so the shader's u_Textures[] array is fully bound.
+    /// <summary>
+    /// Immutable index buffer holding the quad pattern (0,1,2, 2,3,0 per quad) for the whole batch
+    /// capacity, mirroring GL's <c>quadEbo</c>. A batch of nothing but quads draws straight from this,
+    /// so the common flush uploads vertices only.
+    /// </summary>
+    private ID3D11Buffer quadIndexBuffer;
+
+    /// <summary>
+    /// Dynamic index buffer for a batch that contains a triangle list (see
+    /// <see cref="VertexBatch.HasNonQuad"/>), whose indices don't follow the static quad pattern.
+    /// </summary>
+    private ID3D11Buffer dynamicIndexBuffer;
+
+    // White-pixel SRVs bound to all texture_slot_count slots in one call, so the shader's u_Textures[]
+    // array is fully bound whatever the batch ends up assigning. Note this padding is not counted by
+    // TextureBindTracker (it doesn't go through D3D11Texture.Bind), unlike Metal's equivalent — so the
+    // two backends' bind figures aren't directly comparable.
     private ID3D11ShaderResourceView[] whiteSrvs;
 
     // No-clip state injected into every vertex, PushMask/PopMask maintain the stack.
@@ -98,8 +165,6 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     private readonly Stack<ClipState> clipStack = new();
 
     private MaskBlock maskState;
-
-    private SakuraVertex[] drawScratch = new SakuraVertex[256];
 
     // Currently-bound render target + viewport, so BindFrameBuffer can save/restore across nesting.
     private ID3D11RenderTargetView currentRtv;
@@ -157,6 +222,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         if (graphicsSurface is not IWin32GraphicsSurface win32Surface)
             throw new InvalidOperationException($"{nameof(D3D11Renderer)} requires an {nameof(IWin32GraphicsSurface)}.");
 
+        instance = this;
         windowHandle = win32Surface.WindowHandle;
 
         var flags = DeviceCreationFlags.BgraSupport;
@@ -182,6 +248,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         createConstantBuffers();
         createMainShader();
         createWhitePixel();
+        createBatch();
     }
 
     private bool tryCreateDevice(DeviceCreationFlags flags, FeatureLevel[] featureLevels)
@@ -402,6 +469,36 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
             whiteSrvs[i] = white.ShaderResourceView;
     }
 
+    private unsafe void createBatch()
+    {
+        batch = new VertexBatch(max_batch_vertices, FlushBatch);
+
+        // Sized to the batch's capacity so a flush never has to reallocate.
+        ensureVertexCapacity(max_batch_vertices);
+
+        dynamicIndexBuffer = device.CreateBuffer(new BufferDescription(
+            (uint)(batch.MaxIndices * sizeof(uint)), BindFlags.IndexBuffer, ResourceUsage.Dynamic, CpuAccessFlags.Write));
+
+        // The static quad pattern, filled once. Immutable: the contents are the same every frame, so an
+        // all-quad batch (the overwhelming majority) uploads vertices only.
+        int maxQuads = max_batch_vertices / 4;
+        uint[] quadIndices = new uint[maxQuads * 6];
+        for (int q = 0; q < maxQuads; q++)
+        {
+            uint baseIndex = (uint)(q * 4);
+            int o = q * 6;
+            quadIndices[o + 0] = baseIndex;
+            quadIndices[o + 1] = baseIndex + 1;
+            quadIndices[o + 2] = baseIndex + 2;
+            quadIndices[o + 3] = baseIndex + 2;
+            quadIndices[o + 4] = baseIndex + 3;
+            quadIndices[o + 5] = baseIndex;
+        }
+
+        quadIndexBuffer = device.CreateBuffer(quadIndices, new BufferDescription(
+            (uint)(quadIndices.Length * sizeof(uint)), BindFlags.IndexBuffer, ResourceUsage.Immutable));
+    }
+
     #endregion
 
     public void Clear()
@@ -469,7 +566,10 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         context.VSSetConstantBuffer(projection_cb_slot, projectionCb);
         context.PSSetConstantBuffer(mask_cb_slot, maskCb);
         context.PSSetSampler(0, linearClampSampler);
+
+        // Every declared slot gets a valid view; the batch overwrites the ones it assigns.
         context.PSSetShaderResources(0, whiteSrvs);
+        resetTextureSlotsToWhite();
 
         context.RSSetState(rasterizerState);
         context.OMSetDepthStencilState(depthStencilOff, 0);
@@ -525,8 +625,17 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         if (device == null || swapChain == null)
             return;
 
+        stat_draw_calls.Value = 0;
+        stat_vertices_drawn.Value = 0;
+        stat_slot_exhaustion_flushes.Value = 0;
+        stat_state_change_flushes.Value = 0;
+
         rootNode?.Draw(this);
 
+        // Anything still pending belongs to this frame — issue it before the present.
+        FlushBatch();
+
+        // After the final flush, so the batch's binds land in this frame's count.
         TextureBindTracker.EndFrame();
 
         // VSync -> sync interval 1, no flags. Uncapped -> interval 0, tear (if the output supports it)
@@ -549,54 +658,84 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
 
     #region Draw path
 
-    public unsafe void DrawVertices(ReadOnlySpan<SakuraVertex> vertices, Texture texture)
+    /// <summary>
+    /// Resolves a texture to a batch slot index, binding it (and flushing on slot exhaustion) as
+    /// required. Mirrors <c>GLRenderer.prepareTexture</c>, keyed on the shader resource view.
+    /// </summary>
+    private float prepareTexture(Texture texture)
+    {
+        var native = texture?.BackendTexture as D3D11Texture;
+
+        // A texture with no D3D11 backing (e.g., a video texture, drawn by VideoDrawNode itself) or one
+        // whose pixels haven't landed yet samples white. D3D11Texture.Bind applies that fallback
+        // internally, so it has to be resolved here too, otherwise the slot would be keyed by a view
+        // that is not what ends up bound to it.
+        if (native == null || !native.Available)
+            native = D3D11Texture.WhitePixel;
+
+        if (native == null)
+            return 0f;
+
+        nint handle = native.Handle;
+
+        for (int i = 0; i < boundTextureCount; i++)
+        {
+            if (boundTextureHandles[i] == handle)
+                return i;
+        }
+
+        if (boundTextureCount < texture_slot_count)
+        {
+            int slot = boundTextureCount;
+            // D3D11Texture.Bind counts the bind itself, so every backend's figure comes from the same place.
+            native.Bind(slot);
+            boundTextureHandles[slot] = handle;
+            boundTextureCount++;
+            return slot;
+        }
+
+        // All slots taken: flush and start a fresh slot set.
+        stat_slot_exhaustion_flushes.Value++;
+        FlushBatch();
+        resetTextureSlots();
+
+        native.Bind(0);
+        boundTextureHandles[0] = handle;
+        boundTextureCount = 1;
+        return 0;
+    }
+
+    public void DrawVertices(ReadOnlySpan<SakuraVertex> vertices, Texture texture)
     {
         if (device == null || vertices.Length == 0)
             return;
 
-        // Bind the draw's texture to slot 0 (falls back to white pixel via D3D11Texture.Bind),
-        // or the white pixel directly for non-D3D11 (e.g. headless proxy) textures.
-        if (texture?.BackendTexture is D3D11Texture native)
-            native.Bind(0);
-        else
-            D3D11Texture.WhitePixel?.Bind(0);
+        float textureIndex = prepareTexture(texture);
 
-        // Force TexIndex 0 (single texture bound at slot 0) and inject the current clip into each
-        // vertex, mirroring the Metal path (no CPU batch, so draw nodes hand over default clip data).
-        if (drawScratch.Length < vertices.Length)
-            drawScratch = new SakuraVertex[Math.Max(vertices.Length, drawScratch.Length * 2)];
-
-        for (int i = 0; i < vertices.Length; i++)
-        {
-            drawScratch[i] = vertices[i];
-            drawScratch[i].TexIndex = 0f;
-            drawScratch[i].ClipData = currentClip.ClipData;
-            drawScratch[i].ClipShearX = currentClip.ShearX;
-            drawScratch[i].ClipRadius = currentClip.Radius;
-        }
-
-        uploadAndDraw(drawScratch.AsSpan(0, vertices.Length));
+        // The clip state is injected per-vertex on the way into the batch (the pixel shader's
+        // applyClipping reads it from the interpolators), exactly as GL's batch does.
+        batch.AddRange(vertices, textureIndex, currentClip.ClipData, currentClip.ShearX, currentClip.Radius);
     }
 
     public void DrawQuads(ReadOnlySpan<SakuraVertex> vertices, Texture texture)
     {
-        Span<SakuraVertex> tri = stackalloc SakuraVertex[6];
+        if (device == null)
+            return;
+
+        float textureIndex = prepareTexture(texture);
+
         for (int i = 0; i + 4 <= vertices.Length; i += 4)
-        {
-            tri[0] = vertices[i];
-            tri[1] = vertices[i + 1];
-            tri[2] = vertices[i + 2];
-            tri[3] = vertices[i + 2];
-            tri[4] = vertices[i + 3];
-            tri[5] = vertices[i];
-            DrawVertices(tri, texture);
-        }
+            batch.AddQuad(vertices.Slice(i, 4), textureIndex, currentClip.ClipData, currentClip.ShearX, currentClip.Radius);
     }
 
-    public unsafe void DrawVerticesRaw(ReadOnlySpan<SakuraVertex> vertices)
+    public void DrawVerticesRaw(ReadOnlySpan<SakuraVertex> vertices)
     {
         if (device == null || vertices.Length == 0)
             return;
+
+        // This draws immediately, so anything still batched would end up *behind* it. Callers already
+        // flush (VideoDrawNode, runShaderPass), but the ordering guarantee belongs here.
+        FlushBatch();
 
         if (vertices.Length == 4)
         {
@@ -608,10 +747,58 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
             tri[4] = vertices[3];
             tri[5] = vertices[0];
             uploadAndDraw(tri);
-            return;
+        }
+        else
+        {
+            uploadAndDraw(vertices);
         }
 
-        uploadAndDraw(vertices);
+        // The caller bound its own textures (the effect source, or the three video planes) straight
+        // onto the pixel stage, so the slot mirror no longer describes it.
+        resetTextureSlots();
+    }
+
+    /// <summary>
+    /// Uploads and draws the pending batch with a single <c>DrawIndexed</c>. Load-bearing: every state
+    /// change the recorded geometry depends on (blend state, render target, mask constant buffer,
+    /// shader) must call this first, or geometry recorded under one state is drawn under another.
+    /// </summary>
+    public unsafe void FlushBatch()
+    {
+        if (device == null || batch == null || batch.IsEmpty)
+            return;
+
+        int stride = SakuraVertex.Size;
+        int vertexCount = batch.VertexCount;
+        int indexCount = batch.IndexCount;
+
+        MappedSubresource mappedVertices = context.Map(vertexBuffer, 0, MapMode.WriteDiscard, Vortice.Direct3D11.MapFlags.None);
+        fixed (SakuraVertex* src = batch.Vertices)
+            Buffer.MemoryCopy(src, (void*)mappedVertices.DataPointer, (long)vertexBufferCapacity * stride, (long)vertexCount * stride);
+        context.Unmap(vertexBuffer, 0);
+
+        if (batch.HasNonQuad)
+        {
+            MappedSubresource mappedIndices = context.Map(dynamicIndexBuffer, 0, MapMode.WriteDiscard, Vortice.Direct3D11.MapFlags.None);
+            fixed (uint* src = batch.Indices)
+                Buffer.MemoryCopy(src, (void*)mappedIndices.DataPointer, (long)batch.MaxIndices * sizeof(uint), (long)indexCount * sizeof(uint));
+            context.Unmap(dynamicIndexBuffer, 0);
+
+            context.IASetIndexBuffer(dynamicIndexBuffer, Format.R32_UInt, 0);
+        }
+        else
+        {
+            // The static quad buffer already holds the exact pattern for indices [0, indexCount).
+            context.IASetIndexBuffer(quadIndexBuffer, Format.R32_UInt, 0);
+        }
+
+        context.IASetVertexBuffer(0, vertexBuffer, (uint)stride, 0);
+        context.DrawIndexed((uint)indexCount, 0, 0);
+
+        stat_draw_calls.Value++;
+        stat_vertices_drawn.Value += vertexCount;
+
+        batch.Reset();
     }
 
     private unsafe void uploadAndDraw(ReadOnlySpan<SakuraVertex> vertices)
@@ -626,6 +813,35 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
 
         context.IASetVertexBuffer(0, vertexBuffer, (uint)stride, 0);
         context.Draw((uint)vertices.Length, 0);
+
+        stat_draw_calls.Value++;
+        stat_vertices_drawn.Value += vertices.Length;
+    }
+
+    /// <summary>
+    /// Drops the CPU mirror of the pixel stage's shader-resource slots. The views themselves stay bound
+    /// and are simply re-tracked (or replaced) on their next use.
+    /// </summary>
+    private void resetTextureSlots()
+    {
+        boundTextureCount = 0;
+        Array.Clear(boundTextureHandles, 0, boundTextureHandles.Length);
+    }
+
+    /// <summary>
+    /// Drops the slot mirror and records the white pixel as the slot-0 occupant, matching the
+    /// <c>PSSetShaderResources(0, whiteSrvs)</c> that <see cref="rebindFrameState"/> has just issued.
+    /// Solid-color drawables then cost no bind at all.
+    /// </summary>
+    private void resetTextureSlotsToWhite()
+    {
+        resetTextureSlots();
+
+        if (D3D11Texture.WhitePixel == null)
+            return;
+
+        boundTextureHandles[0] = D3D11Texture.WhitePixel.Handle;
+        boundTextureCount = 1;
     }
 
     private void ensureVertexCapacity(int vertexCount)
@@ -644,13 +860,12 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         if (blendingMode == currentBlendMode)
             return;
 
+        // The blend state applies at draw time, so the pending batch must go out under the old mode.
+        stat_state_change_flushes.Value++;
+        FlushBatch();
+
         currentBlendMode = blendingMode;
         context.OMSetBlendState(blendStates[(int)currentBlendMode]);
-    }
-
-    public void FlushBatch()
-    {
-        // Draws are issued immediately (no CPU batch), so nothing is buffered to flush.
     }
 
     public void RestoreMainShader()
@@ -658,7 +873,6 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         // A custom shader's SetUniformBlock rebinds its own CBs to VS b0 / PS b1, so restore the full
         // main-shader frame state (shader, CBs, sampler, textures) not just the projection content.
         currentShader = mainShader;
-        maskState.IsMasking = 0;
         maskState.IsBorder = 0;
         maskState.IsEdgeEffect = 0;
         rebindFrameState();
@@ -728,6 +942,10 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         if (borderThickness <= 0 || vertices.Length < 4)
             return;
 
+        // The MaskBlock upload below applies at draw time, so pending geometry has to be drawn under
+        // the previous mask state first.
+        FlushBatch();
+
         maskState.IsBorder = 1;
         maskState.MaskCenter = new Vector2(maskCenter.X, maskCenter.Y);
         maskState.MaskHalfSize = new Vector2(maskHalfSize.X, maskHalfSize.Y);
@@ -738,6 +956,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         uploadMaskState();
 
         DrawQuads(vertices[..4], WhitePixel);
+        FlushBatch();
 
         maskState.IsBorder = 0;
         uploadMaskState();
@@ -750,6 +969,10 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     {
         if (color.A == 0 || quadVertices.Length < 4)
             return;
+
+        // As in drawBorder: the MaskBlock upload (and the glow blend swap) would otherwise apply
+        // retroactively to pending geometry.
+        FlushBatch();
 
         var previousBlend = currentBlendMode;
         if (glow)
@@ -768,6 +991,7 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         uploadMaskState();
 
         DrawQuads(quadVertices[..4], WhitePixel);
+        FlushBatch();
 
         maskState.IsEdgeEffect = 0;
         uploadMaskState();
@@ -823,6 +1047,9 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         if (device == null || frameBuffer is not D3D11FrameBuffer fb)
             return;
 
+        // Anything batched so far targets the previous render target — flush it there first.
+        FlushBatch();
+
         frameBufferStack.Push(new FrameBufferState(currentRtv, currentViewportW, currentViewportH, projectionMatrix, currentClip));
 
         projectionMatrix = Matrix4x4.CreateOrthographicOffCenter(
@@ -840,6 +1067,9 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
     {
         if (device == null || frameBufferStack.Count == 0)
             return;
+
+        // Pending geometry belongs to the framebuffer — draw it before switching away.
+        FlushBatch();
 
         var state = frameBufferStack.Pop();
         projectionMatrix = state.Projection;
@@ -864,6 +1094,11 @@ public sealed class D3D11Renderer : ID3D11Renderer, IDisposable
         projectionCb?.Dispose();
         maskCb?.Dispose();
         vertexBuffer?.Dispose();
+        quadIndexBuffer?.Dispose();
+        dynamicIndexBuffer?.Dispose();
+
+        if (instance == this)
+            instance = null;
 
         backBufferRtv?.Dispose();
         waitableSwapChain?.Dispose();

--- a/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Texture.cs
+++ b/Sakura.Framework/Graphics/Rendering/Direct3D11/D3D11Texture.cs
@@ -164,6 +164,9 @@ public sealed class D3D11Texture : INativeTexture
         // Nothing can be sampled from a released texture; see MetalTexture.Dispose.
         Available = false;
 
+        // Before the next view can recycle the COM address (see NotifyTextureDeleted).
+        D3D11Renderer.NotifyTextureDeleted(srv?.NativePointer ?? nint.Zero);
+
         rtv?.Dispose();
         rtv = null;
         srv?.Dispose();

--- a/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/GLRenderer.cs
@@ -308,7 +308,6 @@ public class GLRenderer : IGLRenderer, IDisposable
         uploadProjection();
         projectionBuffer.Bind();
 
-        maskState.IsMasking = 0;
         maskState.IsBorder = 0;
         uploadMaskState();
         maskBuffer.Bind();
@@ -380,7 +379,6 @@ public class GLRenderer : IGLRenderer, IDisposable
             ShearX = 0,
             Radius = 0
         };
-        maskState.IsMasking = 0;
         maskState.IsBorder = 0;
         uploadMaskState();
         maskBuffer.Bind();

--- a/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
+++ b/Sakura.Framework/Graphics/Rendering/Metal/MetalRenderer.cs
@@ -7,12 +7,14 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using Sakura.Framework.Graphics.Colors;
+using Sakura.Framework.Graphics.Rendering.Batches;
 using Sakura.Framework.Graphics.Rendering.Uniforms;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.IO;
 using Sakura.Framework.Logging;
 using Sakura.Framework.Maths;
 using Sakura.Framework.Platform;
+using Sakura.Framework.Statistic;
 using Sakura.Framework.Timing;
 using SakuraVertex = Sakura.Framework.Graphics.Rendering.Vertex.Vertex;
 
@@ -23,11 +25,70 @@ namespace Sakura.Framework.Graphics.Rendering.Metal;
 /// </summary>
 public sealed class MetalRenderer : IMetalRenderer
 {
+    private static readonly GlobalStatistic<int> stat_draw_calls = GlobalStatistics.Get<int>("Renderer", "Draw Calls");
+    private static readonly GlobalStatistic<int> stat_vertices_drawn = GlobalStatistics.Get<int>("Renderer", "Vertices Drawn");
+    private static readonly GlobalStatistic<int> stat_slot_exhaustion_flushes = GlobalStatistics.Get<int>("Renderer", "Slot Exhaustion Flushes");
+    private static readonly GlobalStatistic<int> stat_state_change_flushes = GlobalStatistics.Get<int>("Renderer", "State Change Flushes");
+
+    /// <summary>
+    /// The live renderer instance, for static notifications (texture deletion). Effectively a
+    /// singleton: only one Metal renderer exists per process.
+    /// </summary>
+    private static MetalRenderer instance;
+
+    /// <summary>
+    /// Must be called whenever an <c>MTLTexture</c> is destroyed. A freed texture's address can be
+    /// handed straight back to the next allocation, so a new texture (a glyph atlas page, a recreated
+    /// framebuffer attachment) can carry the same handle as a dead one — and if the slot mirror still
+    /// maps that handle to a slot, the renderer would skip the bind and draw with whatever now occupies
+    /// it. Draw thread only, same as the destruction itself.
+    /// </summary>
+    internal static void NotifyTextureDeleted(nint handle)
+    {
+        var renderer = instance;
+        if (renderer == null || handle == nint.Zero)
+            return;
+
+        for (int i = 0; i < renderer.boundTextureHandles.Length; i++)
+        {
+            if (renderer.boundTextureHandles[i] == handle)
+                renderer.boundTextureHandles[i] = -1; // never matches a live handle
+        }
+    }
+
     private nint device; // SakuraMetalDevice*
     private MetalShader mainShader;
 
     private MetalShader currentShader;
     private BlendingMode currentBlendMode = BlendingMode.Alpha;
+
+    /// <summary>
+    /// Vertex capacity of <see cref="batch"/>. Matches the GL batch's 12000, which at 6 vertices per
+    /// quad (Metal is non-indexed, see <see cref="FlushBatch"/>) is 2000 quads before a capacity flush.
+    /// </summary>
+    private const int max_batch_vertices = 1000 * 12;
+
+    /// <summary>
+    /// Matches <c>u_Textures[]</c> in shader.frag, which the cross-compiled MSL declares as
+    /// <c>array&lt;texture2d&lt;float&gt;, 16&gt; [[texture(0)]]</c> with a matching sampler array.
+    /// </summary>
+    private const int max_texture_slots = 16;
+
+    /// <summary>
+    /// CPU mirror of the encoder's fragment-texture argument table: <c>MTLTexture*</c> per slot, dense
+    /// from 0. A render pass switch opens a fresh encoder and drops every binding, so this is cleared
+    /// by <see cref="resetTextureSlots"/> wherever that happens (and wherever something binds a texture
+    /// behind the renderer's back, i.e., the raw custom-shader passes).
+    /// </summary>
+    private readonly nint[] boundTextureHandles = new nint[max_texture_slots];
+    private int boundTextureCount;
+
+    /// <summary>
+    /// The frame's pending geometry. Unlike GL, this batch is non-indexed — the bridge's
+    /// <c>sakura_metal_draw_triangles</c> is a <c>drawPrimitives</c> call — so quads arrive expanded to
+    /// 6 vertices and <see cref="FlushBatch"/> issues one <c>drawPrimitives</c> for the lot.
+    /// </summary>
+    private VertexBatch batch;
 
     private readonly ConcurrentQueue<Action> drawThreadQueue = new();
     private readonly Sakura.Framework.Graphics.Textures.TextureUploadQueue textureUploadQueue = new();
@@ -98,6 +159,8 @@ public sealed class MetalRenderer : IMetalRenderer
         if (graphicsSurface is not IMetalGraphicsSurface metalSurface)
             throw new InvalidOperationException($"{nameof(MetalRenderer)} requires an {nameof(IMetalGraphicsSurface)}.");
 
+        instance = this;
+
         SakuraMetalNative.SetupLibraryResolvers();
 
         device = SakuraMetalNative.sakura_metal_create(metalSurface.MetalLayer);
@@ -106,12 +169,14 @@ public sealed class MetalRenderer : IMetalRenderer
 
         // Cross-compile the main shader to MSL (cached) and build the pipeline with a vertex layout
         // matching the Vertex struct (attribute index = GLSL location, offset = struct field offset).
-        var (vertMsl, fragMsl) = ShaderCompiler.GetOrCompile(
+        (string vertMsl, string fragMsl) = ShaderCompiler.GetOrCompile(
             ShaderStorage, "shader.vert", "shader.frag", SPIRV.CrossCompileTarget.MSL, ShaderCache);
 
         var attributes = buildVertexAttributes();
         mainShader = new MetalShader(device, vertMsl, fragMsl, attributes, SakuraVertex.Size, mainShaderUniformBindings());
         currentShader = mainShader;
+
+        batch = new VertexBatch(max_batch_vertices, FlushBatch, indexed: false);
 
         // 1x1 white pixel. The main shader always samples u_Textures[index]; solid-color drawables
         // sample this white texel so the result is white × v_Color. Bound to slot 0 each frame.
@@ -238,9 +303,9 @@ public sealed class MetalRenderer : IMetalRenderer
 
         // Release native resources orphaned by the GC (a missed Dispose) before anything else this
         // frame, so their memory is freed before new allocations are made against it.
-        Sakura.Framework.Graphics.Textures.NativeDisposalQueue.Process();
+        NativeDisposalQueue.Process();
 
-        // Drain queued uploads (textures, glyphs) on the draw thread, before the render pass opens.
+        // Drain queued uploads (textures, glyphs) on the draw thread before the render pass opens.
         while (drawThreadQueue.TryDequeue(out var action))
             action();
 
@@ -279,11 +344,44 @@ public sealed class MetalRenderer : IMetalRenderer
         uploadProjection();
         uploadMaskState();
 
-        // Bind the white pixel to slot 0 so solid-color drawables (TexIndex 0) sample white.
-        (WhitePixel?.BackendTexture as MetalTexture)?.Bind(0);
+        // The new encoder's fragment-texture table is empty, so the CPU mirror must start empty too
+        // otherwise the next draw would trust a slot assignment that no longer exists on the GPU.
+        fillTextureSlotsWithWhite();
     }
 
-    // Binds the pipeline variant for the current (shader, blend mode) pair to the encoder.
+    /// <summary>
+    /// Binds the white pixel to every one of the 16 fragment texture/sampler slots and resets the slot
+    /// mirror to "slot 0 holds white". Called after every render-pass switch, which is what empties the
+    /// encoder's argument table.
+    /// </summary>
+    /// <remarks>
+    /// All 16, not just the ones in use, because Metal API Validation rejects a draw whose fragment
+    /// function statically references an unbound slot — the cross-compiled MSL's <c>if</c> -chain
+    /// references all 16 of <c>u_Textures[]</c>, so all 16 samplers must be bound even though only the
+    /// selected index is ever read. (This is the mitigation RB-7's first open question called for; with
+    /// <c>METAL_DEVICE_WRAPPER_TYPE=1</c> the old single-slot path asserted with
+    /// <i>"missing Sampler binding at index 2..15"</i>.) Mirrors what D3D11 already does with
+    /// <c>whiteSrvs</c>.
+    /// </remarks>
+    private void fillTextureSlotsWithWhite()
+    {
+        resetTextureSlots();
+
+        if (WhitePixel?.BackendTexture is not MetalTexture white)
+            return;
+
+        for (int i = 0; i < max_texture_slots; i++)
+            white.Bind(i);
+
+        // Slot 0 is recorded as taken, so the very common white-pixel draw costs no further bind. The
+        // rest stay "free" and are overwritten by prepareTexture as it hands them out.
+        boundTextureHandles[0] = white.Handle;
+        boundTextureCount = 1;
+    }
+
+    /// <summary>
+    /// Binds the pipeline variant for the current (shader, blend mode) pair to the encoder
+    /// </summary>
     private void bindPipeline()
     {
         if (currentShader != null)
@@ -325,67 +423,103 @@ public sealed class MetalRenderer : IMetalRenderer
         if (device == nint.Zero)
             return;
 
+        stat_draw_calls.Value = 0;
+        stat_vertices_drawn.Value = 0;
+        stat_slot_exhaustion_flushes.Value = 0;
+        stat_state_change_flushes.Value = 0;
+
         rootNode?.Draw(this);
 
-        // Metal draws immediately, so every bind for the frame has already been issued by here.
+        // Anything still pending belongs to this frame's drawable — issue it before the pass closes.
+        FlushBatch();
+
+        // Done after the final flush, so the batch's binds land in this frame's count rather than the
+        // next one's.
         TextureBindTracker.EndFrame();
 
         SakuraMetalNative.sakura_metal_end_frame(device);
     }
 
     /// <summary>
-    /// Scratch buffer for forcing TexIndex to 0 on the drawn vertices (see below). Reused across draws.
+    /// Resolves a texture to a batch slot index, binding it (and flushing on slot exhaustion) as
+    /// required. Mirrors <c>GLRenderer.prepareTexture</c>; the slot key here is the <c>MTLTexture*</c>
+    /// rather than a GL name.
     /// </summary>
-    private SakuraVertex[] drawScratch = new SakuraVertex[256];
+    private float prepareTexture(Texture texture)
+    {
+        var native = texture?.BackendTexture as MetalTexture;
 
-    public unsafe void DrawVertices(ReadOnlySpan<SakuraVertex> vertices, Texture texture)
+        // A texture with no Metal backing (e.g., a video texture, drawn by VideoDrawNode itself) or one
+        // whose pixels haven't landed yet samples white. MetalTexture.Bind applies that fallback
+        // internally, so it has to be resolved here too — otherwise the slot would be keyed by a handle
+        // that is not what ends up bound to it.
+        if (native == null || !native.Available)
+            native = MetalTexture.WhitePixel;
+
+        if (native == null)
+            return 0f;
+
+        nint handle = native.Handle;
+
+        for (int i = 0; i < boundTextureCount; i++)
+        {
+            if (boundTextureHandles[i] == handle)
+                return i;
+        }
+
+        if (boundTextureCount < max_texture_slots)
+        {
+            int slot = boundTextureCount;
+            // MetalTexture.Bind counts the bind itself, so every backend's figure comes from the same place.
+            native.Bind(slot);
+            boundTextureHandles[slot] = handle;
+            boundTextureCount++;
+            return slot;
+        }
+
+        // All slots taken: flush and start a fresh slot set.
+        stat_slot_exhaustion_flushes.Value++;
+        FlushBatch();
+        resetTextureSlots();
+
+        native.Bind(0);
+        boundTextureHandles[0] = handle;
+        boundTextureCount = 1;
+        return 0;
+    }
+
+    public void DrawVertices(ReadOnlySpan<SakuraVertex> vertices, Texture texture)
     {
         if (device == nint.Zero || vertices.Length == 0)
             return;
 
-        // One texture per draw on Metal (no multi-texture batching yet): bind it to slot 0.
-        var native = (texture?.BackendTexture ?? WhitePixel.BackendTexture) as MetalTexture;
-        native?.Bind(0);
+        float textureIndex = prepareTexture(texture);
 
-        // The vertices may carry a TexIndex chosen for the GL batch's slot assignment. Since we bind
-        // a single texture to slot 0, force TexIndex 0 so the shader samples the texture we bound,
-        // not an unbound slot. Copy into a reusable scratch buffer to avoid mutating the caller's span.
-        //
-        // We also inject the current clip state into each vertex here. Unlike GL — where TriangleBatch
-        // writes currentClip.ClipData into every vertex on its way into the batch — the Metal path has
-        // no batch, so the draw nodes hand over vertices with default (zero) clip data. The fragment
-        // shader's applyClipping reads these per-vertex attributes, so without this injection masking
-        // would silently do nothing. ClipData (0,0,-1,-1) means "no active clip" to the shader.
-        if (drawScratch.Length < vertices.Length)
-            drawScratch = new SakuraVertex[Math.Max(vertices.Length, drawScratch.Length * 2)];
-
-        for (int i = 0; i < vertices.Length; i++)
-        {
-            drawScratch[i] = vertices[i];
-            drawScratch[i].TexIndex = 0f;
-            drawScratch[i].ClipData = currentClip.ClipData;
-            drawScratch[i].ClipShearX = currentClip.ShearX;
-            drawScratch[i].ClipRadius = currentClip.Radius;
-        }
-
-        fixed (SakuraVertex* ptr = drawScratch)
-            SakuraMetalNative.sakura_metal_draw_triangles(device, ptr, vertices.Length, SakuraVertex.Size);
+        // The clip state is injected per-vertex on the way into the batch (the fragment shader's
+        // applyClipping reads v_ClipData/v_ClipShearX/v_ClipRadius), exactly as GL's batch does.
+        batch.AddRange(vertices, textureIndex, currentClip.ClipData, currentClip.ShearX, currentClip.Radius);
     }
 
     public void DrawQuads(ReadOnlySpan<SakuraVertex> vertices, Texture texture)
     {
-        // Expand each quad (TL, TR, BR, BL) into two triangles, since the bridge draws triangle lists.
-        Span<SakuraVertex> tri = stackalloc SakuraVertex[6];
+        if (device == nint.Zero)
+            return;
+
+        float textureIndex = prepareTexture(texture);
+
+        // The batch is non-indexed, so AddQuad expands each quad (TL, TR, BR, BL) into two triangles.
         for (int i = 0; i + 4 <= vertices.Length; i += 4)
-        {
-            tri[0] = vertices[i];
-            tri[1] = vertices[i + 1];
-            tri[2] = vertices[i + 2];
-            tri[3] = vertices[i + 2];
-            tri[4] = vertices[i + 3];
-            tri[5] = vertices[i];
-            DrawVertices(tri, texture);
-        }
+            batch.AddQuad(vertices.Slice(i, 4), textureIndex, currentClip.ClipData, currentClip.ShearX, currentClip.Radius);
+    }
+
+    /// <summary>
+    /// Drops the CPU mirror of the encoder's fragment-texture table. The textures themselves stay bound
+    /// on the encoder and are simply re-tracked (or replaced) on their next use.
+    /// </summary>
+    private void resetTextureSlots()
+    {
+        boundTextureCount = 0;
+        Array.Clear(boundTextureHandles, 0, boundTextureHandles.Length);
     }
 
     #region Masking / borders
@@ -475,6 +609,10 @@ public sealed class MetalRenderer : IMetalRenderer
         if (borderThickness <= 0 || vertices.Length < 4)
             return;
 
+        // The MaskBlock upload below applies to every draw the encoder has not yet issued, so pending
+        // geometry has to be drawn under the *previous* mask state first.
+        FlushBatch();
+
         // Enter the border pass: populate and upload the MaskBlock the fragment shader reads.
         maskState.IsBorder = 1;
         maskState.MaskCenter = new Vector2(maskCenter.X, maskCenter.Y);
@@ -491,6 +629,7 @@ public sealed class MetalRenderer : IMetalRenderer
         // Draw the single mask quad (TL, TR, BR, BL). The border ring is shaded by the SDF, and the
         // current clip is applied per-vertex (the border honours any enclosing parent mask).
         DrawQuads(vertices[..4], WhitePixel);
+        FlushBatch();
 
         // Leave the border pass so subsequent draws render normally.
         maskState.IsBorder = 0;
@@ -506,6 +645,10 @@ public sealed class MetalRenderer : IMetalRenderer
     {
         if (color.A == 0 || quadVertices.Length < 4)
             return;
+
+        // As in drawBorder: the MaskBlock upload (and the glow blend swap) would otherwise apply
+        // retroactively to pending geometry.
+        FlushBatch();
 
         var previousBlend = currentBlendMode;
         if (glow)
@@ -524,6 +667,7 @@ public sealed class MetalRenderer : IMetalRenderer
         uploadMaskState();
 
         DrawQuads(quadVertices[..4], WhitePixel);
+        FlushBatch();
 
         maskState.IsEdgeEffect = 0;
         uploadMaskState();
@@ -544,6 +688,11 @@ public sealed class MetalRenderer : IMetalRenderer
     {
         if (blendingMode == currentBlendMode)
             return;
+
+        // Blend is baked into the pipeline, and the pipeline applies to every draw the encoder has not
+        // yet issued so the pending batch must go out under the old mode first.
+        stat_state_change_flushes.Value++;
+        FlushBatch();
 
         currentBlendMode = blendingMode;
         bindPipeline();
@@ -566,6 +715,9 @@ public sealed class MetalRenderer : IMetalRenderer
     {
         if (device == nint.Zero || frameBuffer is not MetalFrameBuffer metalFrameBuffer)
             return;
+
+        // Anything batched so far targets the previous render target — flush it there first.
+        FlushBatch();
 
         frameBufferStack.Push(new FrameBufferState
         {
@@ -614,6 +766,9 @@ public sealed class MetalRenderer : IMetalRenderer
         if (device == nint.Zero || frameBufferStack.Count == 0)
             throw new InvalidOperationException($"{nameof(UnbindFrameBuffer)} was called without a matching {nameof(BindFrameBuffer)}.");
 
+        // Pending geometry belongs to the framebuffer — draw it before the pass is closed.
+        FlushBatch();
+
         SakuraMetalNative.sakura_metal_end_offscreen(device);
 
         var state = frameBufferStack.Pop();
@@ -648,6 +803,9 @@ public sealed class MetalRenderer : IMetalRenderer
     /// </summary>
     internal void UseShader(MetalShader shader)
     {
+        // Pending geometry was recorded for the main shader's pipeline; draw it before switching.
+        FlushBatch();
+
         currentShader = shader;
         bindPipeline();
     }
@@ -662,9 +820,13 @@ public sealed class MetalRenderer : IMetalRenderer
         bindPipeline();
         uploadProjection();
 
-        maskState.IsMasking = 0;
         maskState.IsBorder = 0;
         uploadMaskState();
+
+        // The custom pass bound its own source texture(s) to slots 0..2 without going through
+        // prepareTexture, so the CPU mirror no longer describes the encoder. No re-padding needed —
+        // the pass replaced bindings rather than clearing them, so every slot still holds something.
+        resetTextureSlots();
     }
 
     /// <summary>
@@ -676,6 +838,10 @@ public sealed class MetalRenderer : IMetalRenderer
     {
         if (device == nint.Zero || vertices.Length == 0)
             return;
+
+        // This draws immediately, so anything still batched would end up *behind* it. Callers already
+        // flush (VideoDrawNode, runShaderPass), but the ordering guarantee belongs here.
+        FlushBatch();
 
         if (vertices.Length == 4)
         {
@@ -690,11 +856,25 @@ public sealed class MetalRenderer : IMetalRenderer
 
             fixed (SakuraVertex* ptr = tri)
                 SakuraMetalNative.sakura_metal_draw_triangles(device, ptr, 6, SakuraVertex.Size);
+
+            rawDrawDone();
             return;
         }
 
         fixed (SakuraVertex* ptr = vertices)
             SakuraMetalNative.sakura_metal_draw_triangles(device, ptr, vertices.Length, SakuraVertex.Size);
+
+        rawDrawDone();
+    }
+
+    /// <summary>
+    /// Bookkeeping after a raw draw: the caller bound its own textures (the effect source, or the three
+    /// video planes) straight onto the encoder, so the slot mirror no longer describes it.
+    /// </summary>
+    private void rawDrawDone()
+    {
+        stat_draw_calls.Value++;
+        resetTextureSlots();
     }
 
     #endregion
@@ -705,9 +885,32 @@ public sealed class MetalRenderer : IMetalRenderer
 
     public void ScheduleTextureUpload(Action upload, long approximateBytes) => textureUploadQueue.Enqueue(upload, approximateBytes);
 
-    public void FlushBatch()
+    /// <summary>
+    /// Uploads the pending batch and issues a single <c>drawPrimitives</c> for it. Load-bearing: every
+    /// state change the recorded geometry depends on (blend mode, render target, mask block, shader)
+    /// must call this first, or geometry recorded under one state is drawn under another.
+    /// </summary>
+    /// <remarks>
+    /// The texture slot assignment deliberately survives a flush. The encoder's argument table is
+    /// unchanged by a draw, so a texture already bound to slot 3 is still there for the next batch —
+    /// only an encoder switch (or a raw pass binding textures behind our back) invalidates it, and
+    /// those call <see cref="resetTextureSlots"/> themselves. GL resets on every flush because its
+    /// slot tracking is cheap to rebuild; here, not resetting is what keeps the bind count down.
+    /// </remarks>
+    public unsafe void FlushBatch()
     {
-        // Metal draws immediately (no batch), so there's nothing buffered to flush.
+        if (device == nint.Zero || batch == null || batch.IsEmpty)
+            return;
+
+        int vertexCount = batch.VertexCount;
+
+        fixed (SakuraVertex* ptr = batch.Vertices)
+            SakuraMetalNative.sakura_metal_draw_triangles(device, ptr, vertexCount, SakuraVertex.Size);
+
+        stat_draw_calls.Value++;
+        stat_vertices_drawn.Value += vertexCount;
+
+        batch.Reset();
     }
 
     public INativeVideoTexture CreateVideoTexture(int width, int height) => new MetalVideoTexture(device, width, height);

--- a/Sakura.Framework/Graphics/Rendering/Uniforms/UniformBlocks.cs
+++ b/Sakura.Framework/Graphics/Rendering/Uniforms/UniformBlocks.cs
@@ -33,7 +33,7 @@ public struct ProjectionBlock
 }
 
 /// <summary>
-/// Masking + border state for the main shader. Matches <c>MaskBlock</c> in shader.frag.
+/// Border + edge-effect state for the main shader. Matches <c>MaskBlock</c> in shader.frag.
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 80)]
 public struct MaskBlock
@@ -76,46 +76,41 @@ public struct MaskBlock
     public float BorderThickness;
 
     /// <summary>
-    /// Masking enabled (0/1). Maps to <c>int u_IsMasking</c> (GLSL bool).
-    /// </summary>
-    [FieldOffset(44)]
-    public int IsMasking;
-
-    /// <summary>
     /// Border pass enabled (0/1). Maps to <c>int u_IsBorder</c> (GLSL bool).
     /// </summary>
-    [FieldOffset(48)]
+    [FieldOffset(44)]
     public int IsBorder;
 
     /// <summary>
     /// Edge-effect pass enabled (0/1). Maps to <c>int u_IsEdgeEffect</c> (GLSL bool).
     /// </summary>
-    [FieldOffset(52)]
+    [FieldOffset(48)]
     public int IsEdgeEffect;
 
     /// <summary>
     /// Edge-effect soft falloff radius in screen pixels. Maps to <c>float u_EdgeRadius</c>.
     /// </summary>
-    [FieldOffset(56)]
+    [FieldOffset(52)]
     public float EdgeRadius;
 
     /// <summary>
     /// Edge-effect offset in screen space (added to the shape centre). Maps to <c>vec2 u_EdgeOffset</c>.
-    /// Aligned to 8 bytes per std140; placed at offset 64 so it does not straddle a 16-byte boundary.
+    /// Aligned to 8 bytes per std140; offset 56 satisfies that and keeps it inside one 16-byte block
+    /// (48..63) rather than straddling a boundary.
     /// </summary>
-    [FieldOffset(64)]
+    [FieldOffset(56)]
     public Vector2 EdgeOffset;
 
     /// <summary>
     /// Hollow edge effect (cut out the interior) (0/1). Maps to <c>int u_EdgeHollow</c> (GLSL bool).
     /// </summary>
-    [FieldOffset(72)]
+    [FieldOffset(64)]
     public int EdgeHollow;
 
     /// <summary>
     /// Glow (1) vs shadow (0) edge effect. Affects falloff shaping. Maps to <c>int u_EdgeGlow</c> (GLSL bool).
     /// </summary>
-    [FieldOffset(76)]
+    [FieldOffset(68)]
     public int EdgeGlow;
 }
 

--- a/Sakura.Framework/Graphics/Textures/MetalTexture.cs
+++ b/Sakura.Framework/Graphics/Textures/MetalTexture.cs
@@ -143,7 +143,11 @@ public sealed class MetalTexture : INativeTexture
         memoryLease?.Dispose();
 
         if (claimed != nint.Zero)
+        {
+            // Before the address can be recycled by the next allocation (see NotifyTextureDeleted).
+            MetalRenderer.NotifyTextureDeleted(claimed);
             SakuraMetalNative.sakura_metal_destroy_texture(claimed);
+        }
     }
 
     ~MetalTexture()
@@ -153,6 +157,12 @@ public sealed class MetalTexture : INativeTexture
         memoryLease?.Dispose();
 
         if (claimed != nint.Zero)
-            NativeDisposalQueue.Enqueue(() => SakuraMetalNative.sakura_metal_destroy_texture(claimed));
+        {
+            NativeDisposalQueue.Enqueue(() =>
+            {
+                MetalRenderer.NotifyTextureDeleted(claimed);
+                SakuraMetalNative.sakura_metal_destroy_texture(claimed);
+            });
+        }
     }
 }

--- a/Sakura.Framework/Resources/Shaders/shader.frag
+++ b/Sakura.Framework/Resources/Shaders/shader.frag
@@ -14,20 +14,19 @@ layout(location = 0) out vec4 FragColor;
 
 layout(set = 1, binding = 0) uniform sampler2D u_Textures[16];
 
-// Masking + border state. Field order matches the std140 layout in MaskBlock in C#
+// Border + edge-effect state. Field order matches the std140 layout in MaskBlock in C#
 //   vec4 u_BorderColor (offset 0)
 //   vec2 u_MaskCenter (offset 16)
 //   vec2 u_MaskHalfSize (offset 24)
 //   float u_ShearX (offset 32)
 //   float u_CornerRadius (offset 36)
 //   float u_BorderThickness(offset 40)
-//   int u_IsMasking (offset 44)
-//   int u_IsBorder (offset 48)
-//   int u_IsEdgeEffect (offset 52)
-//   float u_EdgeRadius (offset 56)
-//   vec2 u_EdgeOffset (offset 64)
-//   int u_EdgeHollow (offset 72)
-//   int u_EdgeGlow (offset 76)
+//   int u_IsBorder (offset 44)
+//   int u_IsEdgeEffect (offset 48)
+//   float u_EdgeRadius (offset 52)
+//   vec2 u_EdgeOffset (offset 56)
+//   int u_EdgeHollow (offset 64)
+//   int u_EdgeGlow (offset 68)
 layout(set = 0, binding = 1, std140) uniform MaskBlock
 {
     vec4 u_BorderColor;
@@ -36,7 +35,6 @@ layout(set = 0, binding = 1, std140) uniform MaskBlock
     float u_ShearX;
     float u_CornerRadius;
     float u_BorderThickness;
-    int u_IsMasking;
     int u_IsBorder;
     int u_IsEdgeEffect;
     float u_EdgeRadius;
@@ -126,17 +124,6 @@ void main()
     else texColor = vec4(1.0);
 
     texColor *= v_Color;
-
-    if (u_IsMasking != 0 && u_CornerRadius > 0.0)
-    {
-        vec2 posInRect = v_FragPos - u_MaskCenter;
-        float sk = u_ShearX * u_MaskHalfSize.y;
-
-        float dist = sdRoundParallelogram(posInRect, u_MaskHalfSize, sk, u_CornerRadius);
-
-        // Discard fragments outside the sheared rounded rectangle
-        if (dist > 0.0) discard;
-    }
 
     FragColor = texColor;
 

--- a/native/sakura-metal/SakuraMetal.m
+++ b/native/sakura-metal/SakuraMetal.m
@@ -41,6 +41,11 @@ static const NSUInteger SAKURA_METAL_VERTEX_BUFFER_INDEX = 30;
 // can stall; >3 adds latency for no gain).
 #define SAKURA_METAL_MAX_FRAMES_IN_FLIGHT 3
 
+// How many one-off overflow vertex buffers a single frame may allocate when its ring slot is too
+// small (see the overflow notes on SakuraMetalDevice). In steady state this is zero — the ring grows
+// to the previous frame's peak — so this only has to cover a startup frame or a sudden spike.
+#define SAKURA_METAL_MAX_OVERFLOW_BUFFERS 8
+
 struct SakuraMetalPipeline
 {
     __unsafe_unretained id<MTLRenderPipelineState> state;
@@ -103,10 +108,19 @@ struct SakuraMetalDevice
     //
     // Within a frame the active buffer never reallocates (that would strand already-recorded draws on a
     // freed buffer — a use-after-free). It is grown only at the START of a frame, sized to the previous
-    // frame's peak; a draw that would overflow the current frame's buffer is skipped, and the recorded
-    // peak ensures next time round the ring the buffer is large enough.
+    // frame's peak; a draw that would overflow the current frame's buffer gets its own one-off
+    // OVERFLOW BUFFER (see below), and the recorded peak ensures next time round the ring the buffer is
+    // large enough.
     __unsafe_unretained id<MTLBuffer> ringBuffers[SAKURA_METAL_MAX_FRAMES_IN_FLIGHT];
     NSUInteger ringCapacity[SAKURA_METAL_MAX_FRAMES_IN_FLIGHT]; // allocated size of each ring buffer
+
+    // the first frame (the ring is
+    // still empty), and spikes above the 1.5x headroom. Dropping such a draw was survivable when a
+    // draw was one quad; now that the host batches, a dropped draw is most of a frame's geometry, so
+    // it is served from a dedicated buffer instead. Released in end_frame — the command buffer retains
+    // the resources its encoders reference, so the GPU can still be reading them.
+    __unsafe_unretained id<MTLBuffer> overflowBuffers[SAKURA_METAL_MAX_OVERFLOW_BUFFERS];
+    int overflowCount;
     __unsafe_unretained dispatch_semaphore_t frameSemaphore; // limits CPU to MAX_FRAMES_IN_FLIGHT ahead of GPU
     BOOL semaphoreWaitedThisFrame;             // did begin_frame take the semaphore? (balance the signal)
     int frameIndex;                            // increments per frame; ring slot = frameIndex % count
@@ -258,6 +272,11 @@ void sakura_metal_destroy(SakuraMetalDevice* device)
         if (device->ringBuffers[i])
             CFRelease((__bridge CFTypeRef)device->ringBuffers[i]);
 
+    // Defensive: end_frame clears these, but destroy may land on a frame that never ended.
+    for (int i = 0; i < device->overflowCount; i++)
+        if (device->overflowBuffers[i])
+            CFRelease((__bridge CFTypeRef)device->overflowBuffers[i]);
+
     if (device->frameSemaphore)
         CFRelease((__bridge CFTypeRef)device->frameSemaphore);
 
@@ -384,6 +403,7 @@ void sakura_metal_begin_frame(SakuraMetalDevice* device, float r, float g, float
     // Start this frame's vertex allocations from the top of the selected buffer.
     device->vertexBufferOffset = 0;
     device->vertexBytesThisFrame = 0;
+    device->overflowCount = 0;
 
     // Grow THIS slot's buffer ONCE here (never mid-frame) to fit the previous frame's peak usage, so no
     // draw recorded this frame sees a reallocation. Headroom (1.5x) absorbs frame-to-frame growth. Each
@@ -443,6 +463,18 @@ void sakura_metal_end_frame(SakuraMetalDevice* device)
 
     if (top->commandBuffer)
         [top->commandBuffer commit];
+
+    // Drop this frame's one-off overflow buffers. Safe after commit: an encoder retains the resources
+    // it references for as long as the command buffer needs them.
+    for (int i = 0; i < device->overflowCount; i++)
+    {
+        if (device->overflowBuffers[i])
+        {
+            CFRelease((__bridge CFTypeRef)device->overflowBuffers[i]);
+            device->overflowBuffers[i] = nil;
+        }
+    }
+    device->overflowCount = 0;
 
     // Release the drawable target's objects (balances the CFRetains in begin_frame / the last reopen).
     if (top->encoder) {
@@ -807,10 +839,44 @@ void sakura_metal_draw_triangles(SakuraMetalDevice* device, const void* data, in
 
     NSUInteger drawOffset = device->vertexBufferOffset;
 
-    // If this frame's buffer can't fit the draw (e.g. first frame, or a sudden spike), skip drawing
-    // it this frame. begin_frame will have grown the buffer by next frame thanks to the peak above.
+    // If this frame's ring slot can't fit the draw (the first frame, or a spike past the 1.5x
+    // headroom), serve it from a one-off buffer rather than dropping it. The host batches, so a
+    // dropped draw is not one quad any more — it is most of a frame's geometry, and visibly missing.
+    // begin_frame will have grown the ring by next frame thanks to the peak recorded above.
     if (device->vertexBuffer == nil || drawOffset + byteLength > device->vertexBufferCapacity)
+    {
+        if (device->overflowCount >= SAKURA_METAL_MAX_OVERFLOW_BUFFERS)
+        {
+            NSLog(@"sakura-metal: dropping a %lu-byte draw; %d overflow buffers already allocated this frame",
+                  (unsigned long)byteLength, device->overflowCount);
+            return;
+        }
+
+        id<MTLBuffer> overflow = [device->device newBufferWithLength:byteLength
+                                                            options:MTLResourceStorageModeShared];
+        if (overflow == nil)
+        {
+            NSLog(@"sakura-metal: dropping a %lu-byte draw; overflow buffer allocation failed",
+                  (unsigned long)byteLength);
+            return;
+        }
+
+        // Released in end_frame; the command buffer retains what its encoders reference, so the GPU
+        // can still be reading this after the release.
+        device->overflowBuffers[device->overflowCount++] = overflow;
+        CFRetain((__bridge CFTypeRef)overflow);
+
+        memcpy(overflow.contents, data, byteLength);
+
+        [device->encoder setVertexBuffer:overflow
+                                  offset:0
+                                 atIndex:SAKURA_METAL_VERTEX_BUFFER_INDEX];
+
+        [device->encoder drawPrimitives:MTLPrimitiveTypeTriangle
+                            vertexStart:0
+                            vertexCount:(NSUInteger)vertexCount];
         return;
+    }
 
     memcpy((char*)device->vertexBuffer.contents + drawOffset, data, byteLength);
     device->vertexBufferOffset += byteLength;


### PR DESCRIPTION
We actually texture batching in OpenGL renderer ([and expand it too since noticing flush in real usage](https://github.com/HelloYeew/sakura/commit/99ac51aade585d085553a7324aaa6874f6cb1fca)) but during implement https://github.com/HelloYeew/sakura/pull/161 noticing that the binding count is really high in Metal since we don't have implement batching yet. This improvement should noticable if your game or application render a lot (I mean "a lot") of texture since before this improvement the Metal and D3D renderer already outperform the OpenGL itself. The draw count should be decrease around x100 but not much noticable in performance.

TODO:

- [x] test on windows
- [x] New nativelib release