### PR TITLE
Fix multiple buffer not update properly due to invalidation ID

### DIFF
--- a/Sakura.Framework.Benchmarks/Benchmarks/DrawNodeGenerationBenchmarks.cs
+++ b/Sakura.Framework.Benchmarks/Benchmarks/DrawNodeGenerationBenchmarks.cs
@@ -22,7 +22,7 @@ public class DrawNodeGenerationBenchmarks
     private ManualClock gridClock = null!;
     private Container gridHolder = null!;
 
-    private int frame;
+    private long frame;
 
     [GlobalSetup]
     public void Setup()
@@ -44,7 +44,7 @@ public class DrawNodeGenerationBenchmarks
     public DrawNode Generate_CleanTree_Wide1000()
     {
         frame++;
-        return wideRoot.GenerateDrawNodeSubtree(frame % 3);
+        return wideRoot.GenerateDrawNodeSubtree((int)(frame % 3));
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class DrawNodeGenerationBenchmarks
     public DrawNode Generate_CleanTree_Grid10x100()
     {
         frame++;
-        return gridRoot.GenerateDrawNodeSubtree(frame % 3);
+        return gridRoot.GenerateDrawNodeSubtree((int)(frame % 3));
     }
 
     /// <summary>
@@ -69,6 +69,6 @@ public class DrawNodeGenerationBenchmarks
 
         gridClock.CurrentTime += BenchmarkTree.FRAME_STEP_MS;
         gridRoot.UpdateSubTree();
-        return gridRoot.GenerateDrawNodeSubtree(frame % 3);
+        return gridRoot.GenerateDrawNodeSubtree((int)(frame % 3));
     }
 }

--- a/Sakura.Framework.Tests/Rendering/DrawNodeStaleBufferTest.cs
+++ b/Sakura.Framework.Tests/Rendering/DrawNodeStaleBufferTest.cs
@@ -1,0 +1,169 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Rendering;
+
+/// <summary>
+/// Reproduction for the stuttering drawable bug (https://github.com/HelloYeew/sakura/pull/166)
+/// </summary>
+[TestFixture]
+public class DrawNodeStaleBufferTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock { CurrentTime = 1000 };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+    }
+
+    /// <summary>
+    /// One host frame: update pass, then draw-node generation into the given buffer, exactly as
+    /// AppHost.PerformUpdate does.
+    /// </summary>
+    private ContainerDrawNode frame(int buffer)
+    {
+        manual.CurrentTime += 16;
+        root.UpdateSubTree();
+        return (ContainerDrawNode)root.GenerateDrawNodeSubtree(buffer);
+    }
+
+    [Test]
+    public void TestChangeAfterUpdatePassReachesEveryBuffer()
+    {
+        var box = new Box { Position = new Vector2(10, 10), Size = new Vector2(50) };
+        root.Add(box);
+
+        for (int i = 0; i < 6; i++)
+            frame(i % 3);
+
+        // The change lands after this frame's update traversal already passed over the box —
+        // e.g. a sibling that updates later in the traversal writing to it, or a callback.
+        manual.CurrentTime += 16;
+        root.UpdateSubTree();
+        box.Position = new Vector2(200, 10);
+        root.GenerateDrawNodeSubtree(0);
+
+        // Nothing else changes from here on. Every buffer must converge on the new position.
+        for (int i = 0; i < 9; i++)
+        {
+            var node = frame((i + 1) % 3);
+            float x = node.Children[0].DrawRectangle.X;
+
+            Assert.That(x, Is.EqualTo(200).Within(0.01f),
+                $"Frame {i} (buffer {(i + 1) % 3}) drew X={x}; the change must be visible in every buffer.");
+        }
+    }
+
+    /// <summary>
+    /// The same thing without reaching in by hand: children are updated back-to-front, so a
+    /// drawable written to by a sibling that sits *later* in the list is always written to after
+    /// its own update pass. (This is the shape of a gameplay HUD whose score text is driven by a
+    /// playfield added before it.)
+    /// </summary>
+    [Test]
+    public void TestWriteFromLaterUpdatingSiblingReachesEveryBuffer()
+    {
+        var target = new Box { Position = new Vector2(10, 10), Size = new Vector2(50) };
+        var writer = new Writer(target);
+
+        // writer first, target second: the traversal runs target's update before writer's.
+        root.Add(writer);
+        root.Add(target);
+
+        for (int i = 0; i < 6; i++)
+            frame(i % 3);
+
+        writer.NextPosition = new Vector2(200, 10);
+
+        // The frame of the write itself legitimately still draws the old geometry: the new one does
+        // not exist until the next update pass recomputes it. Every frame after that must be current.
+        frame(0);
+
+        for (int i = 1; i < 10; i++)
+        {
+            var node = frame(i % 3);
+            var targetNode = node.Children[node.Children.Count - 1];
+
+            Assert.That(targetNode.DrawRectangle.X, Is.EqualTo(200).Within(0.01f),
+                $"Frame {i} (buffer {i % 3}) drew X={targetNode.DrawRectangle.X}; a sibling's write must reach every buffer.");
+        }
+    }
+
+    private partial class Writer : Drawable
+    {
+        public Vector2? NextPosition;
+
+        private readonly Drawable target;
+
+        public Writer(Drawable target)
+        {
+            this.target = target;
+        }
+
+        public override void Update()
+        {
+            base.Update();
+
+            if (NextPosition is Vector2 position)
+            {
+                target.Position = position;
+                NextPosition = null;
+            }
+        }
+    }
+
+    [Test]
+    public void TestMaskedAwayMovementReachesEveryBufferOnReturn()
+    {
+        var masked = new Container { Size = new Vector2(200, 200), Masking = true };
+        var box = new Box { Position = new Vector2(10, 10), Size = new Vector2(50) };
+        masked.Add(box);
+        root.Add(masked);
+
+        for (int i = 0; i < 6; i++)
+            frame(i % 3);
+
+        // Leave the masking bounds, keep moving while outside, then come back to a new position.
+        box.Position = new Vector2(500, 500);
+        for (int i = 0; i < 3; i++)
+            frame(i % 3);
+
+        box.Position = new Vector2(600, 600);
+        for (int i = 0; i < 3; i++)
+            frame(i % 3);
+
+        box.Position = new Vector2(120, 20);
+        for (int i = 0; i < 9; i++)
+        {
+            var maskedNode = (ContainerDrawNode)frame(i % 3).Children[0];
+            Assert.That(maskedNode.Children, Has.Count.EqualTo(1), $"Frame {i}: the box must be back in the draw tree.");
+
+            float x = maskedNode.Children[0].DrawRectangle.X;
+            Assert.That(x, Is.EqualTo(120).Within(0.01f),
+                $"Frame {i} (buffer {i % 3}) drew X={x}; a drawable returning from masking must be current in every buffer.");
+        }
+    }
+}

--- a/Sakura.Framework/Graphics/Drawables/Drawable.cs
+++ b/Sakura.Framework/Graphics/Drawables/Drawable.cs
@@ -659,6 +659,8 @@ public abstract partial class Drawable : IDependencyInjectionCandidate, IDisposa
         DrawSize = finalDrawSize;
 
         GenerateVertices();
+
+        MarkDrawStateRecomputed();
     }
 
     /// <summary>
@@ -1008,6 +1010,19 @@ public abstract partial class Drawable : IDependencyInjectionCandidate, IDisposa
     }
 
     protected internal long DrawNodeInvalidationId { get; private set; } = 1;
+
+    /// <summary>
+    /// Announces that this drawable's drawn state (matrices, vertices, colors) has just been
+    /// recomputed, so every buffered draw node holding an older snapshot must re-apply.
+    /// </summary>
+    protected void MarkDrawStateRecomputed()
+    {
+        DrawNodeInvalidationId++;
+
+        if ((!IsMaskedAway || AlwaysPresent) && !IsEffectivelyHidden)
+            Parent?.MarkSubtreeDrawStateDirty();
+    }
+
     private readonly DrawNode?[] drawNodes = new DrawNode?[3];
     private DrawNode? drawNode;
 
@@ -1268,6 +1283,8 @@ public abstract partial class Drawable : IDependencyInjectionCandidate, IDisposa
         // Rewrite per-corner colors so gradients survive the color-only fast path (used by fades);
         // toLinear folds the freshly-computed DrawAlpha into every corner.
         writeCornerColors();
+
+        MarkDrawStateRecomputed();
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Drawables/SpriteText.cs
+++ b/Sakura.Framework/Graphics/Drawables/SpriteText.cs
@@ -434,19 +434,23 @@ public partial class SpriteText : Drawable
         {
             for (int i = 0; i < currentVertexCount; i++)
                 textVertices[i].Color = drawColor;
-            return;
         }
-
-        var glyphs = shapedText.Glyphs;
-        int vIndex = 0;
-
-        for (int glyphIndex = 0; glyphIndex < glyphs.Count; glyphIndex++)
+        else
         {
-            var glyphColor = glyphs[glyphIndex].IsColorGlyph ? colorGlyphDrawColor : drawColor;
+            var glyphs = shapedText.Glyphs;
+            int vIndex = 0;
 
-            for (int i = 0; i < 4 && vIndex < currentVertexCount; i++, vIndex++)
-                textVertices[vIndex].Color = glyphColor;
+            for (int glyphIndex = 0; glyphIndex < glyphs.Count; glyphIndex++)
+            {
+                var glyphColor = glyphs[glyphIndex].IsColorGlyph ? colorGlyphDrawColor : drawColor;
+
+                for (int i = 0; i < 4 && vIndex < currentVertexCount; i++, vIndex++)
+                    textVertices[vIndex].Color = glyphColor;
+            }
         }
+
+        // This override does not chain to base.UpdateDrawColor, so it has to stamp the new state itself.
+        MarkDrawStateRecomputed();
     }
 
     protected override DrawNode CreateDrawNode() => new SpriteTextDrawNode();


### PR DESCRIPTION
There are a really rare case that the old buffer not got all invalidated due to the renderer that's multiple buffer pick the old and not cleaned one to draw. Can reproduce easier in a drawable that's change frequently. This is due to the `DrawNodeInvalidationId` got bumped but invalidation only "schedules" a recompute. The new vertices don't exist until the next update pass run `UpdateTransforms()`

So when a drawable is invalidated after its own update pass but before the frame's draw node generation:

1. Frame N: `GenerateDrawNodeSubtree(buffer0)` sees `node.InvalidationID != DrawNodeInvalidationId` -> applies state and stamps the node with the new id while the node still holds the old vertices.
2. Frame N+1: the update pass computes the new geometry. No new id bump (the drawable was already dirty, so Invalidate early-returns). Buffers 1 and 2 are stale-by-id, so they apply the new vertices.
3. Buffer 0 now looks current forever. It never re-applies, and the parent container's `subtreeDrawVersion` also matches, so the descent skips it entirely.