### PR TITLE
First pass of SDL audio manager

### DIFF
--- a/Sakura.Framework.Benchmarks/Sakura.Framework.Benchmarks.csproj
+++ b/Sakura.Framework.Benchmarks/Sakura.Framework.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Sakura.Framework.SourceGenerators" Version="2026.609.2">
+    <PackageReference Include="Sakura.Framework.SourceGenerators" Version="2026.708.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Sakura.Framework.NativeLibraries/script/ffmpeg/common.sh
+++ b/Sakura.Framework.NativeLibraries/script/ffmpeg/common.sh
@@ -19,6 +19,11 @@ FFMPEG_FLAGS=(
     --enable-avutil
     --enable-swscale
 
+    # It is here because FFmpeg's native Opus decoder declares "opus_decoder_deps=swresample", and
+    # configure silently drops any decoder whose dependencies are unmet. Without this, the 'opus'
+    # entry in the decoder list below is accepted and then discarded.
+    --enable-swresample
+
     # Video formats, parsers & decoders
     --enable-demuxer='avi,flv,asf,mov,matroska'
     --enable-parser='mpeg4video,h264,hevc,vp8,vp9'

--- a/Sakura.Framework.Tests/Audio/FFmpegAudioDecoderTest.cs
+++ b/Sakura.Framework.Tests/Audio/FFmpegAudioDecoderTest.cs
@@ -1,0 +1,120 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// Test for the new FFmpeg build after native lib update 2026.819.0
+/// </summary>
+[TestFixture]
+public class FFmpegAudioDecoderTest
+{
+    private static Stream open(string resource)
+    {
+        var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"Sakura.Framework.Tests.Resources.{resource}");
+        Assert.That(stream, Is.Not.Null, $"Missing embedded test resource '{resource}'.");
+        return stream!;
+    }
+
+    [TestCase("Tracks.test.mp3")]
+    [TestCase("Tracks.loud.mp3")]
+    [TestCase("Samples.long.mp3")]
+    [TestCase("Samples.test.wav")]
+    public void OpensAndReportsAUsableFormat(string resource)
+    {
+        using var decoder = new FFmpegAudioDecoder(open(resource));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(decoder.SampleRate, Is.GreaterThan(0));
+            Assert.That(decoder.Channels, Is.InRange(1, 8));
+            Assert.That(decoder.Duration, Is.GreaterThan(0));
+        });
+    }
+
+    [TestCase("Tracks.test.mp3")]
+    [TestCase("Tracks.loud.mp3")]
+    [TestCase("Samples.long.mp3")]
+    [TestCase("Samples.test.wav")]
+    public void DecodesWholeFileToInRangeSamples(string resource)
+    {
+        using var decoder = new FFmpegAudioDecoder(open(resource));
+
+        float[] buffer = new float[4096];
+        long totalFloats = 0;
+        float peak = 0;
+        int reads;
+
+        for (reads = 0; reads < 100_000; reads++)
+        {
+            int read = decoder.Read(buffer);
+
+            if (read == 0)
+                break;
+
+            Assert.That(read % decoder.Channels, Is.Zero, "Read returned a partial frame.");
+
+            for (int i = 0; i < read; i++)
+            {
+                float sample = buffer[i];
+                Assert.That(float.IsFinite(sample), Is.True, "Decoder produced a non-finite sample.");
+                peak = Math.Max(peak, Math.Abs(sample));
+            }
+
+            totalFloats += read;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(decoder.EndOfStream, Is.True, "Decoder never reported end of stream.");
+            Assert.That(totalFloats, Is.GreaterThan(0), "Decoder produced no audio at all.");
+
+            // Real audio, not a silent buffer.
+            Assert.That(peak, Is.GreaterThan(0.001f), "Decoded audio was silent.");
+
+            // Float PCM is deliberately NOT clamped to +/-1.0: a lossy decoder reconstructing a hot
+            // master overshoots, and loud.mp3 genuinely peaks at ~2.27 here. The bound is only a
+            // sanity check against a misread sample format, which produces garbage orders of
+            // magnitude out. Whatever mixes this has to expect samples above unity.
+            Assert.That(peak, Is.LessThan(4f), "Decoded audio was far outside any plausible range.");
+
+            // Duration is derived from the container, decoded length from the codec. Measured
+            // agreement across all four assets is within 0.007%, so anything approaching a percent
+            // means frames are being dropped or double-counted somewhere.
+            double decodedMs = totalFloats / (double)decoder.Channels / decoder.SampleRate * 1000.0;
+            Assert.That(decodedMs, Is.EqualTo(decoder.Duration).Within(0.5).Percent);
+        });
+    }
+
+    [Test]
+    public void SeekRewindsAndProducesAudioAgain()
+    {
+        using var decoder = new FFmpegAudioDecoder(open("Tracks.test.mp3"));
+
+        float[] buffer = new float[4096];
+
+        while (decoder.Read(buffer) > 0)
+        {
+        }
+
+        Assert.That(decoder.EndOfStream, Is.True);
+
+        decoder.Seek(0);
+
+        Assert.That(decoder.EndOfStream, Is.False, "Seek did not clear the end-of-stream state.");
+        Assert.That(decoder.Read(buffer), Is.GreaterThan(0), "Decoder produced nothing after seeking back to the start.");
+    }
+
+    [Test]
+    public void RejectsANonAudioSource()
+    {
+        var garbage = new MemoryStream(new byte[4096]);
+        Assert.Throws<InvalidDataException>(() => _ = new FFmpegAudioDecoder(garbage));
+    }
+}

--- a/Sakura.Framework.Tests/Audio/SdlAudioChannelTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlAudioChannelTest.cs
@@ -1,0 +1,376 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// Voice-level coverage: the mix maths, gain and pan, rate resampling, loop handling, and event
+/// ordering. Runs against synthetic PCM and a stub context, so no device and no decoder is involved.
+/// </summary>
+[TestFixture]
+public class SdlAudioChannelTest
+{
+    private const int rate = 44100;
+    private const int channels = 2;
+
+    /// <summary>
+    /// Stands in for the manager. Queues actions rather than running them, so tests control exactly
+    /// when audio-thread work happens.
+    /// </summary>
+    private sealed class StubContext : ISDLAudioContext
+    {
+        public int SampleRate => rate;
+        public int Channels => channels;
+
+        public readonly Queue<Action> Pending = new Queue<Action>();
+        public int WakeCount;
+
+        public void EnqueueAction(Action action) => Pending.Enqueue(action);
+        public void WakeDecoder() => WakeCount++;
+
+        /// <summary>Runs everything queued, including anything queued while draining.</summary>
+        public void Drain()
+        {
+            while (Pending.Count > 0)
+                Pending.Dequeue().Invoke();
+        }
+    }
+
+    /// <summary>
+    /// A source of constant-valued frames, so gain and pan changes are trivially readable in output.
+    /// </summary>
+    private static IPcmSource constant(float value, int frames)
+    {
+        float[] samples = new float[frames * channels];
+        Array.Fill(samples, value);
+        return new MemoryPcmSource(buffer(samples));
+    }
+
+    private static PcmBuffer buffer(float[] samples) => PcmBuffer.FromSamples(samples, channels, rate);
+
+    private static SDLAudioChannel playing(StubContext context, IPcmSource source)
+    {
+        var channel = new SDLAudioChannel(context, source);
+        channel.Play();
+        context.Drain();
+        return channel;
+    }
+
+    [Test]
+    public void Fill_AddsIntoTheDestinationRatherThanOverwriting()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.25f, 512));
+
+        float[] destination = new float[64 * channels];
+        Array.Fill(destination, 0.5f);
+
+        channel.Fill(destination);
+
+        Assert.That(destination[0], Is.EqualTo(0.75f).Within(0.0001f),
+            "A mixer sums children into one buffer, so Fill must add.");
+    }
+
+    [Test]
+    public void Fill_ContributesNothingWhenNotPlaying()
+    {
+        var context = new StubContext();
+        var channel = new SDLAudioChannel(context, constant(0.5f, 512));
+
+        float[] destination = new float[64 * channels];
+        channel.Fill(destination);
+
+        Assert.That(destination, Is.All.Zero);
+    }
+
+    [Test]
+    public void Fill_AppliesVolume()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(1.0f, 512));
+        channel.Volume.Value = 0.25;
+
+        float[] destination = new float[64 * channels];
+        channel.Fill(destination);
+
+        Assert.That(destination[0], Is.EqualTo(0.25f).Within(0.0001f));
+    }
+
+    [TestCase(-1.0, 1.0f, 0.0f)]
+    [TestCase(0.0, 1.0f, 1.0f)]
+    [TestCase(1.0, 0.0f, 1.0f)]
+    [TestCase(0.5, 0.5f, 1.0f)]
+    public void Fill_AppliesLinearPan(double balance, float expectedLeft, float expectedRight)
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(1.0f, 512));
+        channel.Balance.Value = balance;
+
+        float[] destination = new float[64 * channels];
+        channel.Fill(destination);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(destination[0], Is.EqualTo(expectedLeft).Within(0.0001f));
+            Assert.That(destination[1], Is.EqualTo(expectedRight).Within(0.0001f));
+        }
+    }
+
+    [Test]
+    public void Fill_AtUnityFrequencyReproducesTheSourceExactly()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 512));
+
+        float[] destination = new float[64 * channels];
+        channel.Fill(destination);
+
+        // Cubic Hermite at t=0 collapses to the sample itself, so unity rate must be lossless.
+        Assert.That(destination, Is.All.EqualTo(0.5f).Within(0.0001f));
+    }
+
+    [Test]
+    public void Frequency_ConsumesSourceFasterWhenRaised()
+    {
+        double consumedAt(double frequency)
+        {
+            var context = new StubContext();
+            var source = constant(0.5f, 44100);
+            var channel = playing(context, source);
+            channel.Frequency.Value = frequency;
+
+            channel.Fill(new float[1000 * channels]);
+            return source.PositionMs;
+        }
+
+        double atUnity = consumedAt(1.0);
+        double atDouble = consumedAt(2.0);
+        double atHalf = consumedAt(0.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(atDouble, Is.EqualTo(atUnity * 2).Within(5).Percent, "Double rate should consume twice the source.");
+            Assert.That(atHalf, Is.EqualTo(atUnity / 2).Within(5).Percent, "Half rate should consume half the source.");
+        }
+    }
+
+    [Test]
+    public void CurrentTime_ReportsAndMovesThePosition()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 44100));
+
+        channel.Fill(new float[441 * channels]);
+        Assert.That(channel.CurrentTime, Is.EqualTo(10).Within(1));
+
+        channel.CurrentTime = 500;
+        context.Drain();
+
+        Assert.That(channel.CurrentTime, Is.EqualTo(500).Within(1));
+    }
+
+    [Test]
+    public void Stop_RewindsButPauseDoesNot()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 44100));
+
+        channel.Fill(new float[4410 * channels]);
+        double beforePause = channel.CurrentTime;
+
+        channel.Pause();
+        context.Drain();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(channel.IsRunning.Value, Is.False);
+            Assert.That(channel.CurrentTime, Is.EqualTo(beforePause).Within(0.001), "Pause must hold position.");
+        }
+
+        channel.Stop();
+        context.Drain();
+
+        Assert.That(channel.CurrentTime, Is.Zero, "Stop must rewind, matching the BASS backend.");
+    }
+
+    [Test]
+    public void ReachingTheEndRaisesOnEndAndStops()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 128));
+
+        int ended = 0;
+        int stopped = 0;
+        channel.OnEnd += () => ended++;
+        channel.OnStop += () => stopped++;
+
+        // Ask for far more than the source holds.
+        channel.Fill(new float[1024 * channels]);
+        context.Drain();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ended, Is.EqualTo(1));
+            Assert.That(stopped, Is.EqualTo(1));
+            Assert.That(channel.IsRunning.Value, Is.False);
+        }
+    }
+
+    [Test]
+    public void EndIsRaisedOnceEvenAcrossRepeatedFills()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 128));
+
+        int ended = 0;
+        channel.OnEnd += () => ended++;
+
+        for (int i = 0; i < 5; i++)
+        {
+            channel.Fill(new float[1024 * channels]);
+            context.Drain();
+        }
+
+        Assert.That(ended, Is.EqualTo(1), "The end must not re-fire on every subsequent block.");
+    }
+
+    [Test]
+    public void LoopingRestartsAtTheRestartPointAndKeepsPlaying()
+    {
+        var context = new StubContext();
+        var source = constant(0.5f, 4410); // 100ms
+        var channel = playing(context, source);
+
+        channel.Looping = true;
+        channel.RestartPoint = 50;
+
+        int ended = 0;
+        channel.OnEnd += () => ended++;
+
+        channel.Fill(new float[8820 * channels]);
+        context.Drain();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ended, Is.GreaterThanOrEqualTo(1), "Looping should still report the end of each pass.");
+            Assert.That(channel.IsRunning.Value, Is.True, "A looping channel must not stop at the end.");
+            Assert.That(channel.CurrentTime, Is.GreaterThanOrEqualTo(50), "Playback should have resumed from the restart point.");
+        }
+    }
+
+    [Test]
+    public void AutoDisposeReleasesTheSourceAtTheEnd()
+    {
+        var context = new StubContext();
+
+        bool released = false;
+        float[] samples = new float[128 * channels];
+        Array.Fill(samples, 0.5f);
+        var source = new MemoryPcmSource(buffer(samples), () => released = true);
+
+        var channel = new SDLAudioChannel(context, source) { AutoDispose = true };
+        channel.Play();
+        context.Drain();
+
+        channel.Fill(new float[1024 * channels]);
+        context.Drain();
+
+        Assert.That(released, Is.True);
+    }
+
+    [Test]
+    public void PlayAfterFinishingStartsOver()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 128));
+
+        channel.Fill(new float[1024 * channels]);
+        context.Drain();
+        Assert.That(channel.IsRunning.Value, Is.False);
+
+        channel.Play();
+        context.Drain();
+
+        float[] destination = new float[64 * channels];
+        channel.Fill(destination);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(channel.IsRunning.Value, Is.True);
+            Assert.That(destination[0], Is.EqualTo(0.5f).Within(0.0001f), "Replaying should produce audio, not silence at the end.");
+        }
+    }
+
+    [Test]
+    public void AmplitudesFollowTheAudioAndClearWhenStopped()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.8f, 44100));
+        channel.Balance.Value = -1; // hard left
+
+        channel.Fill(new float[2048 * channels]);
+        var amplitudes = channel.CurrentAmplitudes;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(amplitudes.AmplitudeLeft, Is.EqualTo(0.8f).Within(0.01f));
+            Assert.That(amplitudes.AmplitudeRight, Is.Zero, "Panned hard left, the right channel is silent.");
+        }
+
+        channel.Stop();
+        context.Drain();
+
+        Assert.That(channel.CurrentAmplitudes.AmplitudeLeft, Is.Zero);
+    }
+
+    [Test]
+    public void AttachedFilterAffectsTheOutput()
+    {
+        var context = new StubContext();
+        var source = constant(1.0f, 44100);
+        var channel = playing(context, source);
+
+        var filter = channel.AttachLowPassFilter();
+        filter.CutoffFrequency.Value = 200;
+
+        float[] destination = new float[16 * channels];
+        channel.Fill(destination);
+
+        // A steady 1.0 fed into a low-pass starts from the filter's zeroed state, so the first
+        // samples ramp rather than arriving at full level.
+        Assert.That(destination[0], Is.LessThan(0.5f), "The filter is not in the signal path.");
+    }
+
+    [Test]
+    public void DisposeStopsContributingAndNotifiesTheOwner()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 4410));
+
+        bool disposedRaised = false;
+        channel.Disposed += () => disposedRaised = true;
+
+        channel.Dispose();
+        context.Drain();
+
+        float[] destination = new float[64 * channels];
+        channel.Fill(destination);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(disposedRaised, Is.True);
+            Assert.That(destination, Is.All.Zero);
+        }
+
+        Assert.DoesNotThrow(() =>
+        {
+            channel.Dispose();
+            context.Drain();
+        });
+    }
+}

--- a/Sakura.Framework.Tests/Audio/SdlAudioDspTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlAudioDspTest.cs
@@ -1,0 +1,310 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using NUnit.Framework;
+using Sakura.Framework.Audio;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// Signal-level coverage for the SDL backend's DSP building blocks math test
+/// </summary>
+[TestFixture]
+public class SdlAudioDspTest
+{
+    private const int sample_rate = 44100;
+
+    /// <summary>
+    /// A sine placed exactly on bin <paramref name="bin"/> of a <see cref="AudioFft.FFT_SIZE"/>
+    /// transform, so there is no scalloping loss to account for.
+    /// </summary>
+    private static float[] binCentredSine(int bin, float amplitude)
+    {
+        float[] buffer = new float[AudioFft.FFT_SIZE];
+
+        for (int i = 0; i < buffer.Length; i++)
+            buffer[i] = amplitude * MathF.Sin(2f * MathF.PI * bin * i / AudioFft.FFT_SIZE);
+
+        return buffer;
+    }
+
+    private static float[] sine(int sampleCount, double frequency, float amplitude, int channels = 1)
+    {
+        float[] buffer = new float[sampleCount * channels];
+
+        for (int i = 0; i < sampleCount; i++)
+        {
+            float value = amplitude * MathF.Sin((float)(2.0 * Math.PI * frequency * i / sample_rate));
+
+            for (int ch = 0; ch < channels; ch++)
+                buffer[i * channels + ch] = value;
+        }
+
+        return buffer;
+    }
+
+    [Test]
+    public void Fft_Silence_ProducesNoEnergy()
+    {
+        float[] bins = new float[AudioFft.BIN_COUNT];
+        new AudioFft().Compute(new float[AudioFft.FFT_SIZE], bins);
+
+        Assert.That(bins, Is.All.Zero);
+    }
+
+    [TestCase(4)]
+    [TestCase(17)]
+    [TestCase(64)]
+    public void Fft_SinePeaksInItsOwnBin(int bin)
+    {
+        float[] bins = new float[AudioFft.BIN_COUNT];
+        new AudioFft().Compute(binCentredSine(bin, 0.5f), bins);
+
+        int peakBin = 0;
+
+        for (int i = 0; i < bins.Length; i++)
+        {
+            if (bins[i] > bins[peakBin])
+                peakBin = i;
+        }
+
+        Assert.That(peakBin, Is.EqualTo(bin));
+    }
+
+    /// <summary>
+    /// The scaling contract: a bin-centred sine reads back at its own peak amplitude.
+    /// </summary>
+    [TestCase(0.25f)]
+    [TestCase(0.5f)]
+    [TestCase(1.0f)]
+    public void Fft_RecoversSineAmplitude(float amplitude)
+    {
+        float[] bins = new float[AudioFft.BIN_COUNT];
+        new AudioFft().Compute(binCentredSine(20, amplitude), bins);
+
+        // A Hann window puts the tone's main lobe across three bins in a 0.25 / 0.5 / 0.25 split,
+        // so the three together sum to 2A while the centre bin alone carries A. The centre is the
+        // scaling contract; the shoulders are checked here so the split itself cannot drift.
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bins[20], Is.EqualTo(amplitude).Within(1).Percent);
+            Assert.That(bins[19], Is.EqualTo(amplitude / 2f).Within(1).Percent);
+            Assert.That(bins[21], Is.EqualTo(amplitude / 2f).Within(1).Percent);
+        }
+    }
+
+    [Test]
+    public void Fft_EnergyStaysLocalToTheTone()
+    {
+        float[] bins = new float[AudioFft.BIN_COUNT];
+        new AudioFft().Compute(binCentredSine(40, 1.0f), bins);
+
+        float faraway = 0;
+
+        for (int i = 0; i < bins.Length; i++)
+        {
+            if (Math.Abs(i - 40) > 3)
+                faraway = Math.Max(faraway, bins[i]);
+        }
+
+        Assert.That(faraway, Is.LessThan(bins[40] * 0.01f), "Spectral leakage far exceeds what a Hann window should produce.");
+    }
+
+    [Test]
+    public void LowPass_PassesDcUnchanged()
+    {
+        var filter = new SDLLowPassFilter(sample_rate, 1) { CutoffFrequency = { Value = 500 } };
+
+        float[] buffer = new float[4096];
+        Array.Fill(buffer, 0.5f);
+        filter.Process(buffer);
+
+        // The first samples are the filter's step response settling; the tail is the steady state.
+        Assert.That(buffer[^1], Is.EqualTo(0.5f).Within(0.001f));
+    }
+
+    [Test]
+    public void LowPass_AttenuatesAboveCutoffAndPassesBelow()
+    {
+        const int samples = 8192;
+
+        float peakOf(double frequency, double cutoff)
+        {
+            var filter = new SDLLowPassFilter(sample_rate, 1) { CutoffFrequency = { Value = cutoff } };
+            float[] buffer = sine(samples, frequency, 1.0f);
+            filter.Process(buffer);
+
+            float peak = 0;
+
+            // Skip the settling transient and measure the steady state.
+            for (int i = samples / 2; i < samples; i++)
+                peak = Math.Max(peak, Math.Abs(buffer[i]));
+
+            return peak;
+        }
+
+        float passed = peakOf(200, 2000);
+        float stopped = peakOf(12000, 2000);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(passed, Is.EqualTo(1.0f).Within(0.05f), "A tone well below cutoff should pass essentially untouched.");
+            Assert.That(stopped, Is.LessThan(0.05f), "A tone well above cutoff should be strongly attenuated.");
+        }
+    }
+
+    /// <summary>
+    /// At the cutoff frequency a Butterworth low-pass is 3 dB down — about 0.707 of the input.
+    /// This is what pins Q to the same value the BASS backend uses.
+    /// </summary>
+    [Test]
+    public void LowPass_IsThreeDecibelsDownAtCutoff()
+    {
+        const int samples = 16384;
+        const double cutoff = 1000;
+
+        var filter = new SDLLowPassFilter(sample_rate, 1) { CutoffFrequency = { Value = cutoff } };
+        float[] buffer = sine(samples, cutoff, 1.0f);
+        filter.Process(buffer);
+
+        float peak = 0;
+
+        for (int i = samples / 2; i < samples; i++)
+            peak = Math.Max(peak, Math.Abs(buffer[i]));
+
+        Assert.That(peak, Is.EqualTo(0.707f).Within(0.02f));
+    }
+
+    [Test]
+    public void LowPass_ClampsCutoffAboveNyquistInsteadOfExploding()
+    {
+        var filter = new SDLLowPassFilter(sample_rate, 2) { CutoffFrequency = { Value = 500_000 } };
+
+        float[] buffer = sine(2048, 1000, 0.5f, channels: 2);
+        float[] unfiltered = (float[])buffer.Clone();
+        filter.Process(buffer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(buffer, Is.All.Matches<float>(float.IsFinite));
+
+            // Beyond what the rate can express the filter bypasses, so the signal survives intact.
+            Assert.That(buffer, Is.EqualTo(unfiltered));
+        }
+    }
+
+    [Test]
+    public void LowPass_ChannelsAreFilteredIndependently()
+    {
+        var filter = new SDLLowPassFilter(sample_rate, 2) { CutoffFrequency = { Value = 300 } };
+
+        // Left carries a tone, right is silent. Any bleed means the two channels share state.
+        float[] buffer = new float[4096];
+
+        for (int i = 0; i < buffer.Length / 2; i++)
+            buffer[i * 2] = MathF.Sin((float)(2.0 * Math.PI * 100 * i / sample_rate));
+
+        filter.Process(buffer);
+
+        float rightPeak = 0;
+
+        for (int i = 0; i < buffer.Length / 2; i++)
+            rightPeak = Math.Max(rightPeak, Math.Abs(buffer[i * 2 + 1]));
+
+        Assert.That(rightPeak, Is.Zero);
+    }
+
+    [Test]
+    public void LowPass_ResetRestoresTheDefaultCutoff()
+    {
+        var filter = new SDLLowPassFilter(sample_rate, 2);
+        filter.CutoffFrequency.Value = 500;
+
+        filter.Reset();
+
+        Assert.That(filter.CutoffFrequency.Value, Is.EqualTo(ILowPassFilter.DefaultCutoffFrequency));
+    }
+
+    [Test]
+    public void LowPass_DisposeDetachesAndStopsProcessing()
+    {
+        bool detached = false;
+        var filter = new SDLLowPassFilter(sample_rate, 1, () => detached = true) { CutoffFrequency = { Value = 100 } };
+
+        filter.Dispose();
+
+        float[] buffer = sine(512, 10000, 1.0f);
+        float[] expected = (float[])buffer.Clone();
+        filter.Process(buffer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(detached, Is.True);
+            Assert.That(filter.IsDisposed, Is.True);
+            Assert.That(buffer, Is.EqualTo(expected), "A disposed filter must leave audio untouched.");
+        }
+
+        Assert.DoesNotThrow(() => filter.Dispose());
+    }
+
+    [Test]
+    public void Tap_ReportsPerChannelPeaks()
+    {
+        var tap = new AmplitudeTap();
+
+        // Left louder than right, so a swapped pair would be obvious.
+        float[] block = new float[512];
+
+        for (int i = 0; i < block.Length; i += 2)
+        {
+            block[i] = 0.8f;
+            block[i + 1] = -0.3f;
+        }
+
+        tap.Feed(block);
+        var amplitudes = tap.Read();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(amplitudes.AmplitudeLeft, Is.EqualTo(0.8f).Within(0.001f));
+            Assert.That(amplitudes.AmplitudeRight, Is.EqualTo(0.3f).Within(0.001f), "Peak should be taken on magnitude, not signed value.");
+            Assert.That(amplitudes.FrequencyAmplitudes.Length, Is.EqualTo(ChannelAmplitudes.AMPLITUDES_SIZE));
+        }
+    }
+
+    [Test]
+    public void Tap_WithNoAudioReportsSilence()
+    {
+        var amplitudes = new AmplitudeTap().Read();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(amplitudes.AmplitudeLeft, Is.Zero);
+            Assert.That(amplitudes.AmplitudeRight, Is.Zero);
+            Assert.That(amplitudes.FrequencyAmplitudes.ToArray(), Is.All.Zero);
+        }
+    }
+
+    [Test]
+    public void Tap_ResetClearsMeteringAndSpectrum()
+    {
+        var tap = new AmplitudeTap();
+
+        float[] block = new float[AudioFft.FFT_SIZE * 2];
+        Array.Fill(block, 0.9f);
+        tap.Feed(block);
+        tap.Read();
+
+        tap.Reset();
+        var amplitudes = tap.Read();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(amplitudes.AmplitudeLeft, Is.Zero);
+            Assert.That(amplitudes.AmplitudeRight, Is.Zero);
+            Assert.That(amplitudes.FrequencyAmplitudes.ToArray(), Is.All.Zero);
+        }
+    }
+}

--- a/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
@@ -1,0 +1,418 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+using Sakura.Framework.Platform;
+using Sakura.Framework.Statistic;
+using static SDL.SDL3;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// End-to-end coverage of the SDL mixer and manager.
+/// </summary>
+/// <remarks>
+/// The manager tests open a real device through SDL's <c>dummy</c> driver, which consumes its queue
+/// on a real-time clock exactly as hardware does.
+/// </remarks>
+[TestFixture]
+public class SdlAudioEngineTest
+{
+    private const int rate = 44100;
+    private const int channels = 2;
+
+    private static Stream open(string resource) =>
+        Assembly.GetExecutingAssembly().GetManifestResourceStream($"Sakura.Framework.Tests.Resources.{resource}")
+        ?? throw new InvalidOperationException($"Missing embedded test resource '{resource}'.");
+
+    #region Mixer
+
+    private sealed class StubContext : ISDLAudioContext
+    {
+        public int SampleRate => rate;
+        public int Channels => channels;
+        public void EnqueueAction(Action action) => action();
+        public void WakeDecoder() { }
+    }
+
+    private static SDLAudioChannel constantChannel(ISDLAudioContext context, float value, int frames = 44100)
+    {
+        float[] samples = new float[frames * channels];
+        Array.Fill(samples, value);
+
+        var channel = new SDLAudioChannel(context, new MemoryPcmSource(PcmBuffer.FromSamples(samples, channels, rate)));
+        channel.Play();
+        return channel;
+    }
+
+    private static SDLAudioMixer runningMixer(ISDLAudioContext context)
+    {
+        var mixer = new SDLAudioMixer(context);
+        mixer.IsRunning.Value = true;
+        return mixer;
+    }
+
+    [Test]
+    public void Mixer_SumsItsChildren()
+    {
+        var context = new StubContext();
+        var mixer = runningMixer(context);
+
+        mixer.AddChannel(constantChannel(context, 0.25f));
+        mixer.AddChannel(constantChannel(context, 0.5f));
+
+        float[] destination = new float[64 * channels];
+        mixer.Fill(destination);
+
+        Assert.That(destination[0], Is.EqualTo(0.75f).Within(0.0001f));
+    }
+
+    [Test]
+    public void Mixer_AppliesItsOwnVolumeToTheSum()
+    {
+        var context = new StubContext();
+        var mixer = runningMixer(context);
+        mixer.Volume.Value = 0.5;
+
+        mixer.AddChannel(constantChannel(context, 0.4f));
+        mixer.AddChannel(constantChannel(context, 0.4f));
+
+        float[] destination = new float[64 * channels];
+        mixer.Fill(destination);
+
+        Assert.That(destination[0], Is.EqualTo(0.4f).Within(0.0001f), "Mixer volume should scale the summed result.");
+    }
+
+    [Test]
+    public void Mixer_IsItselfAdditive()
+    {
+        var context = new StubContext();
+        var mixer = runningMixer(context);
+        mixer.AddChannel(constantChannel(context, 0.25f));
+
+        float[] destination = new float[64 * channels];
+        Array.Fill(destination, 0.5f);
+        mixer.Fill(destination);
+
+        Assert.That(destination[0], Is.EqualTo(0.75f).Within(0.0001f), "Two mixers must be able to share one output buffer.");
+    }
+
+    [Test]
+    public void Mixer_TracksMembershipAndRunningCount()
+    {
+        var context = new StubContext();
+        var mixer = runningMixer(context);
+
+        var playing = constantChannel(context, 0.5f);
+        var idle = new SDLAudioChannel(context, new MemoryPcmSource(PcmBuffer.FromSamples(new float[128 * channels], channels, rate)));
+
+        mixer.AddChannel(playing);
+        mixer.AddChannel(idle);
+        mixer.AddChannel(playing); // duplicate
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mixer.ActiveChannels.Count(), Is.EqualTo(2), "Adding the same channel twice should not duplicate it.");
+            Assert.That(mixer.RunningChannelCount, Is.EqualTo(1));
+        }
+
+        mixer.RemoveChannel(playing);
+        Assert.That(mixer.ActiveChannels.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Mixer_ActiveChannelsIsSafeToEnumerateWhileMutating()
+    {
+        var context = new StubContext();
+        var mixer = runningMixer(context);
+
+        for (int i = 0; i < 8; i++)
+            mixer.AddChannel(constantChannel(context, 0.1f, 128));
+
+        // The BASS backend hands out its live list and relies on callers taking the same lock; this
+        // one hands out a snapshot, so an unlocked read cannot throw.
+        Assert.DoesNotThrow(() =>
+        {
+            foreach (var channel in mixer.ActiveChannels)
+            {
+                mixer.AddChannel(constantChannel(context, 0.1f, 128));
+                mixer.RemoveChannel(channel);
+            }
+        });
+    }
+
+    [Test]
+    public void Mixer_ContributesNothingWithNoChildren()
+    {
+        var mixer = runningMixer(new StubContext());
+
+        float[] destination = new float[64 * channels];
+        mixer.Fill(destination);
+
+        Assert.That(destination, Is.All.Zero);
+    }
+
+    #endregion
+
+    #region Manager (dummy device)
+
+    /// <summary>
+    /// Routes SDL at its dummy audio backend, so a device can be opened without hardware. Must be
+    /// set before the audio subsystem is initialised.
+    /// </summary>
+    [OneTimeSetUp]
+    public void UseDummyAudioDriver() => SDL_SetHint(SDL_HINT_AUDIO_DRIVER, "dummy");
+
+    [Test]
+    public void Manager_OpensADeviceAndReportsItsFormat()
+    {
+        using var manager = new SDLAudioManager();
+
+        // If the hint did not take, these tests would be silently relying on real hardware and
+        // would not survive CI.
+        Assert.That(SDL_GetCurrentAudioDriver(), Is.EqualTo("dummy"), "SDL did not honour the dummy audio driver hint.");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(manager.SampleRate, Is.GreaterThan(0));
+            Assert.That(manager.Channels, Is.EqualTo(2));
+            Assert.That(manager.TrackMixer, Is.Not.Null);
+            Assert.That(manager.SampleMixer, Is.Not.Null);
+        }
+    }
+
+    /// <summary>
+    /// Phase 0 widened the shipped FFmpeg build specifically to carry these. If one goes missing the
+    /// symptom is a confusing failure deep in <c>avcodec_open2</c> on one file type, so assert it
+    /// directly rather than waiting to trip over it.
+    /// </summary>
+    [Test]
+    public void ShippedFFmpegCarriesEveryExpectedAudioDecoder()
+    {
+        var support = FFmpegLibrary.GetAudioDecoderSupport();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(support.Missing, Is.Empty, "The shipped FFmpeg build is missing audio decoders.");
+            Assert.That(support.Present, Is.Not.Empty);
+        });
+
+        TestContext.Out.WriteLine($"FFmpeg: {FFmpegLibrary.DescribeVersions()}");
+        TestContext.Out.WriteLine($"Decoders: {string.Join(", ", support.Present)}");
+    }
+
+    [Test]
+    public void Manager_KeepsTheDeviceQueueFed()
+    {
+        using var manager = new SDLAudioManager();
+
+        // The mix thread should have pushed audio without anything playing at all — silence still
+        // has to reach the device or the queue starves.
+        Thread.Sleep(200);
+        manager.Update(0);
+
+        double queued = GlobalStatistics.Get<double>("Audio", "SDL Queued (ms)").Value;
+
+        Assert.That(queued, Is.GreaterThan(0), "The mix thread is not filling the device queue.");
+    }
+
+    [Test]
+    public void Manager_PlaysASampleThroughToCompletion()
+    {
+        using var manager = new SDLAudioManager();
+
+        var sample = manager.CreateSample(open("Samples.test.wav"));
+        Assert.That(sample.Length, Is.EqualTo(424.6).Within(5).Percent);
+
+        var channel = sample.Play();
+        Assert.That(channel, Is.Not.Null);
+
+        bool ended = false;
+        channel.OnEnd += () => ended = true;
+
+        var timeout = Stopwatch.StartNew();
+
+        while (!ended && timeout.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        Assert.That(ended, Is.True, "Sample never reported reaching its end.");
+    }
+
+    [Test]
+    public void Manager_PlaysAStreamingTrackAndAdvancesItsPosition()
+    {
+        using var manager = new SDLAudioManager();
+
+        var track = manager.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+        Assert.That(track.Length, Is.GreaterThan(1000));
+
+        var channel = track.GetChannel();
+        channel.Play();
+
+        var timeout = Stopwatch.StartNew();
+
+        while (channel.CurrentTime < 200 && timeout.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        Assert.That(channel.CurrentTime, Is.GreaterThanOrEqualTo(200), "Track position did not advance.");
+
+        channel.Dispose();
+        manager.Update(0);
+    }
+
+    [Test]
+    public void Manager_PublishesItsStatistics()
+    {
+        using var manager = new SDLAudioManager();
+
+        var sample = manager.CreateSample(open("Samples.long.mp3"));
+        sample.Play();
+
+        var timeout = Stopwatch.StartNew();
+
+        while (GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value == 0 && timeout.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value, Is.GreaterThan(0));
+            Assert.That(GlobalStatistics.Get<long>("Audio", "SDL Mix Block (µs)").Value, Is.GreaterThan(0));
+            Assert.That(GlobalStatistics.Get<double>("Audio", "SDL Queued (ms)").Value, Is.GreaterThan(0));
+        });
+    }
+
+    /// <summary>
+    /// A steady multi-second play with no underrunning is the whole point of the decode-ahead design.
+    /// </summary>
+    [Test]
+    public void Manager_PlaysWithoutUnderrunning()
+    {
+        using var manager = new SDLAudioManager();
+
+        long before = GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value;
+
+        var track = manager.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+        var channel = track.GetChannel();
+        channel.Play();
+
+        var timeout = Stopwatch.StartNew();
+
+        while (timeout.Elapsed < TimeSpan.FromSeconds(3))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        manager.Update(0);
+        long after = GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value;
+
+        Assert.That(after - before, Is.Zero, "The device queue ran dry during steady playback.");
+
+        channel.Dispose();
+        manager.Update(0);
+    }
+
+    [Test]
+    public void Manager_MasterVolumeScalesBothMixers()
+    {
+        using var manager = new SDLAudioManager();
+
+        manager.TrackVolume.Value = 0.5;
+        manager.SampleVolume.Value = 0.25;
+        manager.MasterVolume.Value = 0.5;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(manager.TrackMixer.Volume.Value, Is.EqualTo(0.25).Within(0.0001));
+            Assert.That(manager.SampleMixer.Volume.Value, Is.EqualTo(0.125).Within(0.0001));
+        }
+    }
+
+    [Test]
+    public void Manager_StopAllStopsEveryChannel()
+    {
+        using var manager = new SDLAudioManager();
+
+        var sample = manager.CreateSample(open("Samples.long.mp3"));
+        var first = sample.Play();
+        var second = sample.Play();
+
+        manager.Update(0);
+
+        manager.StopAll();
+        manager.Update(0);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first.IsRunning.Value, Is.False);
+            Assert.That(second.IsRunning.Value, Is.False);
+        }
+    }
+
+    [Test]
+    public void Manager_DisposeIsCleanWhileAudioIsPlaying()
+    {
+        var manager = new SDLAudioManager();
+
+        var sample = manager.CreateSample(open("Samples.long.mp3"));
+        sample.Play();
+
+        var track = manager.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+        track.GetChannel().Play();
+
+        Thread.Sleep(100);
+
+        Assert.DoesNotThrow(() => manager.Dispose());
+        Assert.DoesNotThrow(() => manager.Dispose());
+    }
+
+    private static string writeTempCopy(string resource)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"sakura-sdl-audio-{Guid.NewGuid():N}{Path.GetExtension(resource)}");
+
+        using (var input = open(resource))
+        using (var output = File.Create(path))
+            input.CopyTo(output);
+
+        temporary_files.Add(path);
+        return path;
+    }
+
+    private static readonly List<string> temporary_files = new List<string>();
+
+    [OneTimeTearDown]
+    public void CleanUpTemporaryFiles()
+    {
+        foreach (string path in temporary_files)
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        temporary_files.Clear();
+    }
+
+    #endregion
+}

--- a/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
@@ -9,8 +9,8 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
+using Sakura.Framework.Audio;
 using Sakura.Framework.Audio.SdlEngine;
-using Sakura.Framework.Platform;
 using Sakura.Framework.Statistic;
 using static SDL.SDL3;
 
@@ -189,26 +189,6 @@ public class SdlAudioEngineTest
         }
     }
 
-    /// <summary>
-    /// Phase 0 widened the shipped FFmpeg build specifically to carry these. If one goes missing the
-    /// symptom is a confusing failure deep in <c>avcodec_open2</c> on one file type, so assert it
-    /// directly rather than waiting to trip over it.
-    /// </summary>
-    [Test]
-    public void ShippedFFmpegCarriesEveryExpectedAudioDecoder()
-    {
-        var support = FFmpegLibrary.GetAudioDecoderSupport();
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(support.Missing, Is.Empty, "The shipped FFmpeg build is missing audio decoders.");
-            Assert.That(support.Present, Is.Not.Empty);
-        });
-
-        TestContext.Out.WriteLine($"FFmpeg: {FFmpegLibrary.DescribeVersions()}");
-        TestContext.Out.WriteLine($"Decoders: {string.Join(", ", support.Present)}");
-    }
-
     [Test]
     public void Manager_KeepsTheDeviceQueueFed()
     {
@@ -325,6 +305,35 @@ public class SdlAudioEngineTest
 
         Assert.That(after - before, Is.Zero, "The device queue ran dry during steady playback.");
 
+        channel.Dispose();
+        manager.Update(0);
+    }
+
+    /// <summary>
+    /// <see cref="AudioChannelExtensions.AddLowPassFilter"/> has to recognise this backend's channels
+    /// too, or filtering silently becomes a no-op the moment the backend is switched.
+    /// </summary>
+    [Test]
+    public void AddLowPassFilter_AttachesToAnSdlChannel()
+    {
+        using var manager = new SDLAudioManager();
+
+        var sample = manager.CreateSample(open("Samples.long.mp3"));
+        var channel = sample.GetChannel();
+
+        var filter = channel.AddLowPassFilter();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(filter, Is.Not.Null, "The extension does not know about SDL channels.");
+            Assert.That(filter, Is.InstanceOf<SDLLowPassFilter>());
+            Assert.That(filter!.CutoffFrequency.Value, Is.EqualTo(ILowPassFilter.DefaultCutoffFrequency));
+        }
+
+        filter!.CutoffFrequency.Value = 500;
+        Assert.That(filter.CutoffFrequency.Value, Is.EqualTo(500));
+
+        filter.Dispose();
         channel.Dispose();
         manager.Update(0);
     }

--- a/Sakura.Framework.Tests/Audio/SdlPcmSourceTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlPcmSourceTest.cs
@@ -1,0 +1,483 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+using Sakura.Framework.Utilities;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// Coverage for the SDL backend's decode-to-device-format layer: the ring buffer, the SDL-backed
+/// converter, and the two <see cref="IPcmSource"/> implementations.
+/// </summary>
+[TestFixture]
+public class SdlPcmSourceTest
+{
+    private const int device_rate = 44100;
+    private const int device_channels = 2;
+
+    private static Stream open(string resource) =>
+        Assembly.GetExecutingAssembly().GetManifestResourceStream($"Sakura.Framework.Tests.Resources.{resource}")
+        ?? throw new InvalidOperationException($"Missing embedded test resource '{resource}'.");
+
+    #region Ring buffer
+
+    [Test]
+    public void Ring_WritesAndReadsBackInOrder()
+    {
+        var ring = new AudioRingBuffer(8);
+        float[] source = new float[] { 1, 2, 3, 4, 5 };
+
+        Assert.That(ring.Write(source), Is.EqualTo(5));
+        Assert.That(ring.Available, Is.EqualTo(5));
+
+        float[] destination = new float[5];
+        Assert.That(ring.Read(destination), Is.EqualTo(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(destination, Is.EqualTo(source));
+            Assert.That(ring.Available, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void Ring_WrapsAroundWithoutReordering()
+    {
+        var ring = new AudioRingBuffer(8);
+
+        // Push the cursor most of the way round so the next write straddles the wrap point.
+        ring.Write(new float[] { 9, 9, 9, 9, 9, 9 });
+        ring.Read(new float[6]);
+
+        float[] source = new float[] { 1, 2, 3, 4, 5 };
+        Assert.That(ring.Write(source), Is.EqualTo(5));
+
+        float[] destination = new float[5];
+        Assert.That(ring.Read(destination), Is.EqualTo(5));
+        Assert.That(destination, Is.EqualTo(source));
+    }
+
+    [Test]
+    public void Ring_ShortWriteWhenFullRatherThanOverwriting()
+    {
+        var ring = new AudioRingBuffer(4);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ring.Write(new float[] { 1, 2, 3, 4, 5, 6 }), Is.EqualTo(4), "Should report what it accepted.");
+            Assert.That(ring.FreeSpace, Is.Zero);
+            Assert.That(ring.Write(new float[] { 7 }), Is.Zero);
+        }
+
+        float[] destination = new float[4];
+        ring.Read(destination);
+        Assert.That(destination, Is.EqualTo(new float[] { 1, 2, 3, 4 }), "A full buffer must not clobber unread data.");
+    }
+
+    [Test]
+    public void Ring_ShortReadWhenEmpty()
+    {
+        var ring = new AudioRingBuffer(8);
+        ring.Write(new float[] { 1, 2 });
+
+        float[] destination = new float[5];
+        Assert.That(ring.Read(destination), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Ring_SurvivesConcurrentWriterAndReader()
+    {
+        var ring = new AudioRingBuffer(1024);
+        const int total = 200_000;
+
+        long produced = 0;
+        long consumed = 0;
+        float expectedNext = 0;
+        bool ordered = true;
+
+        var writer = new Thread(() =>
+        {
+            float[] block = new float[64];
+            float next = 0;
+
+            while (produced < total)
+            {
+                for (int i = 0; i < block.Length; i++)
+                    block[i] = next + i;
+
+                int written = ring.Write(block);
+                next += written;
+                produced += written;
+
+                if (written < block.Length)
+                    Thread.Yield();
+            }
+        });
+
+        var reader = new Thread(() =>
+        {
+            float[] block = new float[64];
+
+            while (consumed < total)
+            {
+                int read = ring.Read(block);
+
+                for (int i = 0; i < read; i++)
+                {
+                    if (!Precision.AlmostEquals(block[i], expectedNext))
+                        ordered = false;
+
+                    expectedNext++;
+                }
+
+                consumed += read;
+
+                if (read == 0)
+                    Thread.Yield();
+            }
+        });
+
+        writer.Start();
+        reader.Start();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(writer.Join(TimeSpan.FromSeconds(20)), Is.True, "Writer did not finish.");
+            Assert.That(reader.Join(TimeSpan.FromSeconds(20)), Is.True, "Reader did not finish.");
+        }
+
+        Assert.That(ordered, Is.True, "Data crossed the ring out of order or was duplicated.");
+        Assert.That(consumed, Is.EqualTo(total));
+    }
+
+    #endregion
+
+    #region Converter
+
+    [Test]
+    public void Converter_ResamplesToTheTargetRate()
+    {
+        using var converter = new SdlAudioConverter(22050, 2, 44100, 2);
+
+        // One second of stereo at the source rate should come back as roughly one second at the
+        // target rate, i.e. twice as many frames.
+        float[] input = new float[22050 * 2];
+        converter.Put(input);
+        converter.Flush();
+
+        int total = 0;
+        float[] scratch = new float[8192];
+        int got;
+
+        while ((got = converter.Get(scratch)) > 0)
+            total += got;
+
+        Assert.That(total / 2, Is.EqualTo(44100).Within(2).Percent);
+    }
+
+    [Test]
+    public void Converter_UpmixesMonoToStereo()
+    {
+        using var converter = new SdlAudioConverter(44100, 1, 44100, 2);
+
+        float[] input = new float[1000];
+        Array.Fill(input, 0.5f);
+        converter.Put(input);
+        converter.Flush();
+
+        float[] output = new float[4096];
+        int got = converter.Get(output);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(got, Is.EqualTo(2000).Within(2).Percent, "Mono in should be stereo out, same frame count.");
+            Assert.That(output[0], Is.EqualTo(0.5f).Within(0.001f));
+            Assert.That(output[1], Is.EqualTo(0.5f).Within(0.001f));
+        }
+    }
+
+    [Test]
+    public void Converter_ClearDiscardsPendingAudio()
+    {
+        using var converter = new SdlAudioConverter(44100, 2, 44100, 2);
+
+        converter.Put(new float[4096]);
+        converter.Clear();
+
+        Assert.That(converter.Available, Is.Zero);
+    }
+
+    #endregion
+
+    #region Memory source
+
+    [Test]
+    public void Memory_DecodesToDeviceFormatAndPlaysThrough()
+    {
+        var buffer = PcmBuffer.Decode(open("Samples.test.wav"), device_rate, device_channels);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(buffer.SampleRate, Is.EqualTo(device_rate));
+            Assert.That(buffer.Channels, Is.EqualTo(device_channels));
+            Assert.That(buffer.LengthMs, Is.EqualTo(424.6).Within(5).Percent);
+        }
+
+        using var source = new MemoryPcmSource(buffer);
+
+        float[] destination = new float[512 * device_channels];
+        long frames = 0;
+        int read;
+
+        while ((read = source.ReadFrames(destination, 512)) > 0)
+            frames += read;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(source.Ended, Is.True);
+            Assert.That(frames, Is.EqualTo(buffer.FrameCount));
+            Assert.That(source.PositionMs, Is.EqualTo(buffer.LengthMs).Within(0.001));
+        }
+    }
+
+    [Test]
+    public void Memory_SeekMovesThePositionAndClampsToTheEnds()
+    {
+        var buffer = PcmBuffer.Decode(open("Samples.test.wav"), device_rate, device_channels);
+        using var source = new MemoryPcmSource(buffer);
+
+        source.Seek(200);
+        Assert.That(source.PositionMs, Is.EqualTo(200).Within(1));
+
+        source.Seek(-500);
+        Assert.That(source.PositionMs, Is.Zero);
+
+        source.Seek(buffer.LengthMs * 2);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(source.PositionMs, Is.EqualTo(buffer.LengthMs).Within(0.001));
+            Assert.That(source.Ended, Is.True);
+        }
+    }
+
+    [Test]
+    public void Memory_SourcesOverOneBufferAreIndependent()
+    {
+        var buffer = PcmBuffer.Decode(open("Samples.test.wav"), device_rate, device_channels);
+
+        using var first = new MemoryPcmSource(buffer);
+        using var second = new MemoryPcmSource(buffer);
+
+        first.ReadFrames(new float[256 * device_channels], 256);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first.PositionMs, Is.GreaterThan(0));
+            Assert.That(second.PositionMs, Is.Zero, "Cursors must not be shared between channels.");
+        }
+    }
+
+    [Test]
+    public void Memory_DisposeNotifiesTheOwner()
+    {
+        var buffer = PcmBuffer.Decode(open("Samples.test.wav"), device_rate, device_channels);
+
+        bool released = false;
+        var source = new MemoryPcmSource(buffer, () => released = true);
+
+        source.Dispose();
+        source.Dispose();
+
+        Assert.That(released, Is.True);
+    }
+
+    #endregion
+
+    #region Streaming source
+
+    /// <summary>
+    /// Pumps on the calling thread rather than involving the scheduler, so the test is deterministic.
+    /// </summary>
+    private static void pumpUntilBuffered(StreamingPcmSource source, int maxPumps = 500)
+    {
+        for (int i = 0; i < maxPumps && source.WantsDecode; i++)
+        {
+            if (!source.PumpDecode())
+                break;
+        }
+    }
+
+    [Test]
+    public void Streaming_ReportsLengthAndDecodesAudio()
+    {
+        using var source = new StreamingPcmSource(open("Samples.long.mp3"), device_rate, device_channels);
+
+        Assert.That(source.LengthMs, Is.EqualTo(4500).Within(5).Percent);
+
+        pumpUntilBuffered(source);
+
+        float[] destination = new float[512 * device_channels];
+        int read = source.ReadFrames(destination, 512);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(read, Is.EqualTo(512));
+            Assert.That(source.PositionMs, Is.EqualTo(512 / (double)device_rate * 1000.0).Within(0.001));
+        }
+    }
+
+    [Test]
+    public void Streaming_PlaysThroughToTheEndWithTheRightAmountOfAudio()
+    {
+        using var source = new StreamingPcmSource(open("Samples.long.mp3"), device_rate, device_channels);
+
+        float[] destination = new float[512 * device_channels];
+        long frames = 0;
+
+        var timeout = Stopwatch.StartNew();
+
+        while (!source.Ended && timeout.Elapsed < TimeSpan.FromSeconds(30))
+        {
+            pumpUntilBuffered(source, 8);
+            frames += source.ReadFrames(destination, 512);
+        }
+
+        double decodedMs = frames / (double)device_rate * 1000.0;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(source.Ended, Is.True, "Source never reached the end.");
+            Assert.That(decodedMs, Is.EqualTo(source.LengthMs).Within(2).Percent);
+        }
+    }
+
+    [Test]
+    public void Streaming_SeekReportsTheNewPositionImmediately()
+    {
+        using var source = new StreamingPcmSource(open("Samples.long.mp3"), device_rate, device_channels);
+
+        pumpUntilBuffered(source);
+        source.ReadFrames(new float[512 * device_channels], 512);
+
+        // The decode happens on another thread in production, so the position has to move on the
+        // caller's thread or a read-after-write sees a stale value.
+        source.Seek(2000);
+        Assert.That(source.PositionMs, Is.EqualTo(2000).Within(0.001));
+
+        pumpUntilBuffered(source);
+        int read = source.ReadFrames(new float[512 * device_channels], 512);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(read, Is.GreaterThan(0), "No audio after seeking.");
+            Assert.That(source.PositionMs, Is.GreaterThan(2000));
+        }
+    }
+
+    [Test]
+    public void Streaming_SeekBackToTheStartAfterEndingResumesPlayback()
+    {
+        using var source = new StreamingPcmSource(open("Samples.long.mp3"), device_rate, device_channels);
+
+        float[] destination = new float[4096 * device_channels];
+        var timeout = Stopwatch.StartNew();
+
+        while (!source.Ended && timeout.Elapsed < TimeSpan.FromSeconds(30))
+        {
+            pumpUntilBuffered(source, 8);
+            source.ReadFrames(destination, 4096);
+        }
+
+        Assert.That(source.Ended, Is.True);
+
+        // This is what looping does every time a track wraps.
+        source.Seek(0);
+        Assert.That(source.Ended, Is.False, "Seek must clear the ended state.");
+
+        pumpUntilBuffered(source);
+
+        Assert.That(source.ReadFrames(destination, 512), Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void Streaming_ReadingAheadOfTheDecoderCountsAnUnderrunRatherThanEnding()
+    {
+        using var source = new StreamingPcmSource(open("Samples.long.mp3"), device_rate, device_channels);
+
+        // Nothing has been decoded yet, so this read cannot be satisfied.
+        int read = source.ReadFrames(new float[512 * device_channels], 512);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(read, Is.Zero);
+            Assert.That(source.Underruns, Is.EqualTo(1));
+            Assert.That(source.Ended, Is.False, "Starving the mixer is not the end of the source.");
+        }
+    }
+
+    [Test]
+    public void Streaming_SchedulerKeepsTheBufferFed()
+    {
+        using var scheduler = new AudioDecodeScheduler();
+        using var source = new StreamingPcmSource(open("Samples.long.mp3"), device_rate, device_channels);
+
+        scheduler.Register(source);
+
+        float[] destination = new float[512 * device_channels];
+        long frames = 0;
+        var timeout = Stopwatch.StartNew();
+
+        // Drain at roughly real time and let the decode thread keep up on its own.
+        while (frames < device_rate * 2 && timeout.Elapsed < TimeSpan.FromSeconds(30))
+        {
+            int read = source.ReadFrames(destination, 512);
+
+            if (read == 0)
+            {
+                Thread.Sleep(1);
+                continue;
+            }
+
+            frames += read;
+            Thread.Sleep(5);
+        }
+
+        scheduler.Unregister(source);
+
+        Assert.That(frames, Is.GreaterThanOrEqualTo(device_rate * 2), "Decode thread failed to keep two seconds of audio flowing.");
+    }
+
+    [Test]
+    public void Streaming_DisposeIsSafeWhileTheSchedulerIsRunning()
+    {
+        var scheduler = new AudioDecodeScheduler();
+        var source = new StreamingPcmSource(open("Tracks.test.mp3"), device_rate, device_channels);
+
+        scheduler.Register(source);
+        Thread.Sleep(20);
+
+        Assert.DoesNotThrow(() =>
+        {
+            scheduler.Unregister(source);
+            source.Dispose();
+            scheduler.Dispose();
+        });
+    }
+
+    [Test]
+    public void Streaming_RejectsANonAudioSource()
+    {
+        Assert.Throws<InvalidDataException>(() =>
+            _ = new StreamingPcmSource(new MemoryStream(new byte[4096]), device_rate, device_channels));
+    }
+
+    #endregion
+}

--- a/Sakura.Framework.Tests/Audio/SdlPcmSourceTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlPcmSourceTest.cs
@@ -164,7 +164,7 @@ public class SdlPcmSourceTest
     [Test]
     public void Converter_ResamplesToTheTargetRate()
     {
-        using var converter = new SdlAudioConverter(22050, 2, 44100, 2);
+        using var converter = new SDLAudioConverter(22050, 2, 44100, 2);
 
         // One second of stereo at the source rate should come back as roughly one second at the
         // target rate, i.e. twice as many frames.
@@ -185,7 +185,7 @@ public class SdlPcmSourceTest
     [Test]
     public void Converter_UpmixesMonoToStereo()
     {
-        using var converter = new SdlAudioConverter(44100, 1, 44100, 2);
+        using var converter = new SDLAudioConverter(44100, 1, 44100, 2);
 
         float[] input = new float[1000];
         Array.Fill(input, 0.5f);
@@ -206,7 +206,7 @@ public class SdlPcmSourceTest
     [Test]
     public void Converter_ClearDiscardsPendingAudio()
     {
-        using var converter = new SdlAudioConverter(44100, 2, 44100, 2);
+        using var converter = new SDLAudioConverter(44100, 2, 44100, 2);
 
         converter.Put(new float[4096]);
         converter.Clear();

--- a/Sakura.Framework.Tests/Rendering/DrawNodeStaleBufferTest.cs
+++ b/Sakura.Framework.Tests/Rendering/DrawNodeStaleBufferTest.cs
@@ -1,0 +1,172 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Drawables;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Maths;
+using Sakura.Framework.Timing;
+
+namespace Sakura.Framework.Tests.Rendering;
+
+/// <summary>
+/// Reproduction for the "stuttering drawable" bug: a drawable that is invalidated *after* its own
+/// update pass (but before this frame's draw-node generation) stamps the current buffer's node with
+/// the new invalidation id while the node still holds the pre-change geometry. That buffer then
+/// never re-applies, so the drawn value flickers between the old and the new one at draw rate.
+/// </summary>
+[TestFixture]
+public class DrawNodeStaleBufferTest
+{
+    private ManualClock manual = null!;
+    private Container root = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        manual = new ManualClock { CurrentTime = 1000 };
+        root = new Container
+        {
+            Size = new Vector2(800, 600),
+            Clock = new FramedClock(manual)
+        };
+
+        root.Load();
+        root.LoadComplete();
+    }
+
+    /// <summary>
+    /// One host frame: update pass, then draw-node generation into the given buffer, exactly as
+    /// AppHost.PerformUpdate does.
+    /// </summary>
+    private ContainerDrawNode frame(int buffer)
+    {
+        manual.CurrentTime += 16;
+        root.UpdateSubTree();
+        return (ContainerDrawNode)root.GenerateDrawNodeSubtree(buffer);
+    }
+
+    [Test]
+    public void TestChangeAfterUpdatePassReachesEveryBuffer()
+    {
+        var box = new Box { Position = new Vector2(10, 10), Size = new Vector2(50) };
+        root.Add(box);
+
+        for (int i = 0; i < 6; i++)
+            frame(i % 3);
+
+        // The change lands after this frame's update traversal already passed over the box —
+        // e.g. a sibling that updates later in the traversal writing to it, or a callback.
+        manual.CurrentTime += 16;
+        root.UpdateSubTree();
+        box.Position = new Vector2(200, 10);
+        root.GenerateDrawNodeSubtree(0);
+
+        // Nothing else changes from here on. Every buffer must converge on the new position.
+        for (int i = 0; i < 9; i++)
+        {
+            var node = frame((i + 1) % 3);
+            float x = node.Children[0].DrawRectangle.X;
+
+            Assert.That(x, Is.EqualTo(200).Within(0.01f),
+                $"Frame {i} (buffer {(i + 1) % 3}) drew X={x}; the change must be visible in every buffer.");
+        }
+    }
+
+    /// <summary>
+    /// The same thing without reaching in by hand: children are updated back-to-front, so a
+    /// drawable written to by a sibling that sits *later* in the list is always written to after
+    /// its own update pass. (This is the shape of a gameplay HUD whose score text is driven by a
+    /// playfield added before it.)
+    /// </summary>
+    [Test]
+    public void TestWriteFromLaterUpdatingSiblingReachesEveryBuffer()
+    {
+        var target = new Box { Position = new Vector2(10, 10), Size = new Vector2(50) };
+        var writer = new Writer(target);
+
+        // writer first, target second: the traversal runs target's update before writer's.
+        root.Add(writer);
+        root.Add(target);
+
+        for (int i = 0; i < 6; i++)
+            frame(i % 3);
+
+        writer.NextPosition = new Vector2(200, 10);
+
+        // The frame of the write itself legitimately still draws the old geometry: the new one does
+        // not exist until the next update pass recomputes it. Every frame after that must be current.
+        frame(0);
+
+        for (int i = 1; i < 10; i++)
+        {
+            var node = frame(i % 3);
+            var targetNode = node.Children[node.Children.Count - 1];
+
+            Assert.That(targetNode.DrawRectangle.X, Is.EqualTo(200).Within(0.01f),
+                $"Frame {i} (buffer {i % 3}) drew X={targetNode.DrawRectangle.X}; a sibling's write must reach every buffer.");
+        }
+    }
+
+    private partial class Writer : Drawable
+    {
+        public Vector2? NextPosition;
+
+        private readonly Drawable target;
+
+        public Writer(Drawable target)
+        {
+            this.target = target;
+        }
+
+        public override void Update()
+        {
+            base.Update();
+
+            if (NextPosition is Vector2 position)
+            {
+                target.Position = position;
+                NextPosition = null;
+            }
+        }
+    }
+
+    [Test]
+    public void TestMaskedAwayMovementReachesEveryBufferOnReturn()
+    {
+        var masked = new Container { Size = new Vector2(200, 200), Masking = true };
+        var box = new Box { Position = new Vector2(10, 10), Size = new Vector2(50) };
+        masked.Add(box);
+        root.Add(masked);
+
+        for (int i = 0; i < 6; i++)
+            frame(i % 3);
+
+        // Leave the masking bounds, keep moving while outside, then come back to a new position.
+        box.Position = new Vector2(500, 500);
+        for (int i = 0; i < 3; i++)
+            frame(i % 3);
+
+        box.Position = new Vector2(600, 600);
+        for (int i = 0; i < 3; i++)
+            frame(i % 3);
+
+        box.Position = new Vector2(120, 20);
+        for (int i = 0; i < 9; i++)
+        {
+            var maskedNode = (ContainerDrawNode)frame(i % 3).Children[0];
+            Assert.That(maskedNode.Children, Has.Count.EqualTo(1), $"Frame {i}: the box must be back in the draw tree.");
+
+            float x = maskedNode.Children[0].DrawRectangle.X;
+            Assert.That(x, Is.EqualTo(120).Within(0.01f),
+                $"Frame {i} (buffer {i % 3}) drew X={x}; a drawable returning from masking must be current in every buffer.");
+        }
+    }
+}

--- a/Sakura.Framework.Tests/Visuals/Audio/TestLowPassFilter.cs
+++ b/Sakura.Framework.Tests/Visuals/Audio/TestLowPassFilter.cs
@@ -4,7 +4,6 @@
 using NUnit.Framework;
 using Sakura.Framework.Allocation;
 using Sakura.Framework.Audio;
-using Sakura.Framework.Audio.BassEngine;
 using Sakura.Framework.Testing;
 
 namespace Sakura.Framework.Tests.Visuals.Audio;
@@ -18,7 +17,7 @@ public partial class TestLowPassFilter : TestScene
 
     private ITrack track = null!;
     private IAudioChannel channel = null!;
-    private BassLowPassFilter filter = null!;
+    private ILowPassFilter filter = null!;
 
     public override void Load()
     {
@@ -35,7 +34,7 @@ public partial class TestLowPassFilter : TestScene
             channel.Play();
         });
 
-        AddStep("Attach low-pass filter", () => filter = channel.AddLowPassFilter());
+        AddStep("Attach low-pass filter", () => filter = channel.AddLowPassFilter()!);
         AddAssert("Filter was created", () => filter != null);
     }
 
@@ -45,7 +44,7 @@ public partial class TestLowPassFilter : TestScene
         createFilteredChannel();
 
         AddAssert("Cutoff starts at default",
-            () => filter.CutoffFrequency.Value == BassLowPassFilter.DefaultCutoffFrequency);
+            () => filter.CutoffFrequency.Value == ILowPassFilter.DefaultCutoffFrequency);
     }
 
     [Test]
@@ -71,7 +70,7 @@ public partial class TestLowPassFilter : TestScene
     {
         createFilteredChannel();
 
-        AddSliderStep("Cutoff frequency (Hz)", 1.0, 22050.0, BassLowPassFilter.DefaultCutoffFrequency,
+        AddSliderStep("Cutoff frequency (Hz)", 1.0, 22050.0, ILowPassFilter.DefaultCutoffFrequency,
             v => filter.CutoffFrequency.Value = v);
     }
 
@@ -96,7 +95,7 @@ public partial class TestLowPassFilter : TestScene
         AddAssert("Cutoff is 500Hz", () => filter.CutoffFrequency.Value == 500);
         AddStep("Reset filter", () => filter.Reset());
         AddAssert("Cutoff back to default",
-            () => filter.CutoffFrequency.Value == BassLowPassFilter.DefaultCutoffFrequency);
+            () => filter.CutoffFrequency.Value == ILowPassFilter.DefaultCutoffFrequency);
     }
 
     [Test]

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -135,6 +135,7 @@ public partial class App : Container, IFocusManager, IInputManagerProvider
         Cache(Host.Window);
 
         AudioManager = CreateAudioManager();
+        Host.AudioManager = AudioManager;
         var masterVolume = Host.FrameworkConfigManager.Get<double>(FrameworkSetting.MasterVolume);
         var trackVolume = Host.FrameworkConfigManager.Get<double>(FrameworkSetting.TrackVolume);
         var sampleVolume = Host.FrameworkConfigManager.Get<double>(FrameworkSetting.SampleVolume);

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -21,6 +21,7 @@ using Sakura.Framework.Graphics.Text;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Graphics.Video;
 using Sakura.Framework.Input;
+using Sakura.Framework.Logging;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Platform.Dialogs;
 using Sakura.Framework.Reactive;
@@ -270,12 +271,24 @@ public partial class App : Container, IFocusManager, IInputManagerProvider
     protected virtual IImageLoader CreateImageLoader() => new ImageSharpImageLoader();
 
     /// <summary>
-    /// Create the audio manager used for this app, defaults to <see cref="BassAudioManager"/>.
+    /// Create the audio manager used for this app, selected by
+    /// <see cref="FrameworkSetting.AudioBackend"/> and default to <see cref="BassAudioManager"/>.
     /// </summary>
     protected virtual IAudioManager CreateAudioManager()
     {
         if (Host.IsHeadless)
             return new HeadlessAudioManager();
+
+        var backend = Host.FrameworkConfigManager.Get<AudioBackend>(FrameworkSetting.AudioBackend).Value;
+
+        switch (backend)
+        {
+            case AudioBackend.SDL:
+                // TODO: waiting for SDL audio backend implementation
+                Logger.Warning("The SDL audio backend is not implemented yet, falling back to BASS.");
+                break;
+        }
+
         return new BassAudioManager();
     }
 

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using Sakura.Framework.Audio;
 using Sakura.Framework.Audio.BassEngine;
 using Sakura.Framework.Audio.Headless;
+using Sakura.Framework.Audio.SdlEngine;
 using Sakura.Framework.Configurations;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Drawables;
@@ -284,8 +285,15 @@ public partial class App : Container, IFocusManager, IInputManagerProvider
         switch (backend)
         {
             case AudioBackend.SDL:
-                // TODO: waiting for SDL audio backend implementation
-                Logger.Warning("The SDL audio backend is not implemented yet, falling back to BASS.");
+                try
+                {
+                    return new SDLAudioManager();
+                }
+                catch (Exception e)
+                {
+                    Logger.Error("Failed to initialise the SDL audio backend, falling back to BASS.", e);
+                }
+
                 break;
         }
 

--- a/Sakura.Framework/Audio/AudioBackend.cs
+++ b/Sakura.Framework/Audio/AudioBackend.cs
@@ -1,0 +1,29 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Audio;
+
+/// <summary>
+/// The audio backend an app plays sound through
+/// </summary>
+public enum AudioBackend
+{
+    /// <summary>
+    /// Let the framework pick
+    /// </summary>
+    Automatic,
+
+    /// <summary>
+    /// The BASS backend
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    BASS,
+
+    /// <summary>
+    /// The SDL3 audio backend
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    SDL
+}

--- a/Sakura.Framework/Audio/AudioChannelExtensions.cs
+++ b/Sakura.Framework/Audio/AudioChannelExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Sakura.Framework.Audio.BassEngine;
+using Sakura.Framework.Audio.SdlEngine;
 using Sakura.Framework.Extensions.ObjectExtensions;
 
 namespace Sakura.Framework.Audio;
@@ -97,11 +98,16 @@ public static class AudioChannelExtensions
     /// </returns>
     public static ILowPassFilter? AddLowPassFilter(this IAudioChannel channel)
     {
-        if (channel is BassAudioChannel bassChannel)
+        switch (channel)
         {
-            return new BassLowPassFilter(bassChannel.ChannelHandle);
-        }
+            case BassAudioChannel bassChannel:
+                return new BassLowPassFilter(bassChannel.ChannelHandle);
 
-        return null;
+            case SDLAudioChannel sdlChannel:
+                return sdlChannel.AttachLowPassFilter();
+
+            default:
+                return null;
+        }
     }
 }

--- a/Sakura.Framework/Audio/AudioChannelExtensions.cs
+++ b/Sakura.Framework/Audio/AudioChannelExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Sakura.Framework.Audio.BassEngine;
+using Sakura.Framework.Extensions.ObjectExtensions;
 
 namespace Sakura.Framework.Audio;
 
@@ -20,7 +21,7 @@ public static class AudioChannelExtensions
     /// <param name="duration">How long the fade should take in milliseconds.</param>
     public static async Task FadeVolumeToAsync(this IAudioChannel channel, double targetVolume, int duration)
     {
-        if (channel == null) return;
+        if (channel.IsNull()) return;
 
         if (duration <= 0)
         {
@@ -90,16 +91,17 @@ public static class AudioChannelExtensions
     /// <summary>
     /// Applies a reactive Low-Pass filter to the target audio channel.
     /// </summary>
-    /// <returns>The <see cref="BassLowPassFilter"/> instance to control the cutoff frequency.</returns>
-    public static BassLowPassFilter AddLowPassFilter(this IAudioChannel channel)
+    /// <returns>
+    /// An <see cref="ILowPassFilter"/> controlling the cutoff frequency, or null if the channel's
+    /// backend does not support filtering (e.g., the headless backend).
+    /// </returns>
+    public static ILowPassFilter? AddLowPassFilter(this IAudioChannel channel)
     {
         if (channel is BassAudioChannel bassChannel)
         {
-            // Attach the effect directly to the internal BASS handle
             return new BassLowPassFilter(bassChannel.ChannelHandle);
         }
 
-        // Return null or a dummy filter if running in Headless mode
         return null;
     }
 }

--- a/Sakura.Framework/Audio/BassEngine/BassLowPassFilter.cs
+++ b/Sakura.Framework/Audio/BassEngine/BassLowPassFilter.cs
@@ -12,20 +12,14 @@ namespace Sakura.Framework.Audio.BassEngine;
 /// <summary>
 /// Apply low-pass filter effect to a BASS channel or mixer.
 /// </summary>
-public class BassLowPassFilter : IDisposable
+public class BassLowPassFilter : ILowPassFilter
 {
     private readonly int targetChannelHandle;
     private int fxHandle;
     private bool isDisposed;
 
-    public static double DefaultCutoffFrequency => 20000.0; // 44.1kHz
-
-    /// <summary>
-    /// The cutoff frequency of the filter in Hertz.
-    /// Frequencies above this value will be reduced.
-    /// Max is typically half the sample rate (e.g., 22050 for a 44100Hz stream).
-    /// </summary>
-    public Reactive<double> CutoffFrequency { get; } = new Reactive<double>(DefaultCutoffFrequency);
+    /// <inheritdoc cref="ILowPassFilter.CutoffFrequency"/>
+    public Reactive<double> CutoffFrequency { get; } = new Reactive<double>(ILowPassFilter.DefaultCutoffFrequency);
 
     public BassLowPassFilter(int channelHandle, int priority = 0)
     {
@@ -76,7 +70,7 @@ public class BassLowPassFilter : IDisposable
     {
         if (fxHandle == 0 || isDisposed) return;
 
-        CutoffFrequency.Value = DefaultCutoffFrequency;
+        CutoffFrequency.Value = ILowPassFilter.DefaultCutoffFrequency;
     }
 
     public void Dispose()

--- a/Sakura.Framework/Audio/ILowPassFilter.cs
+++ b/Sakura.Framework/Audio/ILowPassFilter.cs
@@ -1,0 +1,34 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using Sakura.Framework.Reactive;
+
+namespace Sakura.Framework.Audio;
+
+/// <summary>
+/// A low-pass filter attached to an <see cref="IAudioChannel"/>, cut off frequencies above
+/// <see cref="CutoffFrequency"/>. Obtained from <see cref="AudioChannelExtensions.AddLowPassFilter"/>.
+/// </summary>
+public interface ILowPassFilter : IDisposable
+{
+    /// <summary>
+    /// The cutoff frequency a filter starts at in Hertz, and the value <see cref="Reset"/> returns to.
+    /// </summary>
+    static double DefaultCutoffFrequency => 20000.0;
+
+    /// <summary>
+    /// The cutoff frequency of the filter in Hertz. Frequencies above this value are reduced.
+    /// </summary>
+    /// <remarks>
+    /// Backends clamp this to what the channel can express at most half the stream's sample rate
+    /// (e.g., 22050 for a 44100Hz stream), so the value read back from the underlying filter may be
+    /// lower than the value written here.
+    /// </remarks>
+    Reactive<double> CutoffFrequency { get; }
+
+    /// <summary>
+    /// Resets <see cref="CutoffFrequency"/> to <see cref="DefaultCutoffFrequency"/>.
+    /// </summary>
+    void Reset();
+}

--- a/Sakura.Framework/Audio/SdlEngine/AmplitudeTap.cs
+++ b/Sakura.Framework/Audio/SdlEngine/AmplitudeTap.cs
@@ -1,0 +1,191 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Threading;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// A metering tap on one point in the mix graph: the mix thread pushes the audio passing through it,
+/// and the update thread pulls a <see cref="ChannelAmplitudes"/> snapshot for visualizers.
+/// </summary>
+/// <remarks>
+/// Behavior is matched to <see cref="BassEngine.BassAudioChannel"/>, see that class for original behavior
+/// </remarks>
+internal sealed class AmplitudeTap
+{
+    /// <summary>
+    /// Minimum interval between recomputing. Matches the BASS backend and means several visualizers
+    /// reading the same tap in one frame share a single transform.
+    /// </summary>
+    private const long cache_interval_ms = 15;
+
+    // Per-frame temporal damping of the spectrum so visualizers receive a smooth signal rather than
+    // the raw, jittery FFT. Each refresh eases the stored value toward the new reading, retaining
+    // this fraction of the old value per ~60fps frame. Copied from BassAudioChannel, including the
+    // framerate-independence: the retained fraction shrinks as more time passes.
+    private const double amplitude_retain_per_frame = 0.4;
+    private const double amplitude_reference_frame_ms = 1000.0 / 60.0;
+
+    private readonly Lock sync = new Lock();
+
+    private readonly AudioFft fft = new AudioFft();
+
+    /// <summary>
+    /// The most recent <see cref="AudioFft.FFT_SIZE"/> mono samples, as a circular buffer.
+    /// </summary>
+    private readonly float[] capture = new float[AudioFft.FFT_SIZE];
+
+    private int captureWritePosition;
+
+    /// <summary>
+    /// Whether anything has been fed since the last <see cref="Reset"/>. Until then the capture
+    /// window is silence, and a visualizer should see an empty spectrum rather than a decaying one.
+    /// </summary>
+    private bool hasAudio;
+
+    private float pendingPeakLeft;
+    private float pendingPeakRight;
+
+    private readonly float[] scratch = new float[AudioFft.FFT_SIZE];
+    private readonly float[] rawBins = new float[AudioFft.BIN_COUNT];
+    private readonly float[] dampedBins = new float[AudioFft.BIN_COUNT];
+
+    private long lastReadTick;
+    private ChannelAmplitudes cached = ChannelAmplitudes.Empty;
+
+    /// <summary>
+    /// The peak level of the left channel over the interval preceding the last <see cref="Read"/>.
+    /// </summary>
+    public float AmplitudeLeft { get; private set; }
+
+    /// <summary>
+    /// The peak level of the right channel over the interval preceding the last <see cref="Read"/>.
+    /// </summary>
+    public float AmplitudeRight { get; private set; }
+
+    /// <summary>
+    /// Records a block of interleaved stereo audio passing through this point.
+    /// </summary>
+    /// <remarks>
+    /// Peaks accumulate until the next <see cref="Read"/> consumes them, so a reader polling at 60Hz
+    /// sees the true peak of that frame's audio rather than whatever the last sample happened to be.
+    /// </remarks>
+    public void Feed(ReadOnlySpan<float> interleavedStereo)
+    {
+        if (interleavedStereo.IsEmpty)
+            return;
+
+        lock (sync)
+        {
+            float peakLeft = pendingPeakLeft;
+            float peakRight = pendingPeakRight;
+            int position = captureWritePosition;
+
+            for (int i = 0; i + 1 < interleavedStereo.Length; i += 2)
+            {
+                float left = interleavedStereo[i];
+                float right = interleavedStereo[i + 1];
+
+                float absoluteLeft = Math.Abs(left);
+                float absoluteRight = Math.Abs(right);
+
+                if (absoluteLeft > peakLeft) peakLeft = absoluteLeft;
+                if (absoluteRight > peakRight) peakRight = absoluteRight;
+
+                // BASS folds both channels into one spectrum unless asked for individual FFTs, so
+                // average rather than picking a side.
+                capture[position] = (left + right) * 0.5f;
+                position = position + 1 == capture.Length ? 0 : position + 1;
+            }
+
+            pendingPeakLeft = peakLeft;
+            pendingPeakRight = peakRight;
+            captureWritePosition = position;
+            hasAudio = true;
+        }
+    }
+
+    /// <summary>
+    /// Returns the current amplitude snapshot, recomputing at most once per
+    /// <see cref="cache_interval_ms"/>.
+    /// </summary>
+    /// <remarks>
+    /// The returned <see cref="ChannelAmplitudes"/> wraps a buffer this tap reuses, matching the BASS
+    /// backend: callers must consume it before the next read rather than holding onto it.
+    /// </remarks>
+    public ChannelAmplitudes Read()
+    {
+        long now = Environment.TickCount64;
+        long elapsed = now - lastReadTick;
+
+        if (elapsed < cache_interval_ms)
+            return cached;
+
+        lastReadTick = now;
+
+        bool any;
+        int start;
+
+        lock (sync)
+        {
+            any = hasAudio;
+            start = captureWritePosition;
+
+            if (any)
+            {
+                // Unwrap oldest-to-newest so the window the FFT sees is contiguous in time.
+                int tail = capture.Length - start;
+                capture.AsSpan(start, tail).CopyTo(scratch);
+                capture.AsSpan(0, start).CopyTo(scratch.AsSpan(tail));
+            }
+
+            AmplitudeLeft = pendingPeakLeft;
+            AmplitudeRight = pendingPeakRight;
+            pendingPeakLeft = 0;
+            pendingPeakRight = 0;
+        }
+
+        if (!any)
+        {
+            Array.Clear(dampedBins);
+            cached = new ChannelAmplitudes(0f, 0f, dampedBins);
+            return cached;
+        }
+
+        fft.Compute(scratch, rawBins);
+
+        // Ease each bin toward its new reading instead of snapping, retaining less of the old value
+        // the more time has passed since the previous read.
+        float retain = (float)Math.Pow(amplitude_retain_per_frame, elapsed / amplitude_reference_frame_ms);
+
+        for (int i = 0; i < dampedBins.Length; i++)
+            dampedBins[i] = rawBins[i] + (dampedBins[i] - rawBins[i]) * retain;
+
+        cached = new ChannelAmplitudes(AmplitudeLeft, AmplitudeRight, dampedBins);
+        return cached;
+    }
+
+    /// <summary>
+    /// Drops all captured audio and metering state, so a stopped or seeked channel does not report a
+    /// spectrum from where it used to be.
+    /// </summary>
+    public void Reset()
+    {
+        lock (sync)
+        {
+            Array.Clear(capture);
+            captureWritePosition = 0;
+            hasAudio = false;
+            pendingPeakLeft = 0;
+            pendingPeakRight = 0;
+        }
+
+        Array.Clear(dampedBins);
+        AmplitudeLeft = 0;
+        AmplitudeRight = 0;
+        lastReadTick = 0;
+        cached = ChannelAmplitudes.Empty;
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/AudioDecodeScheduler.cs
+++ b/Sakura.Framework/Audio/SdlEngine/AudioDecodeScheduler.cs
@@ -1,0 +1,133 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Sakura.Framework.Logging;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// The single background thread that keeps every playing track's buffer topped up.
+/// </summary>
+internal sealed class AudioDecodeScheduler : IDisposable
+{
+    /// <summary>
+    /// How long to idle when no source wanted work. Short relative to the buffer being maintained,
+    /// so the buffer never gets close to empty through scheduling alone.
+    /// </summary>
+    private static readonly TimeSpan idle_delay = TimeSpan.FromMilliseconds(5);
+
+    /// <summary>
+    /// Maximum consecutive pumps for one source before moving on.
+    /// </summary>
+    private const int max_pumps_per_source = 8;
+
+    private readonly List<StreamingPcmSource> sources = new List<StreamingPcmSource>();
+    private readonly Lock sync = new Lock();
+    private readonly AutoResetEvent wakeup = new AutoResetEvent(false);
+    private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
+    private readonly Thread thread;
+
+    private StreamingPcmSource[] snapshot = Array.Empty<StreamingPcmSource>();
+
+    public AudioDecodeScheduler()
+    {
+        thread = new Thread(run)
+        {
+            Name = "SdlAudioDecode",
+            IsBackground = true,
+
+            // Above normal but below the mix thread: falling behind here is an audible dropout, but
+            // it must never be the thing that delays the mixer itself.
+            Priority = ThreadPriority.AboveNormal
+        };
+
+        thread.Start();
+    }
+
+    public void Register(StreamingPcmSource source)
+    {
+        lock (sync)
+        {
+            sources.Add(source);
+            snapshot = sources.ToArray();
+        }
+
+        // A newly started track has an empty buffer, do not make it wait out an idle delay.
+        wakeup.Set();
+    }
+
+    public void Unregister(StreamingPcmSource source)
+    {
+        lock (sync)
+        {
+            sources.Remove(source);
+            snapshot = sources.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Nudges the decode thread, for when a source suddenly needs work. A seek, or playback
+    /// starting rather than waiting for the next idle poll.
+    /// </summary>
+    public void Wake() => wakeup.Set();
+
+    private void run()
+    {
+        while (!cancellation.IsCancellationRequested)
+        {
+            bool didWork = false;
+
+            // registration during a pass is picked up next time
+            // around, which is soon enough and keeps the lock off the decode path.
+            var current = snapshot;
+
+            foreach (var source in current)
+            {
+                if (cancellation.IsCancellationRequested)
+                    break;
+
+                try
+                {
+                    for (int i = 0; i < max_pumps_per_source && source.WantsDecode; i++)
+                    {
+                        if (!source.PumpDecode())
+                            break;
+
+                        didWork = true;
+                    }
+                }
+                catch (Exception e)
+                {
+                    // One bad file must not take the decode thread down with it and silence
+                    // everything else that is playing.
+                    Logger.Error($"[AudioDecodeScheduler] Decoding failed for a source; dropping it.", e);
+                    Unregister(source);
+                }
+            }
+
+            if (!didWork)
+                wakeup.WaitOne(idle_delay);
+        }
+    }
+
+    public void Dispose()
+    {
+        cancellation.Cancel();
+        wakeup.Set();
+
+        if (!thread.Join(TimeSpan.FromSeconds(2)))
+            Logger.Error("[AudioDecodeScheduler] Decode thread did not exit in time.");
+
+        lock (sync)
+        {
+            sources.Clear();
+            snapshot = Array.Empty<StreamingPcmSource>();
+        }
+
+        wakeup.Dispose();
+        cancellation.Dispose();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/AudioFft.cs
+++ b/Sakura.Framework/Audio/SdlEngine/AudioFft.cs
@@ -1,0 +1,129 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Numerics;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// A fixed-size real-input radix-2 FFT producing the magnitude spectrum a visualizer consumes.
+/// </summary>
+internal sealed class AudioFft
+{
+    /// <summary>
+    /// The transform size. Must stay a power of two. Size reference from the original BASS FFT implementation.
+    /// </summary>
+    public const int FFT_SIZE = 512;
+
+    /// <summary>
+    /// The number of magnitude bins produced, covering DC up to (but excluding) Nyquist.
+    /// </summary>
+    public const int BIN_COUNT = ChannelAmplitudes.AMPLITUDES_SIZE;
+
+    private static readonly float[] window = buildHannWindow();
+    private static readonly int[] bit_reversal = buildBitReversal();
+
+    private readonly float[] real = new float[FFT_SIZE];
+    private readonly float[] imaginary = new float[FFT_SIZE];
+
+    static AudioFft()
+    {
+        // A 512-point transform must produce exactly 256 bins for the spectrum to line up with what
+        // ChannelAmplitudes promises; if either constant moves, this stops being true.
+        if (FFT_SIZE / 2 != BIN_COUNT)
+            throw new InvalidOperationException($"{nameof(FFT_SIZE)} must be twice {nameof(BIN_COUNT)}.");
+    }
+
+    private static float[] buildHannWindow()
+    {
+        float[] result = new float[FFT_SIZE];
+
+        for (int i = 0; i < FFT_SIZE; i++)
+            result[i] = (float)(0.5 * (1.0 - Math.Cos(2.0 * Math.PI * i / (FFT_SIZE - 1))));
+
+        return result;
+    }
+
+    private static int[] buildBitReversal()
+    {
+        int[] result = new int[FFT_SIZE];
+        int bits = BitOperations.Log2(FFT_SIZE);
+
+        for (int i = 0; i < FFT_SIZE; i++)
+        {
+            int reversed = 0;
+
+            for (int bit = 0; bit < bits; bit++)
+            {
+                if ((i & (1 << bit)) != 0)
+                    reversed |= 1 << (bits - 1 - bit);
+            }
+
+            result[i] = reversed;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Transforms <paramref name="samples"/> and writes <see cref="BIN_COUNT"/> magnitudes into
+    /// <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="samples">
+    /// Mono input. Fewer than <see cref="FFT_SIZE"/> samples are zero-padded; more are truncated.
+    /// </param>
+    /// <param name="destination">Receives the magnitudes. Must hold at least <see cref="BIN_COUNT"/> floats.</param>
+    /// <remarks>
+    /// Magnitudes are scaled so a bin-centred full-scale sine reads back at its own peak amplitude —
+    /// the <c>2 / (N * coherentGain)</c> correction, which for Hann is <c>4 / N</c>. Values are not
+    /// clipped to 1.0: input above unity is normal (see <c>FFmpegAudioDecoderTest</c>) and clamping
+    /// here would hide it from a visualiser. Exact scale parity with BASS is a Phase 5 A/B item.
+    /// </remarks>
+    public void Compute(ReadOnlySpan<float> samples, Span<float> destination)
+    {
+        if (destination.Length < BIN_COUNT)
+            throw new ArgumentException($"Destination must hold at least {BIN_COUNT} bins.", nameof(destination));
+
+        int count = Math.Min(samples.Length, FFT_SIZE);
+
+        // Window into bit-reversed order in one pass, so the butterflies below can run in place.
+        Array.Clear(real);
+        Array.Clear(imaginary);
+
+        for (int i = 0; i < count; i++)
+            real[bit_reversal[i]] = samples[i] * window[i];
+
+        for (int size = 2; size <= FFT_SIZE; size <<= 1)
+        {
+            int half = size / 2;
+            double angleStep = -2.0 * Math.PI / size;
+
+            for (int start = 0; start < FFT_SIZE; start += size)
+            {
+                for (int k = 0; k < half; k++)
+                {
+                    double angle = angleStep * k;
+                    float twiddleReal = (float)Math.Cos(angle);
+                    float twiddleImaginary = (float)Math.Sin(angle);
+
+                    int even = start + k;
+                    int odd = even + half;
+
+                    float oddReal = real[odd] * twiddleReal - imaginary[odd] * twiddleImaginary;
+                    float oddImaginary = real[odd] * twiddleImaginary + imaginary[odd] * twiddleReal;
+
+                    real[odd] = real[even] - oddReal;
+                    imaginary[odd] = imaginary[even] - oddImaginary;
+                    real[even] += oddReal;
+                    imaginary[even] += oddImaginary;
+                }
+            }
+        }
+
+        const float scale = 4f / FFT_SIZE;
+
+        for (int i = 0; i < BIN_COUNT; i++)
+            destination[i] = MathF.Sqrt(real[i] * real[i] + imaginary[i] * imaginary[i]) * scale;
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/AudioRingBuffer.cs
+++ b/Sakura.Framework/Audio/SdlEngine/AudioRingBuffer.cs
@@ -1,0 +1,131 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Threading;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// A fixed-capacity circular buffer of floats, written by a decode thread and read by the mix
+/// thread.
+/// </summary>
+internal sealed class AudioRingBuffer
+{
+    private readonly Lock sync = new Lock();
+    private readonly float[] buffer;
+
+    private int readPosition;
+    private int count;
+
+    /// <summary>
+    /// Total capacity in floats.
+    /// </summary>
+    public int Capacity => buffer.Length;
+
+    /// <summary>
+    /// Floats currently readable.
+    /// </summary>
+    public int Available
+    {
+        get
+        {
+            lock (sync)
+                return count;
+        }
+    }
+
+    /// <summary>
+    /// Floats that can be written before the buffer is full.
+    /// </summary>
+    public int FreeSpace
+    {
+        get
+        {
+            lock (sync)
+                return buffer.Length - count;
+        }
+    }
+
+    public AudioRingBuffer(int capacity)
+    {
+        if (capacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+
+        buffer = new float[capacity];
+    }
+
+    /// <summary>
+    /// Appends as much of <paramref name="source"/> as fits.
+    /// </summary>
+    /// <returns>
+    /// The number of floats written. A short writing means the buffer is full and the caller should
+    /// retain the remainder, dropping it would put a gap in the audio.
+    /// </returns>
+    public int Write(ReadOnlySpan<float> source)
+    {
+        if (source.IsEmpty)
+            return 0;
+
+        lock (sync)
+        {
+            int writable = Math.Min(source.Length, buffer.Length - count);
+
+            if (writable == 0)
+                return 0;
+
+            int writePosition = (readPosition + count) % buffer.Length;
+            int firstChunk = Math.Min(writable, buffer.Length - writePosition);
+
+            source.Slice(0, firstChunk).CopyTo(buffer.AsSpan(writePosition));
+
+            if (writable > firstChunk)
+                source.Slice(firstChunk, writable - firstChunk).CopyTo(buffer);
+
+            count += writable;
+            return writable;
+        }
+    }
+
+    /// <summary>
+    /// Removes up to <paramref name="destination"/>'s length of floats from the front.
+    /// </summary>
+    /// <returns>The number of floats written, which is 0 when the buffer has run dry.</returns>
+    public int Read(Span<float> destination)
+    {
+        if (destination.IsEmpty)
+            return 0;
+
+        lock (sync)
+        {
+            int readable = Math.Min(destination.Length, count);
+
+            if (readable == 0)
+                return 0;
+
+            int firstChunk = Math.Min(readable, buffer.Length - readPosition);
+
+            buffer.AsSpan(readPosition, firstChunk).CopyTo(destination);
+
+            if (readable > firstChunk)
+                buffer.AsSpan(0, readable - firstChunk).CopyTo(destination.Slice(firstChunk));
+
+            readPosition = (readPosition + readable) % buffer.Length;
+            count -= readable;
+
+            return readable;
+        }
+    }
+
+    /// <summary>
+    /// Discards everything buffered.
+    /// </summary>
+    public void Clear()
+    {
+        lock (sync)
+        {
+            readPosition = 0;
+            count = 0;
+        }
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/CubicResampler.cs
+++ b/Sakura.Framework/Audio/SdlEngine/CubicResampler.cs
@@ -1,0 +1,188 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Per-voice playback-rate resampling, using 4-point third-order Hermite interpolation.
+/// </summary>
+internal sealed class CubicResampler
+{
+    /// <summary>
+    /// Interpolation needs the frame either side of the one being produced, so the window is four
+    /// frames wide: <c>w0</c> trails, <c>w1</c>–<c>w2</c> bracket the output, <c>w3</c> leads.
+    /// </summary>
+    private const int window_frames = 4;
+
+    /// <summary>
+    /// Bounds on the rate ratio. The lower bound keeps a near-zero ratio from spinning out enormous
+    /// numbers of output frames from one input frame; the upper bound caps how far ahead of the
+    /// source a single block can run.
+    /// </summary>
+    private const double min_ratio = 1.0 / 64.0;
+
+    private const double max_ratio = 64.0;
+
+    private readonly int channels;
+    private readonly float[] window;
+    private readonly float[] frameScratch;
+
+    /// <summary>
+    /// Position between <c>w1</c> and <c>w2</c>, in [0, 1).
+    /// </summary>
+    private double position;
+
+    private bool primed;
+
+    /// <summary>
+    /// How many all-zero frames have been shifted in since the source ran dry. Once the whole window
+    /// is zeros there is nothing left to interpolate and the resampler reports exhaustion.
+    /// </summary>
+    private int drainedFrames;
+
+    public CubicResampler(int channels)
+    {
+        if (channels <= 0)
+            throw new ArgumentOutOfRangeException(nameof(channels));
+
+        this.channels = channels;
+        window = new float[window_frames * channels];
+        frameScratch = new float[channels];
+    }
+
+    /// <summary>
+    /// Discards the interpolation window. Required after a seek, carrying frames across a
+    /// discontinuity smears audio from the old position into the new one.
+    /// </summary>
+    public void Reset()
+    {
+        Array.Clear(window);
+        position = 0;
+        primed = false;
+        drainedFrames = 0;
+    }
+
+    /// <summary>
+    /// Produces up to <paramref name="frameCount"/> frames into <paramref name="destination"/>,
+    /// pulling from <paramref name="source"/> at <paramref name="ratio"/> input frames per output
+    /// frame.
+    /// </summary>
+    /// <returns>
+    /// Frames produced. Fewer than requested means the source could not supply enough input either
+    /// it ended, or it is a streaming source that has not decoded far enough ahead.
+    /// </returns>
+    public int Read(IPcmSource source, Span<float> destination, int frameCount, double ratio)
+    {
+        if (frameCount <= 0)
+            return 0;
+
+        ratio = Math.Clamp(ratio, min_ratio, max_ratio);
+
+        if (!primed && !prime(source))
+            return 0;
+
+        int produced = 0;
+
+        while (produced < frameCount)
+        {
+            int offset = produced * channels;
+
+            for (int ch = 0; ch < channels; ch++)
+            {
+                float w0 = window[ch];
+                float w1 = window[channels + ch];
+                float w2 = window[2 * channels + ch];
+                float w3 = window[3 * channels + ch];
+
+                destination[offset + ch] = interpolate(w0, w1, w2, w3, (float)position);
+            }
+
+            produced++;
+            position += ratio;
+
+            while (position >= 1.0)
+            {
+                if (!advance(source))
+                    return produced;
+
+                position -= 1.0;
+            }
+        }
+
+        return produced;
+    }
+
+    /// <summary>
+    /// 4-point, third-order Hermite (Catmull-Rom) interpolation between <paramref name="w1"/> and
+    /// <paramref name="w2"/>.
+    /// </summary>
+    private static float interpolate(float w0, float w1, float w2, float w3, float t)
+    {
+        float c0 = w1;
+        float c1 = 0.5f * (w2 - w0);
+        float c2 = w0 - 2.5f * w1 + 2f * w2 - 0.5f * w3;
+        float c3 = 0.5f * (w3 - w0) + 1.5f * (w1 - w2);
+
+        return ((c3 * t + c2) * t + c1) * t + c0;
+    }
+
+    /// <summary>
+    /// Fills the window for the first time. <c>w0</c> is left silent: there is no frame before the
+    /// start of the source, and inventing one would be worse than starting from zero.
+    /// </summary>
+    private bool prime(IPcmSource source)
+    {
+        for (int i = 1; i < window_frames; i++)
+        {
+            if (!pullFrame(source, window.AsSpan(i * channels, channels)))
+            {
+                // Nothing at all to play yet. Stay unprimed so the next call tries again rather than
+                // treating a not-yet-decoded streaming source as an empty one.
+                if (i == 1)
+                {
+                    Array.Clear(window);
+                    return false;
+                }
+
+                break;
+            }
+        }
+
+        primed = true;
+        position = 0;
+        return true;
+    }
+
+    /// <summary>
+    /// Slides the window forward one frame.
+    /// </summary>
+    private bool advance(IPcmSource source)
+    {
+        Array.Copy(window, channels, window, 0, (window_frames - 1) * channels);
+
+        var last = window.AsSpan((window_frames - 1) * channels, channels);
+
+        if (pullFrame(source, last))
+        {
+            drainedFrames = 0;
+            return true;
+        }
+
+        // Let the tail of the window play out into silence rather than cutting off mid-sample, but
+        // stop once the whole window is zeros — past that there is genuinely nothing left.
+        last.Clear();
+
+        return ++drainedFrames < window_frames;
+    }
+
+    private bool pullFrame(IPcmSource source, Span<float> destination)
+    {
+        if (source.ReadFrames(frameScratch, 1) != 1)
+            return false;
+
+        frameScratch.CopyTo(destination);
+        return true;
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/FFmpegAudioDecoder.cs
+++ b/Sakura.Framework/Audio/SdlEngine/FFmpegAudioDecoder.cs
@@ -1,0 +1,538 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using FFmpeg.AutoGen;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Platform;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Decodes an audio file to interleaved 32-bit float PCM using FFmpeg, reading through a custom AVIO
+/// context so any <see cref="Stream"/> can be a source.
+/// </summary>
+/// <remarks>
+/// Not thread-safe. Each instance belongs to a single decode thread.
+/// </remarks>
+internal sealed unsafe class FFmpegAudioDecoder : IDisposable
+{
+    private const int io_buffer_size = 4096;
+
+    /// <summary>
+    /// The sample rate of the decoded output in Hz. This is the file's own rate.
+    /// </summary>
+    public int SampleRate { get; private set; }
+
+    /// <summary>
+    /// The channel count of the decoded output. This is the file's own channel count so mono files
+    /// decode as mono.
+    /// </summary>
+    public int Channels { get; private set; }
+
+    /// <summary>
+    /// The total duration in milliseconds, or 0 if the container does not report one.
+    /// </summary>
+    public double Duration { get; private set; }
+
+    /// <summary>
+    /// Whether <see cref="Seek"/> can be honored. False for non-seekable sources.
+    /// </summary>
+    public bool CanSeek { get; private set; }
+
+    /// <summary>
+    /// True once the decoder has been fully drained. Cleared by a successful <see cref="Seek"/>.
+    /// </summary>
+    public bool EndOfStream { get; private set; }
+
+    private Stream? source;
+    private GCHandle selfHandle;
+
+    private AVFormatContext* formatContext;
+    private AVIOContext* ioContext;
+    private AVCodecContext* codecContext;
+    private AVPacket* packet;
+    private AVFrame* frame;
+
+    private avio_alloc_context_read_packet? readCallback;
+    private avio_alloc_context_seek? seekCallback;
+
+    private int audioStreamIndex = -1;
+    private double timeBaseInSeconds;
+    private bool inputOpened;
+
+    /// <summary>
+    /// Samples decoded from the current frame that did not fit in the caller's buffer, carried over
+    /// to the next <see cref="Read"/>. Grown to the largest frame seen and then reused.
+    /// </summary>
+    private float[] pending = Array.Empty<float>();
+
+    private int pendingOffset;
+    private int pendingCount;
+
+    /// <summary>
+    /// True, once a null packet has been pushed to flush the decoder's internal buffer.
+    /// </summary>
+    private bool flushed;
+
+    /// <summary>
+    /// Opens <paramref name="stream"/> and reads enough of it to determine the stream format.
+    /// The stream will be disposed of with this decoder.
+    /// </summary>
+    /// <exception cref="InvalidDataException">The source has no decodable audio stream.</exception>
+    public FFmpegAudioDecoder(Stream stream)
+    {
+        if (!stream.CanRead)
+            throw new ArgumentException("Stream must be readable.", nameof(stream));
+
+        FFmpegLibrary.EnsureInitialized();
+
+        source = stream;
+        selfHandle = GCHandle.Alloc(this);
+
+        try
+        {
+            open();
+        }
+        catch
+        {
+            // The caller never receives the instance, so nothing else will dispose it.
+            Dispose();
+            throw;
+        }
+    }
+
+    private void open()
+    {
+        readCallback = readPacket;
+        seekCallback = source!.CanSeek ? seekStream : null;
+        CanSeek = source.CanSeek;
+
+        byte* ioBuffer = (byte*)ffmpeg.av_malloc(io_buffer_size);
+        ioContext = ffmpeg.avio_alloc_context(ioBuffer, io_buffer_size, 0,
+            (void*)GCHandle.ToIntPtr(selfHandle), readCallback, null, seekCallback);
+
+        if (ioContext == null)
+            throw new InvalidDataException("Could not allocate an AVIO context for audio decoding.");
+
+        var context = ffmpeg.avformat_alloc_context();
+        context->pb = ioContext;
+
+        int openResult = ffmpeg.avformat_open_input(&context, "pipe:", null, null);
+
+        if (openResult < 0)
+            throw new InvalidDataException($"avformat_open_input failed for audio source: {errorString(openResult)}");
+
+        inputOpened = true;
+        formatContext = context;
+
+        if (ffmpeg.avformat_find_stream_info(formatContext, null) < 0)
+            throw new InvalidDataException("Could not read stream info from the audio source.");
+
+        AVCodec* codec = null;
+        audioStreamIndex = ffmpeg.av_find_best_stream(formatContext, AVMediaType.AVMEDIA_TYPE_AUDIO, -1, -1, &codec, 0);
+
+        if (audioStreamIndex < 0 || codec == null)
+            throw new InvalidDataException("The source contains no decodable audio stream.");
+
+        var avStream = formatContext->streams[audioStreamIndex];
+        timeBaseInSeconds = avStream->time_base.num / (double)avStream->time_base.den;
+
+        codecContext = ffmpeg.avcodec_alloc_context3(codec);
+
+        if (codecContext == null)
+            throw new InvalidDataException("Could not allocate an audio codec context.");
+
+        if (ffmpeg.avcodec_parameters_to_context(codecContext, avStream->codecpar) < 0)
+            throw new InvalidDataException("Could not copy audio codec parameters.");
+
+        int codecOpenResult = ffmpeg.avcodec_open2(codecContext, codec, null);
+
+        if (codecOpenResult < 0)
+        {
+            // The most likely cause by far is a decoder compiled out of the shipped FFmpeg build,
+            // so name the codec rather than leaving a bare error code.
+            string name = Marshal.PtrToStringAnsi((IntPtr)codec->name) ?? "unknown";
+            throw new InvalidDataException($"Could not open the '{name}' audio decoder: {errorString(codecOpenResult)}. " +
+                                           "The shipped FFmpeg build may not include it.");
+        }
+
+        SampleRate = codecContext->sample_rate;
+        Channels = codecContext->ch_layout.nb_channels;
+
+        if (SampleRate <= 0 || Channels <= 0)
+            throw new InvalidDataException($"Audio stream reports an unusable format ({SampleRate}Hz, {Channels}ch).");
+
+        Duration = avStream->duration > 0
+            ? avStream->duration * timeBaseInSeconds * 1000.0
+            : formatContext->duration > 0
+                ? formatContext->duration / (double)ffmpeg.AV_TIME_BASE * 1000.0
+                : 0;
+
+        packet = ffmpeg.av_packet_alloc();
+        frame = ffmpeg.av_frame_alloc();
+
+        if (packet == null || frame == null)
+            throw new InvalidDataException("Could not allocate FFmpeg audio packet/frame.");
+    }
+
+    /// <summary>
+    /// Decodes into <paramref name="destination"/> as interleaved floats at <see cref="SampleRate"/>
+    /// and <see cref="Channels"/>.
+    /// </summary>
+    /// <returns>
+    /// The number of floats written, which is a whole number of frames. 0 means the stream is
+    /// exhausted; <see cref="EndOfStream"/> is set at that point.
+    /// </returns>
+    public int Read(Span<float> destination)
+    {
+        if (destination.IsEmpty || codecContext == null)
+            return 0;
+
+        int written = 0;
+
+        while (written < destination.Length)
+        {
+            if (pendingCount > 0)
+            {
+                int take = Math.Min(pendingCount, destination.Length - written);
+                pending.AsSpan(pendingOffset, take).CopyTo(destination.Slice(written));
+                pendingOffset += take;
+                pendingCount -= take;
+                written += take;
+                continue;
+            }
+
+            if (!decodeNextFrame())
+                break;
+        }
+
+        // Never hand back a partial frame, every consumer downstream counts in frames, and a split
+        // frame would silently rotate the channel order of everything after it.
+        int remainder = written % Channels;
+        if (remainder != 0)
+            written -= remainder;
+
+        return written;
+    }
+
+    /// <summary>
+    /// Pulls packets until one produces a decoded frame, which is converted into
+    /// <see cref="pending"/>.
+    /// </summary>
+    /// <returns>False once the decoder is drained and no further frames will arrive.</returns>
+    private bool decodeNextFrame()
+    {
+        while (true)
+        {
+            int receiveResult = ffmpeg.avcodec_receive_frame(codecContext, frame);
+
+            if (receiveResult == 0)
+            {
+                convertFrame();
+                ffmpeg.av_frame_unref(frame);
+
+                // A frame carrying no samples is legal, keep pulling rather than reporting silence.
+                if (pendingCount > 0)
+                    return true;
+
+                continue;
+            }
+
+            if (receiveResult == ffmpeg.AVERROR_EOF)
+            {
+                EndOfStream = true;
+                return false;
+            }
+
+            if (receiveResult != ffmpeg.AVERROR(ffmpeg.EAGAIN))
+            {
+                Logger.Error($"[FFmpegAudioDecoder] avcodec_receive_frame failed: {errorString(receiveResult)}");
+                EndOfStream = true;
+                return false;
+            }
+
+            // EAGAIN: the decoder wants another packet.
+            if (flushed)
+            {
+                EndOfStream = true;
+                return false;
+            }
+
+            if (!sendNextPacket())
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads packets until one belonging to the audio stream has been handed to the decoder, or the
+    /// container runs out and the decoder is put into flush mode.
+    /// </summary>
+    private bool sendNextPacket()
+    {
+        while (true)
+        {
+            int readResult = ffmpeg.av_read_frame(formatContext, packet);
+
+            if (readResult < 0)
+            {
+                // Push a null packet so the decoder emits whatever it is still holding.
+                ffmpeg.avcodec_send_packet(codecContext, null);
+                flushed = true;
+                return true;
+            }
+
+            if (packet->stream_index != audioStreamIndex)
+            {
+                ffmpeg.av_packet_unref(packet);
+                continue;
+            }
+
+            int sendResult = ffmpeg.avcodec_send_packet(codecContext, packet);
+            ffmpeg.av_packet_unref(packet);
+
+            if (sendResult < 0 && sendResult != ffmpeg.AVERROR(ffmpeg.EAGAIN))
+            {
+                Logger.Error($"[FFmpegAudioDecoder] avcodec_send_packet failed: {errorString(sendResult)}");
+                EndOfStream = true;
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Converts <see cref="frame"/> into interleaved float in <see cref="pending"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the job <c>libswresample</c> would normally do. It is not built into the shipped
+    /// FFmpeg, and pulling it in for what amounts to a scale-and-transpose is not worth the binary
+    /// size; the formats the enabled decoders actually emit are all covered here.
+    /// </remarks>
+    private void convertFrame()
+    {
+        int samples = frame->nb_samples;
+        int channels = frame->ch_layout.nb_channels;
+
+        if (samples <= 0 || channels <= 0)
+        {
+            pendingOffset = 0;
+            pendingCount = 0;
+            return;
+        }
+
+        // Channel count can in principle change mid-stream; downstream is built around a fixed
+        // format, so fold to what was advertised rather than emitting a differently shaped block.
+        if (channels != Channels)
+            channels = Math.Min(channels, Channels);
+
+        int total = samples * Channels;
+
+        if (pending.Length < total)
+            pending = new float[total];
+
+        pendingOffset = 0;
+        pendingCount = total;
+
+        var format = (AVSampleFormat)frame->format;
+        bool planar = ffmpeg.av_sample_fmt_is_planar(format) != 0;
+        var output = pending.AsSpan(0, total);
+
+        // Any channel the frame does not carry stays silent rather than repeating another channel.
+        if (channels < Channels)
+            output.Clear();
+
+        for (int ch = 0; ch < channels; ch++)
+        {
+            // extended_data rather than data[]: the latter only covers the first 8 planes.
+            byte* plane = planar ? frame->extended_data[ch] : frame->extended_data[0];
+            int stride = planar ? 1 : channels;
+            int start = planar ? 0 : ch;
+
+            switch (format)
+            {
+                case AVSampleFormat.AV_SAMPLE_FMT_U8:
+                case AVSampleFormat.AV_SAMPLE_FMT_U8P:
+                    for (int i = 0; i < samples; i++)
+                        output[i * Channels + ch] = (plane[start + i * stride] - 128) / 128f;
+                    break;
+
+                case AVSampleFormat.AV_SAMPLE_FMT_S16:
+                case AVSampleFormat.AV_SAMPLE_FMT_S16P:
+                {
+                    short* data = (short*)plane;
+                    for (int i = 0; i < samples; i++)
+                        output[i * Channels + ch] = data[start + i * stride] / 32768f;
+                    break;
+                }
+
+                case AVSampleFormat.AV_SAMPLE_FMT_S32:
+                case AVSampleFormat.AV_SAMPLE_FMT_S32P:
+                {
+                    int* data = (int*)plane;
+                    for (int i = 0; i < samples; i++)
+                        output[i * Channels + ch] = data[start + i * stride] / 2147483648f;
+                    break;
+                }
+
+                case AVSampleFormat.AV_SAMPLE_FMT_S64:
+                case AVSampleFormat.AV_SAMPLE_FMT_S64P:
+                {
+                    long* data = (long*)plane;
+                    for (int i = 0; i < samples; i++)
+                        output[i * Channels + ch] = (float)(data[start + i * stride] / 9223372036854775808.0);
+                    break;
+                }
+
+                case AVSampleFormat.AV_SAMPLE_FMT_FLT:
+                case AVSampleFormat.AV_SAMPLE_FMT_FLTP:
+                {
+                    float* data = (float*)plane;
+                    for (int i = 0; i < samples; i++)
+                        output[i * Channels + ch] = data[start + i * stride];
+                    break;
+                }
+
+                case AVSampleFormat.AV_SAMPLE_FMT_DBL:
+                case AVSampleFormat.AV_SAMPLE_FMT_DBLP:
+                {
+                    double* data = (double*)plane;
+                    for (int i = 0; i < samples; i++)
+                        output[i * Channels + ch] = (float)data[start + i * stride];
+                    break;
+                }
+
+                default:
+                    Logger.Error($"[FFmpegAudioDecoder] Unsupported sample format {format}; emitting silence.");
+                    output.Clear();
+                    return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Seeks to <paramref name="milliseconds"/> and discards any buffered output, so the next
+    /// <see cref="Read"/> returns audio from the new position.
+    /// </summary>
+    /// <remarks>
+    /// Lands on the keyframe at or before the requested time; for compressed formats the true
+    /// position may be slightly earlier. Callers needing sample accuracy must discard the difference.
+    /// </remarks>
+    public void Seek(double milliseconds)
+    {
+        if (!CanSeek || formatContext == null || codecContext == null)
+            return;
+
+        long timestamp = (long)(Math.Max(0, milliseconds) / 1000.0 / timeBaseInSeconds);
+
+        int result = ffmpeg.av_seek_frame(formatContext, audioStreamIndex, timestamp, ffmpeg.AVSEEK_FLAG_BACKWARD);
+
+        if (result < 0)
+        {
+            Logger.Error($"[FFmpegAudioDecoder] Seek to {milliseconds}ms failed: {errorString(result)}");
+            return;
+        }
+
+        ffmpeg.avcodec_flush_buffers(codecContext);
+
+        pendingOffset = 0;
+        pendingCount = 0;
+        flushed = false;
+        EndOfStream = false;
+    }
+
+    private static int readPacket(void* opaque, byte* buffer, int bufferSize)
+    {
+        var handle = GCHandle.FromIntPtr((IntPtr)opaque);
+
+        if (!handle.IsAllocated || handle.Target is not FFmpegAudioDecoder decoder || decoder.source == null)
+            return ffmpeg.AVERROR_EOF;
+
+        int read = decoder.source.Read(new Span<byte>(buffer, bufferSize));
+        return read == 0 ? ffmpeg.AVERROR_EOF : read;
+    }
+
+    private static long seekStream(void* opaque, long offset, int whence)
+    {
+        var handle = GCHandle.FromIntPtr((IntPtr)opaque);
+
+        if (!handle.IsAllocated || handle.Target is not FFmpegAudioDecoder decoder || decoder.source?.CanSeek != true)
+            return -1;
+
+        return whence switch
+        {
+            0 => decoder.source.Seek(offset, SeekOrigin.Begin),
+            1 => decoder.source.Seek(offset, SeekOrigin.Current),
+            2 => decoder.source.Seek(offset, SeekOrigin.End),
+            // AVSEEK_SIZE — report the total length rather than moving.
+            0x10000 => decoder.source.Length,
+            _ => -1
+        };
+    }
+
+    private static string errorString(int error)
+    {
+        const int buffer_size = 256;
+        byte* buffer = stackalloc byte[buffer_size];
+        ffmpeg.av_strerror(error, buffer, buffer_size);
+        return Marshal.PtrToStringAnsi((IntPtr)buffer) ?? error.ToString();
+    }
+
+    private bool isDisposed;
+
+    public void Dispose()
+    {
+        if (isDisposed) return;
+        isDisposed = true;
+
+        if (frame != null)
+        {
+            fixed (AVFrame** p = &frame)
+                ffmpeg.av_frame_free(p);
+        }
+
+        if (packet != null)
+        {
+            fixed (AVPacket** p = &packet)
+                ffmpeg.av_packet_free(p);
+        }
+
+        if (codecContext != null)
+        {
+            fixed (AVCodecContext** p = &codecContext)
+                ffmpeg.avcodec_free_context(p);
+        }
+
+        if (formatContext != null && inputOpened)
+        {
+            fixed (AVFormatContext** p = &formatContext)
+                ffmpeg.avformat_close_input(p);
+        }
+        else if (formatContext != null)
+        {
+            // open_input never took ownership, so the context (and the AVIO buffer it points at)
+            // is still ours to free.
+            ffmpeg.avformat_free_context(formatContext);
+            formatContext = null;
+        }
+
+        if (ioContext != null)
+        {
+            ffmpeg.av_freep(&ioContext->buffer);
+            fixed (AVIOContext** p = &ioContext)
+                ffmpeg.avio_context_free(p);
+        }
+
+        source?.Dispose();
+        source = null;
+
+        readCallback = null;
+        seekCallback = null;
+
+        if (selfHandle.IsAllocated)
+            selfHandle.Free();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/IPcmSource.cs
+++ b/Sakura.Framework/Audio/SdlEngine/IPcmSource.cs
@@ -1,0 +1,45 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// A cursor over decoded audio, already in the device's format, that a voice pulls frames from.
+/// </summary>
+internal interface IPcmSource : IDisposable
+{
+    /// <summary>
+    /// Total length in milliseconds, or 0 when the source does not know.
+    /// </summary>
+    double LengthMs { get; }
+
+    /// <summary>
+    /// The read cursor, in milliseconds. Reflects what has been handed to the mixer, so it runs
+    /// ahead of what is audible by however many sits in the device buffer.
+    /// </summary>
+    double PositionMs { get; }
+
+    /// <summary>
+    /// Whether the source has been fully consumed. A streaming source is only ended once its
+    /// decoder is drained <em>and</em> its buffer is empty.
+    /// </summary>
+    bool Ended { get; }
+
+    /// <summary>
+    /// Reads sequential interleaved frames, advancing the cursor.
+    /// </summary>
+    /// <returns>
+    /// Frames written. A short read means either the end of the source or — for a streaming source —
+    /// that the decoder has not kept up, which the caller should treat as an underrun rather than an
+    /// end.
+    /// </returns>
+    int ReadFrames(Span<float> destination, int frameCount);
+
+    /// <summary>
+    /// Moves the cursor. Takes effect immediately as far as <see cref="PositionMs"/> is concerned,
+    /// even where the underlying decoding happens asynchronously.
+    /// </summary>
+    void Seek(double milliseconds);
+}

--- a/Sakura.Framework/Audio/SdlEngine/ISDLAudioContext.cs
+++ b/Sakura.Framework/Audio/SdlEngine/ISDLAudioContext.cs
@@ -1,0 +1,42 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// The slice of the audio engine a channel needs: the output format it must produce, and a way to
+/// get work onto the audio thread.
+/// </summary>
+/// <remarks>
+/// An interface rather than a direct reference to the manager so a voice can be exercised without
+/// opening a device, the mix maths is entirely testable against a stub, and only the manager
+/// itself needs real hardware.
+/// </remarks>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal interface ISDLAudioContext
+{
+    /// <summary>
+    /// Output sample rate in Hz. Every <see cref="IPcmSource"/> feeding a channel is already at this rate.
+    /// </summary>
+    int SampleRate { get; }
+
+    /// <summary>
+    /// Output channel count.
+    /// </summary>
+    int Channels { get; }
+
+    /// <summary>
+    /// Queues work for the audio thread. Channel state changes and user-facing events go through
+    /// here rather than firing on the mix thread, matching the BASS backend.
+    /// </summary>
+    void EnqueueAction(Action action);
+
+    /// <summary>
+    /// Nudges the decode thread, for when a channel suddenly needs audio it does not have — after a
+    /// seek, or on starting playback.
+    /// </summary>
+    void WakeDecoder();
+}

--- a/Sakura.Framework/Audio/SdlEngine/MemoryPcmSource.cs
+++ b/Sakura.Framework/Audio/SdlEngine/MemoryPcmSource.cs
@@ -1,0 +1,70 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// An <see cref="IPcmSource"/> cursor over a shared, fully decoded <see cref="PcmBuffer"/>.
+/// </summary>
+internal sealed class MemoryPcmSource : IPcmSource
+{
+    private readonly PcmBuffer buffer;
+
+    /// <summary>
+    /// Invoked on <see cref="Dispose"/> so the owning sample can drop its reference count.
+    /// </summary>
+    private readonly Action? onDisposed;
+
+    private int framePosition;
+    private bool isDisposed;
+
+    public double LengthMs => buffer.LengthMs;
+
+    public double PositionMs => framePosition / (double)buffer.SampleRate * 1000.0;
+
+    public bool Ended => framePosition >= buffer.FrameCount;
+
+    public MemoryPcmSource(PcmBuffer buffer, Action? onDisposed = null)
+    {
+        this.buffer = buffer;
+        this.onDisposed = onDisposed;
+    }
+
+    public int ReadFrames(Span<float> destination, int frameCount)
+    {
+        if (isDisposed || frameCount <= 0)
+            return 0;
+
+        int channels = buffer.Channels;
+        int available = Math.Min(frameCount, buffer.FrameCount - framePosition);
+        available = Math.Min(available, destination.Length / channels);
+
+        if (available <= 0)
+            return 0;
+
+        buffer.Samples.AsSpan(framePosition * channels, available * channels).CopyTo(destination);
+        framePosition += available;
+
+        return available;
+    }
+
+    public void Seek(double milliseconds)
+    {
+        if (isDisposed)
+            return;
+
+        int frame = (int)(Math.Max(0, milliseconds) / 1000.0 * buffer.SampleRate);
+        framePosition = Math.Clamp(frame, 0, buffer.FrameCount);
+    }
+
+    public void Dispose()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+        onDisposed?.Invoke();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/PcmBuffer.cs
+++ b/Sakura.Framework/Audio/SdlEngine/PcmBuffer.cs
@@ -36,6 +36,22 @@ internal sealed class PcmBuffer
     }
 
     /// <summary>
+    /// Wraps already-decoded interleaved samples, which are taken as-is and not copied.
+    /// </summary>
+    /// <remarks>
+    /// For callers that produced PCM by some route other than <see cref="Decode"/> synthesized
+    /// audio, and the test suite, which needs buffers with exactly known contents.
+    /// </remarks>
+    public static PcmBuffer FromSamples(float[] samples, int channels, int sampleRate)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(channels);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
+
+        return samples.Length % channels != 0 ? throw new ArgumentException("Sample count must be a whole number of frames.", nameof(samples)) : new PcmBuffer(samples, channels, sampleRate);
+
+    }
+
+    /// <summary>
     /// Decodes <paramref name="stream"/> in full and converts it to the given device format.
     /// </summary>
     /// <remarks>Takes ownership of the stream.</remarks>
@@ -43,7 +59,7 @@ internal sealed class PcmBuffer
     public static PcmBuffer Decode(Stream stream, int deviceSampleRate, int deviceChannels)
     {
         using var decoder = new FFmpegAudioDecoder(stream);
-        using var converter = new SdlAudioConverter(decoder.SampleRate, decoder.Channels, deviceSampleRate, deviceChannels);
+        using var converter = new SDLAudioConverter(decoder.SampleRate, decoder.Channels, deviceSampleRate, deviceChannels);
 
         // Sized from the source duration where the container reports one, so the common case is a
         // single allocation rather than a doubling walk.
@@ -79,7 +95,7 @@ internal sealed class PcmBuffer
         return new PcmBuffer(output, deviceChannels, deviceSampleRate);
     }
 
-    private static int drain(SdlAudioConverter converter, float[] scratch, ref float[] output, int written)
+    private static int drain(SDLAudioConverter converter, float[] scratch, ref float[] output, int written)
     {
         int total = 0;
 

--- a/Sakura.Framework/Audio/SdlEngine/PcmBuffer.cs
+++ b/Sakura.Framework/Audio/SdlEngine/PcmBuffer.cs
@@ -1,0 +1,104 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// A whole audio file decoded to interleaved float PCM in the device's format, held in memory and
+/// shared by every channel playing it.
+/// </summary>
+internal sealed class PcmBuffer
+{
+    /// <summary>
+    /// Interleaved samples at <see cref="SampleRate"/> with <see cref="Channels"/> channels.
+    /// </summary>
+    public float[] Samples { get; }
+
+    public int Channels { get; }
+
+    public int SampleRate { get; }
+
+    /// <summary>
+    /// Length in frames.
+    /// </summary>
+    public int FrameCount => Samples.Length / Channels;
+
+    public double LengthMs => FrameCount / (double)SampleRate * 1000.0;
+
+    private PcmBuffer(float[] samples, int channels, int sampleRate)
+    {
+        Samples = samples;
+        Channels = channels;
+        SampleRate = sampleRate;
+    }
+
+    /// <summary>
+    /// Decodes <paramref name="stream"/> in full and converts it to the given device format.
+    /// </summary>
+    /// <remarks>Takes ownership of the stream.</remarks>
+    /// <exception cref="InvalidDataException">The source could not be decoded.</exception>
+    public static PcmBuffer Decode(Stream stream, int deviceSampleRate, int deviceChannels)
+    {
+        using var decoder = new FFmpegAudioDecoder(stream);
+        using var converter = new SdlAudioConverter(decoder.SampleRate, decoder.Channels, deviceSampleRate, deviceChannels);
+
+        // Sized from the source duration where the container reports one, so the common case is a
+        // single allocation rather than a doubling walk.
+        int estimatedFrames = decoder.Duration > 0
+            ? (int)(decoder.Duration / 1000.0 * deviceSampleRate) + deviceSampleRate
+            : deviceSampleRate;
+
+        float[] output = new float[Math.Max(estimatedFrames, 1) * deviceChannels];
+        int written = 0;
+
+        float[] decodeScratch = new float[8192];
+        float[] convertScratch = new float[8192];
+
+        while (true)
+        {
+            int read = decoder.Read(decodeScratch);
+
+            if (read == 0)
+            {
+                // Without this the converter holds back its tail waiting for input that never comes.
+                converter.Flush();
+                written += drain(converter, convertScratch, ref output, written);
+                break;
+            }
+
+            converter.Put(decodeScratch.AsSpan(0, read));
+            written += drain(converter, convertScratch, ref output, written);
+        }
+
+        if (written < output.Length)
+            Array.Resize(ref output, written);
+
+        return new PcmBuffer(output, deviceChannels, deviceSampleRate);
+    }
+
+    private static int drain(SdlAudioConverter converter, float[] scratch, ref float[] output, int written)
+    {
+        int total = 0;
+
+        while (true)
+        {
+            int got = converter.Get(scratch);
+
+            if (got == 0)
+                break;
+
+            int required = written + total + got;
+
+            if (required > output.Length)
+                Array.Resize(ref output, Math.Max(required, output.Length * 2));
+
+            scratch.AsSpan(0, got).CopyTo(output.AsSpan(written + total));
+            total += got;
+        }
+
+        return total;
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
@@ -1,0 +1,366 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Sakura.Framework.Reactive;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// SDL implementation of <see cref="IAudioChannel"/> — one playing voice.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The signal path, in order: pull from the <see cref="IPcmSource"/> through the rate resampler,
+/// apply the low-pass insert if one is attached, apply volume and pan, meter, then add into the
+/// caller's buffer. Filtering happens before gain so that automating volume does not change the
+/// filter's behavior.
+/// </para>
+/// <para>
+/// Threading: <see cref="Fill"/> runs on the mix thread; everything else is called from the update
+/// thread. Values the mix loop needs are cached into plain fields as they change, so the audio path
+/// never reads a <see cref="Reactive{T}"/>, and user-visible events are marshaled to the audio
+/// thread through <see cref="ISDLAudioContext.EnqueueAction"/> exactly as the BASS backend does.
+/// </para>
+/// </remarks>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal class SDLAudioChannel : IAudioChannel
+{
+    public event Action OnStart = () => { };
+    public event Action OnStop = () => { };
+    public event Action OnEnd = () => { };
+
+    /// <summary>
+    /// Raised once this channel has released its source, on the audio thread. Whatever created the
+    /// channel uses it to drop the reference, keeping the underlying audio data alive.
+    /// </summary>
+    internal event Action? Disposed;
+
+    public ReactiveBool IsRunning { get; } = new ReactiveBool();
+
+    public Reactive<double> Volume { get; } = new Reactive<double>(1.0);
+    public Reactive<double> Frequency { get; } = new Reactive<double>(1.0);
+    public Reactive<double> Balance { get; } = new Reactive<double>(0.0);
+
+    /// <summary>
+    /// Pitch-preserving speed. A no-op on this backend, as <see cref="IAudioChannel.Tempo"/> permits
+    /// for backends without a tempo DSP — a WSOLA implementation is a later item.
+    /// </summary>
+    public Reactive<double> Tempo { get; } = new Reactive<double>(1.0);
+
+    public bool AutoDispose { get; set; }
+
+    public bool Looping { get; set; }
+
+    public double RestartPoint { get; set; }
+
+    protected readonly ISDLAudioContext Context;
+
+    private readonly IPcmSource? source;
+    private readonly CubicResampler? resampler;
+    private readonly AmplitudeTap tap = new AmplitudeTap();
+
+    /// <summary>
+    /// Scratch for one block of this voice's own output before it is summed into the destination.
+    /// Grown on demand and then reused, so a steady-state mix allocates nothing.
+    /// </summary>
+    private float[] scratch = Array.Empty<float>();
+
+    // Snapshots of the reactive properties, refreshed on change so the mix thread reads plain
+    // fields. Assignments to these types are atomic, so a torn read is not possible.
+    private volatile float volume = 1f;
+    private volatile float gainLeft = 1f;
+    private volatile float gainRight = 1f;
+    private double frequency = 1.0;
+
+    private SDLLowPassFilter? filter;
+
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Set on the mix thread when the source runs out, so the end is handled once on the audio
+    /// thread rather than repeatedly from inside the mix loop.
+    /// </summary>
+    private bool endHandled;
+
+    public SDLAudioChannel(ISDLAudioContext context, IPcmSource? source)
+    {
+        Context = context;
+        this.source = source;
+
+        if (source != null)
+            resampler = new CubicResampler(context.Channels);
+
+        IsRunning.ValueChanged += e =>
+        {
+            if (e.NewValue) OnStart?.Invoke();
+            else OnStop?.Invoke();
+        };
+
+        Volume.ValueChanged += e => volume = (float)Math.Max(0, e.NewValue);
+        Balance.ValueChanged += _ => updateBalance();
+        Frequency.ValueChanged += e => frequency = e.NewValue;
+
+        updateBalance();
+    }
+
+    private void updateBalance()
+    {
+        // Linear pan, matching the BASS backend's ChannelAttribute.Pan: full on one side at the
+        // extreme, both sides unity at centre.
+        double balance = Math.Clamp(Balance.Value, -1.0, 1.0);
+
+        gainLeft = (float)(balance <= 0 ? 1.0 : 1.0 - balance);
+        gainRight = (float)(balance >= 0 ? 1.0 : 1.0 + balance);
+    }
+
+    /// <summary>
+    /// The low-pass insert attached to this channel, if any.
+    /// </summary>
+    internal SDLLowPassFilter? Filter => filter;
+
+    /// <summary>
+    /// Attaches a low-pass filter, replacing any existing one.
+    /// </summary>
+    internal SDLLowPassFilter AttachLowPassFilter()
+    {
+        filter?.Dispose();
+
+        var attached = new SDLLowPassFilter(Context.SampleRate, Context.Channels);
+        filter = attached;
+        return attached;
+    }
+
+    /// <summary>
+    /// Mixes this channel's contribution for one block <b>additively</b> into
+    /// <paramref name="destination"/>.
+    /// </summary>
+    /// <remarks>
+    /// Additive rather than overwriting: a mixer sums its children into one buffer, so the caller
+    /// zeroes the destination once and every child adds to it. A channel that is stopped, disposed,
+    /// or has nothing decoded yet contributes nothing and leaves the buffer untouched.
+    /// </remarks>
+    public virtual void Fill(Span<float> destination)
+    {
+        if (isDisposed || !IsRunning.Value || source == null || resampler == null)
+            return;
+
+        int channels = Context.Channels;
+        int frames = destination.Length / channels;
+
+        if (frames <= 0)
+            return;
+
+        if (scratch.Length < frames * channels)
+            scratch = new float[frames * channels];
+
+        var block = scratch.AsSpan(0, frames * channels);
+        int produced = resampler.Read(source, block, frames, frequency);
+
+        if (produced < frames)
+        {
+            // Nothing more is coming from this source for now. Whether that is the end of the audio
+            // or a decoder that has fallen behind is the source's call, not ours.
+            block.Slice(produced * channels).Clear();
+
+            if (source.Ended)
+                handleEnd();
+        }
+
+        if (produced > 0)
+        {
+            var produsedBlock = block.Slice(0, produced * channels);
+
+            filter?.Process(produsedBlock);
+            applyGain(produsedBlock, channels);
+            tap.Feed(produsedBlock);
+
+            for (int i = 0; i < produsedBlock.Length; i++)
+                destination[i] += produsedBlock[i];
+        }
+    }
+
+    private void applyGain(Span<float> block, int channels)
+    {
+        float left = volume * gainLeft;
+        float right = volume * gainRight;
+
+        if (channels == 2)
+        {
+            for (int i = 0; i + 1 < block.Length; i += 2)
+            {
+                block[i] *= left;
+                block[i + 1] *= right;
+            }
+
+            return;
+        }
+
+        // Panning is only meaningful in stereo; anything else just takes the volume.
+        for (int i = 0; i < block.Length; i++)
+            block[i] *= volume;
+    }
+
+    /// <summary>
+    /// Called from the mix thread the moment the source runs dry. Loops immediately so the wrap is
+    /// as tight as the decoder allows, and defers everything user-visible to the audio thread.
+    /// </summary>
+    private void handleEnd()
+    {
+        if (endHandled)
+            return;
+
+        endHandled = true;
+
+        bool looping = Looping;
+
+        if (looping)
+        {
+            seekInternal(RestartPoint);
+            endHandled = false;
+        }
+
+        Context.EnqueueAction(() =>
+        {
+            OnEnd?.Invoke();
+
+            if (looping)
+                return;
+
+            IsRunning.Value = false;
+
+            if (AutoDispose)
+                Dispose();
+        });
+    }
+
+    public virtual void Play()
+    {
+        if (isDisposed)
+            return;
+
+        Context.EnqueueAction(() =>
+        {
+            if (isDisposed)
+                return;
+
+            // Replaying something that already finished should start it over rather than sit at the
+            // end producing silence.
+            if (source?.Ended == true)
+                seekInternal(Looping ? RestartPoint : 0);
+
+            endHandled = false;
+            IsRunning.Value = true;
+            Context.WakeDecoder();
+        });
+    }
+
+    public virtual void Stop()
+    {
+        if (isDisposed)
+            return;
+
+        Context.EnqueueAction(() =>
+        {
+            if (isDisposed)
+                return;
+
+            IsRunning.Value = false;
+
+            // Matches the BASS backend, where Stop rewinds and Pause does not.
+            seekInternal(0);
+            endHandled = false;
+        });
+    }
+
+    public virtual void Pause()
+    {
+        if (isDisposed)
+            return;
+
+        Context.EnqueueAction(() =>
+        {
+            if (isDisposed)
+                return;
+
+            IsRunning.Value = false;
+        });
+    }
+
+    /// <summary>
+    /// Moves the source and clears every piece of state that holds audio from the old position:
+    /// the interpolation window, the filter's delay line, and the metering capture.
+    /// </summary>
+    private void seekInternal(double milliseconds)
+    {
+        source?.Seek(milliseconds);
+        resampler?.Reset();
+        filter?.ClearState();
+        tap.Reset();
+        Context.WakeDecoder();
+    }
+
+    public double CurrentTime
+    {
+        get => isDisposed ? 0 : source?.PositionMs ?? 0;
+        set
+        {
+            if (isDisposed)
+                return;
+
+            Context.EnqueueAction(() =>
+            {
+                if (isDisposed)
+                    return;
+
+                seekInternal(value);
+                endHandled = false;
+            });
+        }
+    }
+
+    public double Length => source?.LengthMs ?? 0;
+
+    public float AmplitudeLeft => CurrentAmplitudes.AmplitudeLeft;
+
+    public float AmplitudeRight => CurrentAmplitudes.AmplitudeRight;
+
+    public virtual ChannelAmplitudes CurrentAmplitudes
+    {
+        get
+        {
+            if (isDisposed || !IsRunning.Value)
+                return ChannelAmplitudes.Empty;
+
+            return tap.Read();
+        }
+    }
+
+    public virtual void Dispose()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+
+        Context.EnqueueAction(() =>
+        {
+            // Only once the mix thread can no longer be inside Fill for this channel, which the
+            // isDisposed check above guarantees by the time this runs on the audio thread.
+            filter?.Dispose();
+            filter = null;
+
+            source?.Dispose();
+
+            IsRunning.Value = false;
+            OnStart = null!;
+            OnStop = null!;
+            OnEnd = null!;
+
+            var disposed = Disposed;
+            Disposed = null;
+            disposed?.Invoke();
+        });
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
@@ -59,7 +59,11 @@ internal class SDLAudioChannel : IAudioChannel
 
     private readonly IPcmSource? source;
     private readonly CubicResampler? resampler;
-    private readonly AmplitudeTap tap = new AmplitudeTap();
+
+    /// <summary>
+    /// Metering for this node, fed with its post-gain output.
+    /// </summary>
+    protected readonly AmplitudeTap Tap = new AmplitudeTap();
 
     /// <summary>
     /// Scratch for one block of this voice's own output before it is summed into the destination.
@@ -77,6 +81,12 @@ internal class SDLAudioChannel : IAudioChannel
     private SDLLowPassFilter? filter;
 
     private volatile bool isDisposed;
+
+    /// <summary>
+    /// Whether <see cref="Dispose"/> has been called. Checked by the mix loop before touching
+    /// anything this channel owns.
+    /// </summary>
+    protected bool IsDisposed => isDisposed;
 
     /// <summary>
     /// Set on the mix thread when the source runs out, so the end is handled once on the audio
@@ -169,16 +179,25 @@ internal class SDLAudioChannel : IAudioChannel
         }
 
         if (produced > 0)
-        {
-            var produsedBlock = block.Slice(0, produced * channels);
+            ApplyInsertsAndMix(block.Slice(0, produced * channels), destination);
+    }
 
-            filter?.Process(produsedBlock);
-            applyGain(produsedBlock, channels);
-            tap.Feed(produsedBlock);
+    /// <summary>
+    /// Runs a block of this node's own audio through its insert chain — filter, then gain and pan,
+    /// then metering — and sums the result into <paramref name="destination"/>.
+    /// </summary>
+    /// <remarks>
+    /// Shared with <see cref="SDLAudioMixer"/>, whose children produce the block instead of a
+    /// source, so that a mixer's own volume, filter and metering behave exactly like a channel's.
+    /// </remarks>
+    protected void ApplyInsertsAndMix(Span<float> block, Span<float> destination)
+    {
+        filter?.Process(block);
+        applyGain(block, Context.Channels);
+        Tap.Feed(block);
 
-            for (int i = 0; i < produsedBlock.Length; i++)
-                destination[i] += produsedBlock[i];
-        }
+        for (int i = 0; i < block.Length && i < destination.Length; i++)
+            destination[i] += block[i];
     }
 
     private void applyGain(Span<float> block, int channels)
@@ -297,7 +316,7 @@ internal class SDLAudioChannel : IAudioChannel
         source?.Seek(milliseconds);
         resampler?.Reset();
         filter?.ClearState();
-        tap.Reset();
+        Tap.Reset();
         Context.WakeDecoder();
     }
 
@@ -333,7 +352,7 @@ internal class SDLAudioChannel : IAudioChannel
             if (isDisposed || !IsRunning.Value)
                 return ChannelAmplitudes.Empty;
 
-            return tap.Read();
+            return Tap.Read();
         }
     }
 

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioConverter.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioConverter.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file for full license text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using SDL;
 using static SDL.SDL3;
 
@@ -13,9 +14,10 @@ namespace Sakura.Framework.Audio.SdlEngine;
 /// </summary>
 /// <remarks>
 /// This class stand for <c>libswresample</c>, which the shipped FFmpeg build deliberately omits.
-/// Also, this is not thread-safe, an instance belongs to whichever thread is decoding into it.
+/// Also, this is not thread-safe; an instance belongs to whichever thread is decoding into it.
 /// </remarks>
-internal sealed unsafe class SdlAudioConverter : IDisposable
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed unsafe class SDLAudioConverter : IDisposable
 {
     private const int bytes_per_float = sizeof(float);
 
@@ -51,7 +53,7 @@ internal sealed unsafe class SdlAudioConverter : IDisposable
     /// <param name="targetRate">Output sample rate in Hz.</param>
     /// <param name="targetChannels">Output channel count.</param>
     /// <exception cref="InvalidOperationException">SDL could not create the stream.</exception>
-    public SdlAudioConverter(int sourceRate, int sourceChannels, int targetRate, int targetChannels)
+    public SDLAudioConverter(int sourceRate, int sourceChannels, int targetRate, int targetChannels)
     {
         var source = new SDL_AudioSpec
         {

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
@@ -1,0 +1,450 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using Sakura.Framework.Extensions.ObjectExtensions;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Platform;
+using Sakura.Framework.Reactive;
+using Sakura.Framework.Statistic;
+using SDL;
+using static SDL.SDL3;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// SDL3 implementation of <see cref="IAudioManager"/>: owns the output device, the mix thread, and
+/// the two master mixers.
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, IDisposable
+{
+    /// <summary>
+    /// Frames mixed per block. At 44.1kHz this is ~11.6ms of audio, small enough that a volume or
+    /// seek change is applied promptly, large enough that per-block overhead is negligible.
+    /// </summary>
+    private const int mix_block_frames = 512;
+
+    /// <summary>
+    /// How much audio to keep queued on the device.
+    /// </summary>
+    /// <remarks>
+    /// This is the output latency, and it is generous on purpose — see the class remarks. Phase 3
+    /// replaces this with <c>SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES</c> and a configurable target once
+    /// the GC can no longer interrupt the mix loop.
+    /// </remarks>
+    private const double target_queue_ms = 80;
+
+    private const int fallback_sample_rate = 44100;
+    private const int output_channels = 2;
+
+    public int SampleRate { get; }
+
+    public int Channels => output_channels;
+
+    public Reactive<double> MasterVolume { get; } = new Reactive<double>(1.0);
+    public Reactive<double> TrackVolume { get; } = new Reactive<double>(1.0);
+    public Reactive<double> SampleVolume { get; } = new Reactive<double>(1.0);
+
+    private readonly SDLAudioMixer trackMixer;
+    private readonly SDLAudioMixer sampleMixer;
+
+    public IAudioMixer TrackMixer => trackMixer;
+    public IAudioMixer SampleMixer => sampleMixer;
+
+    private readonly ConcurrentQueue<Action> audioThreadActions = new ConcurrentQueue<Action>();
+    private readonly List<SDLAudioChannel> activeChannels = new List<SDLAudioChannel>();
+    private readonly AudioDecodeScheduler decodeScheduler = new AudioDecodeScheduler();
+
+    private readonly SDL_AudioStream* deviceStream;
+    private readonly Thread mixThread;
+    private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
+
+    private readonly float[] mixBuffer = new float[mix_block_frames * output_channels];
+
+    private readonly bool ownsAudioSubsystem;
+
+    // Written on the mix thread, published to GlobalStatistics from Update on the audio thread so
+    // the mix loop does no dictionary work.
+    private long underruns;
+    private long mixMicroseconds;
+    private double queuedMilliseconds;
+
+    private bool isDisposed;
+
+    /// <exception cref="InvalidOperationException">SDL audio could not be started.</exception>
+    public SDLAudioManager()
+    {
+        // Decoding runs through FFmpeg, so bring it up here rather than lazily on the first track:
+        // a missing or mis-located native library should fail at startup, where it is diagnosable.
+        FFmpegLibrary.EnsureInitialized();
+
+        if (!SDL_InitSubSystem(SDL_InitFlags.SDL_INIT_AUDIO))
+            throw new InvalidOperationException($"Failed to initialise SDL audio: {SDL_GetError()}");
+
+        ownsAudioSubsystem = true;
+
+        SampleRate = queryDeviceSampleRate();
+
+        var spec = new SDL_AudioSpec
+        {
+            format = SDLAudioConverter.SAMPLE_FORMAT,
+            channels = output_channels,
+            freq = SampleRate
+        };
+
+        // No callback: this backend pushes from its own mix thread, so nothing SDL calls can ever be
+        // waiting on managed code.
+        deviceStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, null, IntPtr.Zero);
+
+        if (deviceStream == null)
+        {
+            SDL_QuitSubSystem(SDL_InitFlags.SDL_INIT_AUDIO);
+            throw new InvalidOperationException($"Failed to open an SDL audio device: {SDL_GetError()}");
+        }
+
+        trackMixer = new SDLAudioMixer(this);
+        sampleMixer = new SDLAudioMixer(this);
+
+        trackMixer.IsRunning.Value = true;
+        sampleMixer.IsRunning.Value = true;
+
+        TrackVolume.ValueChanged += e => trackMixer.Volume.Value = e.NewValue * MasterVolume.Value;
+        SampleVolume.ValueChanged += e => sampleMixer.Volume.Value = e.NewValue * MasterVolume.Value;
+        MasterVolume.ValueChanged += e =>
+        {
+            trackMixer.Volume.Value = TrackVolume.Value * e.NewValue;
+            sampleMixer.Volume.Value = SampleVolume.Value * e.NewValue;
+        };
+
+        if (!SDL_ResumeAudioStreamDevice(deviceStream))
+            Logger.Error($"Failed to start the SDL audio device: {SDL_GetError()}");
+
+        mixThread = new Thread(runMixLoop)
+        {
+            Name = "SdlAudioMix",
+            IsBackground = true,
+
+            // The highest priority in the engine: everything else can be late by a frame, this
+            // cannot be late by a block.
+            Priority = ThreadPriority.Highest
+        };
+
+        mixThread.Start();
+
+        logInitialisationDetails();
+    }
+
+    /// <summary>
+    /// Reports what the audio stack actually resolved to at startup.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors what <see cref="BassEngine.BassAudioManager"/> logs — driver, device, buffer sizes —
+    /// so a bug report from either backend carries the same information. The FFmpeg and decoder
+    /// lines are specific to this one: with BASS the decoders are part of the library, whereas here
+    /// they depend on how the shipped FFmpeg was configured, which is exactly the thing that is
+    /// awkward to diagnose after the fact.
+    /// </remarks>
+    private void logInitialisationDetails()
+    {
+        Logger.Verbose("🔈 SDL audio initialised");
+
+        int version = SDL_GetVersion();
+        Logger.Verbose($"SDL Version: {version / 1000000}.{version / 1000 % 1000}.{version % 1000}");
+        Logger.Verbose($"SDL Revision: {SDL_GetRevision()}");
+
+        Logger.Verbose($"SDL Audio Driver: {SDL_GetCurrentAudioDriver()} (available: {availableDrivers()})");
+
+        var device = SDL_GetAudioStreamDevice(deviceStream);
+        Logger.Verbose($"Device: {SDL_GetAudioDeviceName(device)}");
+
+        SDL_AudioSpec deviceSpec;
+        int deviceFrames;
+
+        if (SDL_GetAudioDeviceFormat(device, &deviceSpec, &deviceFrames))
+        {
+            double deviceBufferMs = deviceSpec.freq > 0 ? deviceFrames / (double)deviceSpec.freq * 1000.0 : 0;
+            Logger.Verbose($"Device format: {deviceSpec.freq} Hz, {deviceSpec.channels} ch, {formatName(deviceSpec.format)}");
+            Logger.Verbose($"Device buffer: {deviceFrames} frames ({deviceBufferMs:F1} ms)");
+        }
+        else
+        {
+            Logger.Verbose($"Device format: unavailable ({SDL_GetError()})");
+        }
+
+        Logger.Verbose($"Mix format: {SampleRate} Hz, {output_channels} ch, {formatName(SDLAudioConverter.SAMPLE_FORMAT)}");
+        Logger.Verbose($"Mix block: {mix_block_frames} frames ({mix_block_frames / (double)SampleRate * 1000.0:F1} ms)");
+        Logger.Verbose($"Target queue length: {target_queue_ms} ms");
+
+        logDecoderSupport();
+    }
+
+    private static string availableDrivers()
+    {
+        int count = SDL_GetNumAudioDrivers();
+
+        if (count <= 0)
+            return "none reported";
+
+        string[] names = new string[count];
+
+        for (int i = 0; i < count; i++)
+            names[i] = SDL_GetAudioDriver(i) ?? "?";
+
+        return string.Join(", ", names);
+    }
+
+    /// <summary>
+    /// Trims SDL's enum spelling down to the part worth reading — <c>SDL_AUDIO_F32LE</c> to
+    /// <c>F32LE</c>.
+    /// </summary>
+    private static string formatName(SDL_AudioFormat format) =>
+        format.ToString().Replace("SDL_AUDIO_", string.Empty);
+
+    /// <summary>
+    /// Reports the FFmpeg build in use and which audio decoders it was compiled with.
+    /// </summary>
+    /// <remarks>
+    /// Specific to this backend: with BASS the decoders are part of the library, whereas here they
+    /// depend on how the shipped FFmpeg was configured. See <see cref="FFmpegLibrary.GetAudioDecoderSupport"/>.
+    /// </remarks>
+    private static void logDecoderSupport()
+    {
+        Logger.Verbose($"FFmpeg: {FFmpegLibrary.DescribeVersions()}");
+
+        var support = FFmpegLibrary.GetAudioDecoderSupport();
+        int total = support.Present.Count + support.Missing.Count;
+
+        Logger.Verbose($"Audio decoders ({support.Present.Count}/{total}): {string.Join(", ", support.Present)}");
+
+        if (support.Missing.Count > 0)
+        {
+            Logger.Warning($"Audio decoders missing from the shipped FFmpeg build: {string.Join(", ", support.Missing)}. " +
+                           "Files in those formats will fail to load.");
+        }
+    }
+
+    /// <summary>
+    /// Uses the device's own rate where SDL will tell us, so the common case involves no resampling
+    /// between our mix and the hardware.
+    /// </summary>
+    private static int queryDeviceSampleRate()
+    {
+        SDL_AudioSpec deviceSpec;
+        int deviceFrames;
+
+        if (SDL_GetAudioDeviceFormat(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &deviceSpec, &deviceFrames) && deviceSpec.freq > 0)
+            return deviceSpec.freq;
+
+        Logger.Verbose($"Could not query the audio device format ({SDL_GetError()}); defaulting to {fallback_sample_rate}Hz.");
+        return fallback_sample_rate;
+    }
+
+    #region Mixing
+
+    private void runMixLoop()
+    {
+        var stopwatch = new Stopwatch();
+
+        while (!cancellation.IsCancellationRequested)
+        {
+            double queued = queuedMs();
+            queuedMilliseconds = queued;
+
+            if (queued >= target_queue_ms)
+            {
+                // Sleep well short of the queue depth, so scheduling jitter cannot drain it.
+                Thread.Sleep(1);
+                continue;
+            }
+
+            // Nothing queued while audio is playing means the device ran dry and the listener heard
+            // it. This is the number that says whether the design is holding up.
+            if (queued <= 0 && runningVoices() > 0)
+                Interlocked.Increment(ref underruns);
+
+            stopwatch.Restart();
+            mixOneBlock();
+            mixMicroseconds = stopwatch.ElapsedTicks * 1_000_000 / Stopwatch.Frequency;
+        }
+    }
+
+    private void mixOneBlock()
+    {
+        var block = mixBuffer.AsSpan();
+        block.Clear();
+
+        try
+        {
+            trackMixer.Fill(block);
+            sampleMixer.Fill(block);
+        }
+        catch (Exception e)
+        {
+            // A throwing voice must not kill the mix thread and silence everything.
+            block.Clear();
+            Logger.Error("[SDLAudioManager] Mixing failed for a block.", e);
+        }
+
+        // Sources are not normalized — a lossy decoder reconstructing a hot master genuinely exceeds
+        // unity — and summing several of them exceeds it further. Clamp here, at the one place the
+        // audio leaves our control, rather than quietly wrapping in the driver.
+        for (int i = 0; i < block.Length; i++)
+            block[i] = Math.Clamp(block[i], -1f, 1f);
+
+        fixed (float* pointer = block)
+        {
+            if (!SDL_PutAudioStreamData(deviceStream, (IntPtr)pointer, block.Length * sizeof(float)))
+                Logger.Error($"SDL_PutAudioStreamData failed: {SDL_GetError()}");
+        }
+    }
+
+    private double queuedMs()
+    {
+        int bytes = SDL_GetAudioStreamQueued(deviceStream);
+
+        if (bytes <= 0)
+            return 0;
+
+        return bytes / (double)(sizeof(float) * output_channels) / SampleRate * 1000.0;
+    }
+
+    private int runningVoices() => trackMixer.RunningChannelCount + sampleMixer.RunningChannelCount;
+
+    #endregion
+
+    #region Channel lifetime
+
+    /// <summary>
+    /// Builds a channel over <paramref name="source"/>, routes it into <paramref name="mixer"/>, and
+    /// registers it for decoding and shutdown.
+    /// </summary>
+    internal SDLAudioChannel CreateChannel(IPcmSource source, IAudioMixer mixer, bool streaming)
+    {
+        var channel = new SDLAudioChannel(this, source);
+
+        if (streaming && source is StreamingPcmSource streamingSource)
+            decodeScheduler.Register(streamingSource);
+
+        lock (activeChannels)
+            activeChannels.Add(channel);
+
+        mixer.AddChannel(channel);
+
+        channel.Disposed += () =>
+        {
+            if (source is StreamingPcmSource registered)
+                decodeScheduler.Unregister(registered);
+
+            mixer.RemoveChannel(channel);
+
+            lock (activeChannels)
+                activeChannels.Remove(channel);
+        };
+
+        return channel;
+    }
+
+    #endregion
+
+    #region IAudioManager
+
+    public ITrack CreateTrack(Stream stream) => new SDLTrack(this, stream);
+
+    public ITrack CreateTrackFromFile(string path) => new SDLTrack(this, path);
+
+    public ISample CreateSample(Stream stream) => new SDLSample(this, stream);
+
+    public ISample CreateSampleFromFile(string path) => new SDLSample(this, path);
+
+    public void EnqueueAction(Action action)
+    {
+        if (action.IsNotNull())
+            audioThreadActions.Enqueue(action);
+    }
+
+    public void WakeDecoder() => decodeScheduler.Wake();
+
+    public void Update(double frameTime)
+    {
+        while (audioThreadActions.TryDequeue(out var action))
+        {
+            try
+            {
+                action.Invoke();
+            }
+            catch (Exception e)
+            {
+                Logger.Error("[SDLAudioManager] A queued audio action failed.", e);
+            }
+        }
+
+        GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value = Interlocked.Read(ref underruns);
+        GlobalStatistics.Get<long>("Audio", "SDL Mix Block (µs)").Value = mixMicroseconds;
+        GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value = runningVoices();
+        GlobalStatistics.Get<double>("Audio", "SDL Queued (ms)").Value = Math.Round(queuedMilliseconds, 1);
+    }
+
+    public void StopAll()
+    {
+        SDLAudioChannel[] toStop;
+
+        lock (activeChannels)
+            toStop = activeChannels.ToArray();
+
+        foreach (var channel in toStop)
+            channel.Stop();
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+
+        cancellation.Cancel();
+
+        if (!mixThread.Join(TimeSpan.FromSeconds(2)))
+            Logger.Error("[SDLAudioManager] Mix thread did not exit in time.");
+
+        SDLAudioChannel[] toDispose;
+
+        lock (activeChannels)
+        {
+            toDispose = activeChannels.ToArray();
+            activeChannels.Clear();
+        }
+
+        foreach (var channel in toDispose)
+            channel.Dispose();
+
+        // Channel disposal is queued onto the audio thread, and nothing else will pump it now.
+        Update(0);
+
+        trackMixer.Dispose();
+        sampleMixer.Dispose();
+        Update(0);
+
+        decodeScheduler.Dispose();
+
+        if (deviceStream != null)
+            SDL_DestroyAudioStream(deviceStream);
+
+        cancellation.Dispose();
+
+        // Refcounted, so this releases only our own claim and leaves any other SDL audio user alone.
+        if (ownsAudioSubsystem)
+            SDL_QuitSubSystem(SDL_InitFlags.SDL_INIT_AUDIO);
+
+        Logger.Verbose("🔈 SDL audio shut down");
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioMixer.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioMixer.cs
@@ -1,0 +1,133 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// SDL implementation of <see cref="IAudioMixer"/>
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed class SDLAudioMixer : SDLAudioChannel, IAudioMixer
+{
+    private readonly Lock sync = new Lock();
+    private readonly List<IAudioChannel> channels = new List<IAudioChannel>();
+
+    /// <summary>
+    /// Immutable view of <see cref="channels"/>, rebuilt only when membership changes.
+    /// </summary>
+    /// <remarks>
+    /// Rebuilt on mutation rather than copied on read because <see cref="ActiveChannels"/> is polled
+    /// every frame by <see cref="Graphics.Performance.AudioMixerVisualiser"/>, and a per-read copy
+    /// would add steady allocation churn to a backend whose whole premise is not provoking the GC.
+    /// </remarks>
+    private volatile IAudioChannel[] snapshot = Array.Empty<IAudioChannel>();
+
+    /// <summary>
+    /// Sum of this mixer's children for the current block, before its own inserts.
+    /// </summary>
+    private float[] scratch = Array.Empty<float>();
+
+    public SDLAudioMixer(ISDLAudioContext context)
+        : base(context, null)
+    {
+    }
+
+    /// <summary>
+    /// The channels routed into this mixer.
+    /// </summary>
+    /// <remarks>
+    /// Returns an immutable snapshot, so enumerating it is safe without external locking and cannot
+    /// throw if a channel is added or removed mid-iteration. The BASS backend instead hands out its
+    /// live backing list and happens to work because callers lock the same object — this does not
+    /// reproduce that arrangement.
+    /// </remarks>
+    public IEnumerable<IAudioChannel> ActiveChannels => snapshot;
+
+    public void AddChannel(IAudioChannel channel)
+    {
+        if (channel is not SDLAudioChannel)
+            return;
+
+        lock (sync)
+        {
+            if (channels.Contains(channel))
+                return;
+
+            channels.Add(channel);
+            snapshot = channels.ToArray();
+        }
+    }
+
+    public void RemoveChannel(IAudioChannel channel)
+    {
+        lock (sync)
+        {
+            if (!channels.Remove(channel))
+                return;
+
+            snapshot = channels.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// The number of children currently producing audio.
+    /// </summary>
+    public int RunningChannelCount
+    {
+        get
+        {
+            var current = snapshot;
+            int count = 0;
+
+            foreach (var channel in current)
+            {
+                if (channel.IsRunning.Value)
+                    count++;
+            }
+
+            return count;
+        }
+    }
+
+    public override void Fill(Span<float> destination)
+    {
+        if (IsDisposed || !IsRunning.Value)
+            return;
+
+        var current = snapshot;
+
+        if (current.Length == 0)
+            return;
+
+        if (scratch.Length < destination.Length)
+            scratch = new float[destination.Length];
+
+        var block = scratch.AsSpan(0, destination.Length);
+        block.Clear();
+
+        foreach (var channel in current)
+        {
+            // Children add into the shared block; a stopped or starved one contributes nothing.
+            if (channel is SDLAudioChannel sdlChannel)
+                sdlChannel.Fill(block);
+        }
+
+        ApplyInsertsAndMix(block, destination);
+    }
+
+    public override void Dispose()
+    {
+        lock (sync)
+        {
+            channels.Clear();
+            snapshot = Array.Empty<IAudioChannel>();
+        }
+
+        base.Dispose();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLLowPassFilter.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLLowPassFilter.cs
@@ -1,0 +1,157 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Sakura.Framework.Reactive;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// A second-order Butterworth low-pass biquad for SDL backend's <see cref="ILowPassFilter"/>.
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed class SDLLowPassFilter : ILowPassFilter
+{
+    /// <summary>
+    /// Butterworth response — the same Q the BASS backend passes as <c>fQ</c>.
+    /// </summary>
+    private const double filter_q = 0.707;
+
+    /// <summary>
+    /// One coherent set of normalised biquad coefficients, published to the mix thread as a unit.
+    /// </summary>
+    private sealed record Coefficients(float B0, float B1, float B2, float A1, float A2)
+    {
+        /// <summary>
+        /// A pass-through, used when the cutoff is at or above what the sample rate can express.
+        /// </summary>
+        public static readonly Coefficients Bypass = new Coefficients(1f, 0f, 0f, 0f, 0f);
+    }
+
+    private readonly int sampleRate;
+    private readonly int channels;
+    private readonly Action? onDisposed;
+
+    /// <summary>
+    /// Transposed direct form II state, two elements per channel. TDF-II rather than DF-I because it
+    /// needs half the state and is better behaved numerically at low cutoffs, where DF-I's delay line
+    /// accumulates error against large-magnitude history.
+    /// </summary>
+    private readonly double[] state;
+
+    private volatile Coefficients coefficients = Coefficients.Bypass;
+
+    /// <inheritdoc cref="ILowPassFilter.CutoffFrequency"/>
+    public Reactive<double> CutoffFrequency { get; } = new Reactive<double>(ILowPassFilter.DefaultCutoffFrequency);
+
+    /// <summary>
+    /// Whether <see cref="Dispose"/> has run. The owning channel stops calling
+    /// <see cref="Process"/> once this is set.
+    /// </summary>
+    public bool IsDisposed { get; private set; }
+
+    /// <param name="sampleRate">The rate of the audio this filter will process, in Hz.</param>
+    /// <param name="channels">Channel count of the interleaved buffers passed to <see cref="Process"/>.</param>
+    /// <param name="onDisposed">Invoked on <see cref="Dispose"/> so the owner can detach the filter.</param>
+    public SDLLowPassFilter(int sampleRate, int channels, Action? onDisposed = null)
+    {
+        if (sampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels));
+
+        this.sampleRate = sampleRate;
+        this.channels = channels;
+        this.onDisposed = onDisposed;
+
+        state = new double[channels * 2];
+
+        updateCoefficients();
+        CutoffFrequency.ValueChanged += _ => updateCoefficients();
+    }
+
+    private void updateCoefficients()
+    {
+        double maxCutoff = sampleRate / 2.0 - 1.0;
+        double cutoff = Math.Clamp(CutoffFrequency.Value, 1.0, maxCutoff);
+
+        // At the very top of the range, the filter does nothing audible, and the coefficient maths
+        // degenerates as w0 approaches pi. Bypass rather than ring.
+        if (cutoff >= maxCutoff)
+        {
+            coefficients = Coefficients.Bypass;
+            return;
+        }
+
+        double w0 = 2.0 * Math.PI * cutoff / sampleRate;
+        double cosW0 = Math.Cos(w0);
+        double alpha = Math.Sin(w0) / (2.0 * filter_q);
+
+        double a0 = 1.0 + alpha;
+        double b0 = (1.0 - cosW0) / 2.0;
+        double b1 = 1.0 - cosW0;
+        double b2 = b0;
+        double a1 = -2.0 * cosW0;
+        double a2 = 1.0 - alpha;
+
+        coefficients = new Coefficients(
+            (float)(b0 / a0),
+            (float)(b1 / a0),
+            (float)(b2 / a0),
+            (float)(a1 / a0),
+            (float)(a2 / a0));
+    }
+
+    /// <summary>
+    /// Filters <paramref name="buffer"/> in place. Interleaved, with the channel count this filter
+    /// was constructed for; each channel carries its own independent state.
+    /// </summary>
+    public void Process(Span<float> buffer)
+    {
+        if (IsDisposed)
+            return;
+
+        var c = coefficients;
+
+        if (ReferenceEquals(c, Coefficients.Bypass))
+            return;
+
+        for (int i = 0; i + channels <= buffer.Length; i += channels)
+        {
+            for (int ch = 0; ch < channels; ch++)
+            {
+                int s = ch * 2;
+                double input = buffer[i + ch];
+
+                double output = c.B0 * input + state[s];
+                state[s] = c.B1 * input - c.A1 * output + state[s + 1];
+                state[s + 1] = c.B2 * input - c.A2 * output;
+
+                buffer[i + ch] = (float)output;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears the filter's delay line without touching <see cref="CutoffFrequency"/>. Used on seek,
+    /// where carrying history across a discontinuity would produce an audible transient.
+    /// </summary>
+    public void ClearState() => Array.Clear(state);
+
+    public void Reset()
+    {
+        if (IsDisposed)
+            return;
+
+        CutoffFrequency.Value = ILowPassFilter.DefaultCutoffFrequency;
+    }
+
+    public void Dispose()
+    {
+        if (IsDisposed)
+            return;
+
+        IsDisposed = true;
+        CutoffFrequency.UnbindAll();
+        onDisposed?.Invoke();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLSample.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLSample.cs
@@ -1,0 +1,99 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using Sakura.Framework.Extensions.ObjectExtensions;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// SDL implementation of <see cref="ISample"/>. Samples are decoded to PCM once at a load and shared
+/// by every channel playing them.
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed class SDLSample : ISample, IHasActiveChannels, IDisposable
+{
+    private readonly SDLAudioManager manager;
+    private readonly PcmBuffer? buffer;
+
+    private int activeChannelCount;
+    private bool isDisposed;
+
+    public double Length => buffer?.LengthMs ?? 0;
+
+    public bool HasActiveChannels => Volatile.Read(ref activeChannelCount) > 0;
+
+    public SDLSample(SDLAudioManager manager, Stream stream)
+        : this(manager, () => stream)
+    {
+    }
+
+    public SDLSample(SDLAudioManager manager, string path)
+        : this(manager, () => File.OpenRead(path))
+    {
+    }
+
+    private SDLSample(SDLAudioManager manager, Func<Stream> open)
+    {
+        this.manager = manager;
+
+        try
+        {
+            buffer = PcmBuffer.Decode(open(), manager.SampleRate, manager.Channels);
+
+            GlobalStatistics.Get<int>("Audio", "Loaded Samples").Value++;
+            Logger.Verbose($"🔈 Sample decoded to PCM ({buffer.Samples.Length * sizeof(float) / 1024} KB, {buffer.LengthMs:F0}ms)");
+        }
+        catch (Exception e)
+        {
+            Logger.Error("Could not decode a sample.", e);
+            buffer = null;
+        }
+    }
+
+    public IAudioChannel GetChannel()
+    {
+        if (isDisposed || buffer == null)
+            return null!;
+
+        var source = new MemoryPcmSource(buffer);
+        var channel = manager.CreateChannel(source, manager.SampleMixer, streaming: false);
+
+        Interlocked.Increment(ref activeChannelCount);
+        channel.Disposed += () => Interlocked.Decrement(ref activeChannelCount);
+
+        return channel;
+    }
+
+    public IAudioChannel Play()
+    {
+        var channel = GetChannel();
+
+        if (channel.IsNull())
+            return null!;
+
+        channel.AutoDispose = true;
+        channel.Play();
+
+        return channel;
+    }
+
+    public void Dispose()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+
+        if (buffer != null)
+            GlobalStatistics.Get<int>("Audio", "Loaded Samples").Value--;
+
+        // Channels hold their own reference to the buffer through MemoryPcmSource, and the GC frees
+        // it once the last of them is gone — there is no unmanaged block to release here.
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLTrack.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLTrack.cs
@@ -1,0 +1,181 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using Sakura.Framework.IO;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// SDL implementation of <see cref="ITrack"/>. Tracks stream: each channel decodes independently
+/// of the encoded source, so nothing holds a whole song as float PCM.
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed unsafe class SDLTrack : ITrack, IHasActiveChannels, IDisposable
+{
+    private readonly SDLAudioManager manager;
+    private readonly string? filePath;
+    private readonly NativeMemoryBuffer? data;
+
+    private int activeChannelCount;
+    private bool isDisposed;
+
+    public double Length { get; }
+
+    /// <summary>
+    /// Where looping playback restarts from, in milliseconds. Applied to channels this track creates.
+    /// </summary>
+    public double RestartPoint { get; set; }
+
+    public bool HasActiveChannels => Volatile.Read(ref activeChannelCount) > 0;
+
+    public SDLTrack(SDLAudioManager manager, string path)
+    {
+        this.manager = manager;
+        filePath = path;
+
+        Length = probeLength();
+
+        if (Length > 0)
+        {
+            GlobalStatistics.Get<int>("Audio", "Loaded Tracks").Value++;
+            Logger.Debug($"🔈 Track opened from file, no in-memory copy: {path}");
+        }
+    }
+
+    public SDLTrack(SDLAudioManager manager, Stream stream)
+    {
+        this.manager = manager;
+
+        data = NativeMemoryBuffer.CreateFrom(stream, NativeMemoryCategory.Audio);
+
+        if (data == null)
+        {
+            Logger.Error("Refusing to create a track from an empty stream.", new InvalidDataException("Audio stream contained no data."));
+            return;
+        }
+
+        Length = probeLength();
+
+        if (Length > 0)
+        {
+            GlobalStatistics.Get<int>("Audio", "Loaded Tracks").Value++;
+            Logger.Verbose($"🔈 Track loaded from stream ({data.Length / 1024} KB held in unmanaged memory)");
+        }
+    }
+
+    /// <summary>
+    /// Reads just enough of the source to learn its duration. Header parsing only — no audio is
+    /// decoded and nothing is retained.
+    /// </summary>
+    private double probeLength()
+    {
+        try
+        {
+            var source = openEncodedStream();
+
+            if (source == null)
+                return 0;
+
+            using var decoder = new FFmpegAudioDecoder(source);
+            return decoder.Duration;
+        }
+        catch (Exception e)
+        {
+            Logger.Error($"Could not read the duration of {filePath ?? "an audio stream"}.", e);
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Opens an independent read over the encoded audio, for one decoder to own.
+    /// </summary>
+    private Stream? openEncodedStream()
+    {
+        if (filePath != null)
+            return File.OpenRead(filePath);
+
+        if (data == null)
+            return null;
+
+        return new UnmanagedMemoryStream((byte*)data.Pointer, data.Length);
+    }
+
+    public IAudioChannel GetChannel()
+    {
+        if (isDisposed || Length <= 0)
+            return null!;
+
+        // Held for as long as the channel lives. Without it an eviction between here and the
+        // channel's disposal would free the encoded bytes underneath a live decoder.
+        bool holdsReference = false;
+
+        try
+        {
+            if (data != null)
+            {
+                holdsReference = data.AddReference();
+
+                if (!holdsReference)
+                    return null!;
+            }
+
+            var stream = openEncodedStream();
+
+            if (stream == null)
+            {
+                if (holdsReference) data.Release();
+                return null!;
+            }
+
+            var source = new StreamingPcmSource(stream, manager.SampleRate, manager.Channels);
+            var channel = manager.CreateChannel(source, manager.TrackMixer, streaming: true);
+
+            Interlocked.Increment(ref activeChannelCount);
+
+            bool releaseOnDispose = holdsReference;
+
+            channel.Disposed += () =>
+            {
+                Interlocked.Decrement(ref activeChannelCount);
+
+                if (releaseOnDispose)
+                    data!.Release();
+            };
+
+            // Tracks loop by default, matching the BASS backend.
+            channel.Looping = true;
+            channel.RestartPoint = RestartPoint;
+
+            return channel;
+        }
+        catch (Exception e)
+        {
+            if (holdsReference)
+                data!.Release();
+
+            Logger.Error($"Could not create a playback channel for {filePath ?? "an audio stream"}.", e);
+            return null!;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+
+        if (Length > 0)
+            GlobalStatistics.Get<int>("Audio", "Loaded Tracks").Value--;
+
+        // Only this track's own reference. Channels still playing hold theirs, and the block
+        // survives until the last of them is disposed.
+        data?.Release();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SdlAudioConverter.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SdlAudioConverter.cs
@@ -1,0 +1,135 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using SDL;
+using static SDL.SDL3;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Converts float PCM between sample rates and channel counts, wrapping an <c>SDL_AudioStream</c>
+/// used purely as a converter, it is never bound to a device.
+/// </summary>
+/// <remarks>
+/// This class stand for <c>libswresample</c>, which the shipped FFmpeg build deliberately omits.
+/// Also, this is not thread-safe, an instance belongs to whichever thread is decoding into it.
+/// </remarks>
+internal sealed unsafe class SdlAudioConverter : IDisposable
+{
+    private const int bytes_per_float = sizeof(float);
+
+    /// <summary>
+    /// The sample format used on both sides of every conversion.
+    /// </summary>
+    /// <remarks>
+    /// Spelled <c>LE</c> explicitly because the binding exposes only the two endian-specific enum
+    /// members, not SDL's native-endian <c>SDL_AUDIO_F32</c> alias. Every platform this framework
+    /// targets is little-endian, and a big-endian port would have to revisit this.
+    /// </remarks>
+    internal const SDL_AudioFormat SAMPLE_FORMAT = SDL_AudioFormat.SDL_AUDIO_F32LE;
+
+    private SDL_AudioStream* stream;
+
+    /// <summary>
+    /// Number of floats currently converted and waiting to be read.
+    /// </summary>
+    public int Available
+    {
+        get
+        {
+            if (stream == null)
+                return 0;
+
+            int bytes = SDL_GetAudioStreamAvailable(stream);
+            return bytes <= 0 ? 0 : bytes / bytes_per_float;
+        }
+    }
+
+    /// <param name="sourceRate">Input sample rate in Hz.</param>
+    /// <param name="sourceChannels">Input channel count.</param>
+    /// <param name="targetRate">Output sample rate in Hz.</param>
+    /// <param name="targetChannels">Output channel count.</param>
+    /// <exception cref="InvalidOperationException">SDL could not create the stream.</exception>
+    public SdlAudioConverter(int sourceRate, int sourceChannels, int targetRate, int targetChannels)
+    {
+        var source = new SDL_AudioSpec
+        {
+            format = SAMPLE_FORMAT,
+            channels = sourceChannels,
+            freq = sourceRate
+        };
+
+        var target = new SDL_AudioSpec
+        {
+            format = SAMPLE_FORMAT,
+            channels = targetChannels,
+            freq = targetRate
+        };
+
+        stream = SDL_CreateAudioStream(&source, &target);
+
+        if (stream == null)
+            throw new InvalidOperationException($"SDL_CreateAudioStream failed: {SDL_GetError()}");
+    }
+
+    /// <summary>
+    /// Feeds interleaved source-format floats in.
+    /// </summary>
+    public void Put(ReadOnlySpan<float> source)
+    {
+        if (stream == null || source.IsEmpty)
+            return;
+
+        fixed (float* pointer = source)
+        {
+            if (!SDL_PutAudioStreamData(stream, (IntPtr)pointer, source.Length * bytes_per_float))
+                throw new InvalidOperationException($"SDL_PutAudioStreamData failed: {SDL_GetError()}");
+        }
+    }
+
+    /// <summary>
+    /// Reads converted interleaved target-format floats out.
+    /// </summary>
+    /// <returns>The number of floats written, which may be fewer than requested.</returns>
+    public int Get(Span<float> destination)
+    {
+        if (stream == null || destination.IsEmpty)
+            return 0;
+
+        fixed (float* pointer = destination)
+        {
+            int bytes = SDL_GetAudioStreamData(stream, (IntPtr)pointer, destination.Length * bytes_per_float);
+            return bytes <= 0 ? 0 : bytes / bytes_per_float;
+        }
+    }
+
+    /// <summary>
+    /// Tells the converter no more input is coming, so it emits the tail it would otherwise hold
+    /// back waiting for more. Call at the end of the stream, or the last few milliseconds never arrive.
+    /// </summary>
+    public void Flush()
+    {
+        if (stream != null)
+            SDL_FlushAudioStream(stream);
+    }
+
+    /// <summary>
+    /// Discards all buffered input and output. Used on seek, where anything still in flight belongs
+    /// to the position being left behind.
+    /// </summary>
+    public void Clear()
+    {
+        if (stream != null)
+            SDL_ClearAudioStream(stream);
+    }
+
+    public void Dispose()
+    {
+        if (stream == null)
+            return;
+
+        SDL_DestroyAudioStream(stream);
+        stream = null;
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/StreamingPcmSource.cs
+++ b/Sakura.Framework/Audio/SdlEngine/StreamingPcmSource.cs
@@ -1,0 +1,295 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// An <see cref="IPcmSource"/> that decodes on demand, keeping a buffer of audio ready ahead of the
+/// mixer. This is the track path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three threads meet here, and which one does what is the whole design:
+/// </para>
+/// <list type="bullet">
+/// <item>the <b>decode thread</b> calls <see cref="PumpDecode"/>, the only place FFmpeg is touched;</item>
+/// <item>the <b>mix thread</b> calls <see cref="ReadFrames"/>, which only ever drains the ring buffer;</item>
+/// <item>the <b>update thread</b> calls <see cref="Seek"/>, which never blocks on decoding.</item>
+/// </list>
+/// <para>
+/// A seek therefore cannot be applied where it is requested. It is recorded as a request and the
+/// decode thread picks it up, so audio decoded for the old position may still be in flight when it
+/// lands. A generation counter stamps each request; the decode thread discards anything it produced
+/// under a superseded generation rather than letting a moment of pre-seek audio through.
+/// </para>
+/// </remarks>
+internal sealed class StreamingPcmSource : IPcmSource
+{
+    /// <summary>
+    /// How far ahead to decode. Large enough that a GC pause or a slow read cannot starve the mixer,
+    /// and irrelevant to output latency, which is set by the device buffer alone.
+    /// </summary>
+    private const double target_buffer_ms = 500;
+
+    /// <summary>
+    /// Don't wake the decoder for scraps; wait until this much of the buffer has drained.
+    /// </summary>
+    private const double refill_threshold_ms = 100;
+
+    private readonly Lock sync = new Lock();
+
+    /// <summary>
+    /// Held across all decoding, and by <see cref="Dispose"/>, so the decoder is never freed while
+    /// the decode thread is inside it.
+    /// </summary>
+    private readonly Lock decodeSync = new Lock();
+
+    private readonly AudioRingBuffer ring;
+    private readonly int deviceSampleRate;
+    private readonly int deviceChannels;
+
+    private readonly float[] decodeScratch = new float[8192];
+    private readonly float[] convertScratch = new float[8192];
+
+    private FFmpegAudioDecoder? decoder;
+    private SdlAudioConverter? converter;
+
+    private double? pendingSeekMs;
+    private int seekGeneration;
+
+    private double basePositionMs;
+    private long framesSinceBase;
+
+    /// <summary>
+    /// Set once the decoder has no more audio. Distinct from <see cref="Ended"/>, which also waits
+    /// for the ring to drain.
+    /// </summary>
+    private bool decoderDrained;
+
+    private bool isDisposed;
+
+    public double LengthMs { get; }
+
+    /// <summary>
+    /// How many times the mixer asked for frames the decoder had not produced yet. Non-zero means
+    /// decoding is not keeping up. For benchmark.
+    /// </summary>
+    public long Underruns => Interlocked.Read(ref underruns);
+
+    private long underruns;
+
+    public double PositionMs
+    {
+        get
+        {
+            lock (sync)
+                return basePositionMs + framesSinceBase / (double)deviceSampleRate * 1000.0;
+        }
+    }
+
+    public bool Ended
+    {
+        get
+        {
+            lock (sync)
+                return decoderDrained && ring.Available == 0;
+        }
+    }
+
+    /// <summary>
+    /// Whether the decode thread should spend time on this source right now.
+    /// </summary>
+    public bool WantsDecode
+    {
+        get
+        {
+            lock (sync)
+            {
+                if (isDisposed)
+                    return false;
+
+                if (pendingSeekMs.HasValue)
+                    return true;
+
+                if (decoderDrained)
+                    return false;
+
+                return ring.Available <= millisecondsToFloats(target_buffer_ms - refill_threshold_ms);
+            }
+        }
+    }
+
+    /// <param name="stream">The encoded source. Ownership passes to this instance.</param>
+    /// <param name="deviceSampleRate">Sample rate to decode to, in Hz.</param>
+    /// <param name="deviceChannels">Channel count to decode to.</param>
+    /// <exception cref="InvalidDataException">The source could not be decoded.</exception>
+    public StreamingPcmSource(Stream stream, int deviceSampleRate, int deviceChannels)
+    {
+        this.deviceSampleRate = deviceSampleRate;
+        this.deviceChannels = deviceChannels;
+
+        decoder = new FFmpegAudioDecoder(stream);
+
+        try
+        {
+            converter = new SdlAudioConverter(decoder.SampleRate, decoder.Channels, deviceSampleRate, deviceChannels);
+        }
+        catch
+        {
+            decoder.Dispose();
+            decoder = null;
+            throw;
+        }
+
+        LengthMs = decoder.Duration;
+        ring = new AudioRingBuffer(millisecondsToFloats(target_buffer_ms));
+    }
+
+    private int millisecondsToFloats(double milliseconds) =>
+        Math.Max(deviceChannels, (int)(milliseconds / 1000.0 * deviceSampleRate) * deviceChannels);
+
+    public int ReadFrames(Span<float> destination, int frameCount)
+    {
+        if (frameCount <= 0)
+            return 0;
+
+        int wanted = Math.Min(frameCount * deviceChannels, destination.Length - destination.Length % deviceChannels);
+
+        if (wanted <= 0)
+            return 0;
+
+        int got = ring.Read(destination.Slice(0, wanted));
+        int frames = got / deviceChannels;
+
+        lock (sync)
+        {
+            if (isDisposed)
+                return 0;
+
+            framesSinceBase += frames;
+
+            // Short of what was asked for, with the decoder still holding audio, means decoding
+            // fell behind. At the true end of the source this is not an underrun.
+            if (got < wanted && !decoderDrained)
+                Interlocked.Increment(ref underruns);
+        }
+
+        return frames;
+    }
+
+    public void Seek(double milliseconds)
+    {
+        lock (sync)
+        {
+            if (isDisposed)
+                return;
+
+            double target = Math.Max(0, milliseconds);
+
+            pendingSeekMs = target;
+            seekGeneration++;
+
+            // Everything buffered belongs to where we just left, so drop it. Reporting the new
+            // position immediately — rather than when the decode thread catches up — is what makes
+            // a read straight after a write see the value that was written.
+            ring.Clear();
+            basePositionMs = target;
+            framesSinceBase = 0;
+            decoderDrained = false;
+        }
+    }
+
+    /// <summary>
+    /// Does one unit of decoding work. Called only from the decode thread.
+    /// </summary>
+    /// <returns>True if there is more to do for this source right now.</returns>
+    public bool PumpDecode()
+    {
+        lock (decodeSync)
+        {
+            if (isDisposed || decoder == null || converter == null)
+                return false;
+
+            double? seek;
+            int generation;
+
+            lock (sync)
+            {
+                seek = pendingSeekMs;
+                pendingSeekMs = null;
+                generation = seekGeneration;
+
+                if (seek == null && (decoderDrained || ring.FreeSpace < convertScratch.Length))
+                    return false;
+            }
+
+            if (seek.HasValue)
+            {
+                decoder.Seek(seek.Value);
+                converter.Clear();
+                decoderDrained = false;
+            }
+
+            int read = decoder.Read(decodeScratch);
+
+            if (read == 0)
+            {
+                // Flush or the converter withholds its tail — the last few milliseconds of every
+                // track would silently go missing.
+                converter.Flush();
+            }
+            else
+            {
+                converter.Put(decodeScratch.AsSpan(0, read));
+            }
+
+            int converted = converter.Get(convertScratch);
+
+            lock (sync)
+            {
+                // A seek landed while this block was being decoded, so it is audio from a position
+                // we have already left. Dropping it is the point of the generation counter.
+                if (generation != seekGeneration || isDisposed)
+                    return true;
+
+                if (converted > 0)
+                    ring.Write(convertScratch.AsSpan(0, converted));
+
+                if (read == 0 && converted == 0)
+                {
+                    decoderDrained = true;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (sync)
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+        }
+
+        // Outside the state lock but inside the decode lock: waits for any in-flight decode to
+        // finish rather than freeing FFmpeg state underneath it.
+        lock (decodeSync)
+        {
+            decoder?.Dispose();
+            decoder = null;
+            converter?.Dispose();
+            converter = null;
+        }
+
+        ring.Clear();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/StreamingPcmSource.cs
+++ b/Sakura.Framework/Audio/SdlEngine/StreamingPcmSource.cs
@@ -56,7 +56,7 @@ internal sealed class StreamingPcmSource : IPcmSource
     private readonly float[] convertScratch = new float[8192];
 
     private FFmpegAudioDecoder? decoder;
-    private SdlAudioConverter? converter;
+    private SDLAudioConverter? converter;
 
     private double? pendingSeekMs;
     private int seekGeneration;
@@ -136,7 +136,7 @@ internal sealed class StreamingPcmSource : IPcmSource
 
         try
         {
-            converter = new SdlAudioConverter(decoder.SampleRate, decoder.Channels, deviceSampleRate, deviceChannels);
+            converter = new SDLAudioConverter(decoder.SampleRate, decoder.Channels, deviceSampleRate, deviceChannels);
         }
         catch
         {

--- a/Sakura.Framework/Configurations/FrameworkConfigManager.cs
+++ b/Sakura.Framework/Configurations/FrameworkConfigManager.cs
@@ -1,6 +1,7 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using Sakura.Framework.Audio;
 using Sakura.Framework.Graphics.Performance;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Threading;
@@ -22,6 +23,7 @@ public class FrameworkConfigManager : ConfigManager<FrameworkSetting>
         Get(FrameworkSetting.MasterVolume, 1.0);
         Get(FrameworkSetting.TrackVolume, 1.0);
         Get(FrameworkSetting.SampleVolume, 1.0);
+        Get(FrameworkSetting.AudioBackend, AudioBackend.BASS);
         Get(FrameworkSetting.WindowMode, WindowMode.Windowed);
         Get(FrameworkSetting.HardwareAcceleration, true);
         Get(FrameworkSetting.RendererType, RendererType.Automatic);

--- a/Sakura.Framework/Configurations/FrameworkSetting.cs
+++ b/Sakura.Framework/Configurations/FrameworkSetting.cs
@@ -11,6 +11,7 @@ public enum FrameworkSetting
     MasterVolume,
     TrackVolume,
     SampleVolume,
+    AudioBackend,
     WindowMode,
     ExecutionMode,
     HardwareAcceleration,

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -3,9 +3,11 @@
 
 using System;
 using Sakura.Framework.Allocation;
+using Sakura.Framework.Audio;
 using Sakura.Framework.Configurations;
 using Sakura.Framework.Extensions.ColorExtensions;
 using Sakura.Framework.Extensions.DrawableExtensions;
+using Sakura.Framework.Extensions.ObjectExtensions;
 using Sakura.Framework.Graphics.Colors;
 using Sakura.Framework.Graphics.Containers;
 using Sakura.Framework.Graphics.Drawables;
@@ -39,6 +41,7 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
     private SpriteText windowModeText;
     private SpriteText executionModeText;
     private SpriteText rendererText;
+    private SpriteText audioText;
 
     private readonly FontUsage graphFontUsage = FontUsage.Default.With(size: 14);
     private readonly FontUsage boldGraphFontUsage = FontUsage.Default.With(size: 14, weight: "Bold");
@@ -77,7 +80,7 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
         {
             Anchor = Anchor.TopLeft,
             Origin = Anchor.TopLeft,
-            Size = new Vector2(extended_width, 100),
+            Size = new Vector2(extended_width, 120),
             Children = new Drawable[]
             {
                 new Box()
@@ -214,6 +217,36 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
                                     Text = "N/A"
                                 }
                             }
+                        },
+                        new FlowContainer()
+                        {
+                            Anchor = Anchor.TopLeft,
+                            Origin = Anchor.TopLeft,
+                            Direction = FlowDirection.Horizontal,
+                            Size = new Vector2(1, 20),
+                            RelativeSizeAxes = Axes.X,
+                            Spacing = new Vector2(10, 0),
+                            Children = new Drawable[]
+                            {
+                                new SpriteText()
+                                {
+                                    Anchor = Anchor.TopLeft,
+                                    Origin = Anchor.TopLeft,
+                                    Size = new Vector2(200, 10),
+                                    Color = Color.White,
+                                    Font = boldGraphFontUsage,
+                                    Text = "AudioManager"
+                                },
+                                audioText = new SpriteText()
+                                {
+                                    Anchor = Anchor.TopLeft,
+                                    Origin = Anchor.TopLeft,
+                                    Size = new Vector2(200, 10),
+                                    Color = Color.White,
+                                    Font = graphFontUsage,
+                                    Text = "N/A"
+                                }
+                            }
                         }
                     }
                 }
@@ -242,7 +275,37 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
         if (actual.EndsWith("Renderer"))
             actual = actual[..^"Renderer".Length];
 
-        return configured == RendererType.Automatic ? $"Automatic ({actual})" : actual;
+        return configured == RendererType.Automatic ? $"{getWindowType()} + Automatic ({actual})" : getWindowType() + actual;
+    }
+
+    private string getWindowType()
+    {
+        var type = host.Window?.GetType();
+        string windowType;
+        if (type.IsNotNull() && type.BaseType.IsNotNull())
+        {
+            windowType = type.BaseType.Name;
+        }
+        else
+        {
+            windowType = type?.Name ?? "None";
+        }
+
+        if (windowType.EndsWith("Window"))
+            windowType = windowType[..^"Window".Length];
+
+        return windowType;
+    }
+
+    private string getAudioText()
+    {
+        var configured = host.FrameworkConfigManager.Get<AudioBackend>(FrameworkSetting.AudioBackend).Value;
+        string actual = host.AudioManager?.GetType().Name ?? "None";
+
+        if (actual.EndsWith("AudioManager"))
+            actual = actual[..^"AudioManager".Length];
+
+        return configured == AudioBackend.Automatic ? $"Automatic ({actual})" : actual;
     }
 
     public override void LoadComplete()
@@ -253,6 +316,7 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
         executionModeText.Text = $"{host.ExecutionMode.Value}";
         limiterText.Text = $"{host.FrameLimiter.Value}";
         rendererText.Text = getRendererText();
+        audioText.Text = getAudioText();
 
         host.FrameLimiter.ValueChanged += value =>
         {

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -235,7 +235,7 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
                                     Size = new Vector2(200, 10),
                                     Color = Color.White,
                                     Font = boldGraphFontUsage,
-                                    Text = "AudioManager"
+                                    Text = "AudioBackend"
                                 },
                                 audioText = new SpriteText()
                                 {

--- a/Sakura.Framework/Graphics/Video/VideoDecoder.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDecoder.cs
@@ -12,6 +12,7 @@ using FFmpeg.AutoGen;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.Logging;
+using Sakura.Framework.Platform;
 using Sakura.Framework.Reactive;
 using Sakura.Framework.Statistic;
 using Texture = Sakura.Framework.Graphics.Textures.Texture;
@@ -105,24 +106,7 @@ public unsafe class VideoDecoder : IDisposable
     private readonly IRenderer renderer;
     private readonly ITextureManager textureManager;
 
-    static VideoDecoder()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            ffmpeg.RootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "runtimes", "osx", "native");
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "win-arm64" : "win-x64";
-            ffmpeg.RootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "runtimes", arch, "native");
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "linux-arm64" : "linux-x64";
-            ffmpeg.RootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "runtimes", arch, "native");
-        }
-
-        Logger.Verbose($"Initialized FFmpeg with root path {ffmpeg.RootPath}");
-        DynamicallyLoadedBindings.Initialize();
-    }
+    static VideoDecoder() => FFmpegLibrary.EnsureInitialized();
 
     public VideoDecoder(IRenderer renderer, ITextureManager textureManager, string filePath)
         : this(renderer, textureManager, File.OpenRead(filePath)) { }

--- a/Sakura.Framework/Platform/AppHost.cs
+++ b/Sakura.Framework/Platform/AppHost.cs
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Sakura.Framework.Audio;
 using Sakura.Framework.Configurations;
 using Sakura.Framework.Development;
 using Sakura.Framework.Extensions.ExceptionExtensions;
@@ -49,6 +50,9 @@ public abstract class AppHost : IDisposable
 
     public IWindow Window { get; private set; }
     public IRenderer Renderer { get; private set; }
+
+    [CanBeNull]
+    public IAudioManager AudioManager { get; set; }
 
     private App app;
 

--- a/Sakura.Framework/Platform/FFmpegLibrary.cs
+++ b/Sakura.Framework/Platform/FFmpegLibrary.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file for full license text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -53,4 +54,56 @@ internal static class FFmpegLibrary
             Volatile.Write(ref initialised, true);
         }
     }
+
+    /// <summary>
+    /// Which of the audio formats the framework expects to handle are actually decodable by the
+    /// shipped FFmpeg build.
+    /// </summary>
+    public static AudioDecoderSupport GetAudioDecoderSupport()
+    {
+        EnsureInitialized();
+
+        (string Name, AVCodecID Id)[] expected =
+        [
+            ("mp3", AVCodecID.AV_CODEC_ID_MP3),
+            ("vorbis", AVCodecID.AV_CODEC_ID_VORBIS),
+            ("flac", AVCodecID.AV_CODEC_ID_FLAC),
+            ("aac", AVCodecID.AV_CODEC_ID_AAC),
+            ("alac", AVCodecID.AV_CODEC_ID_ALAC),
+            ("opus", AVCodecID.AV_CODEC_ID_OPUS),
+            ("pcm_s16le", AVCodecID.AV_CODEC_ID_PCM_S16LE)
+        ];
+
+        var present = new List<string>();
+        var missing = new List<string>();
+
+        foreach (var (name, id) in expected)
+        {
+            unsafe
+            {
+                (ffmpeg.avcodec_find_decoder(id) != null ? present : missing).Add(name);
+            }
+        }
+
+        return new AudioDecoderSupport(present, missing);
+    }
+
+    /// <summary>
+    /// Version numbers of the loaded FFmpeg libraries for logging.
+    /// </summary>
+    public static string DescribeVersions()
+    {
+        EnsureInitialized();
+
+        return $"avcodec {version(ffmpeg.avcodec_version())}, " +
+               $"avformat {version(ffmpeg.avformat_version())}, " +
+               $"avutil {version(ffmpeg.avutil_version())} ({ffmpeg.av_version_info()})";
+
+        static string version(uint packed) => $"{packed >> 16 & 0xFF}.{packed >> 8 & 0xFF}.{packed & 0xFF}";
+    }
 }
+
+/// <summary>
+/// The audio formats the shipped FFmpeg build can and cannot decode.
+/// </summary>
+internal readonly record struct AudioDecoderSupport(IReadOnlyList<string> Present, IReadOnlyList<string> Missing);

--- a/Sakura.Framework/Platform/FFmpegLibrary.cs
+++ b/Sakura.Framework/Platform/FFmpegLibrary.cs
@@ -1,0 +1,56 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using FFmpeg.AutoGen;
+using Sakura.Framework.Logging;
+
+namespace Sakura.Framework.Platform;
+
+/// <summary>
+/// Locates the shipped FFmpeg binaries and initialises <see cref="FFmpeg.AutoGen"/>'s dynamic
+/// bindings. Every consumer of FFmpeg must call <see cref="EnsureInitialized"/> before its first
+/// <c>ffmpeg.*</c> call.
+/// </summary>
+internal static class FFmpegLibrary
+{
+    private static readonly Lock initialisation_lock = new Lock();
+    private static bool initialised;
+
+    /// <summary>
+    /// Points <see cref="ffmpeg.RootPath"/> at the runtime-specific native directory and initializes
+    /// the bindings, once per process.
+    /// </summary>
+    public static void EnsureInitialized()
+    {
+        lock (initialisation_lock)
+        {
+            if (Volatile.Read(ref initialised))
+                return;
+
+            if (initialised)
+                return;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                ffmpeg.RootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "runtimes", "osx", "native");
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "win-arm64" : "win-x64";
+                ffmpeg.RootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "runtimes", arch, "native");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "linux-arm64" : "linux-x64";
+                ffmpeg.RootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "runtimes", arch, "native");
+            }
+
+            Logger.Verbose($"Initialized FFmpeg with root path {ffmpeg.RootPath}");
+            DynamicallyLoadedBindings.Initialize();
+
+            Volatile.Write(ref initialised, true);
+        }
+    }
+}

--- a/Sakura.Framework/Sakura.Framework.csproj
+++ b/Sakura.Framework/Sakura.Framework.csproj
@@ -32,13 +32,13 @@
     <PackageReference Include="ManagedBass.Fx" Version="4.0.2" />
     <PackageReference Include="ManagedBass.Mix" Version="4.0.2" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="Sakura.Framework.NativeLibraries" Version="2026.804.0" />
+    <PackageReference Include="Sakura.Framework.NativeLibraries" Version="2026.819.0" />
     <PackageReference Include="Sakura.Framework.SourceGenerators" Version="2026.708.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Sakura.Framework.SPIRV" Version="2026.617.0" />
-    <PackageReference Include="ppy.SDL3-CS" Version="2026.629.0" />
+    <PackageReference Include="ppy.SDL3-CS" Version="2026.722.0" />
     <PackageReference Include="Silk.NET.OpenGL" Version="2.23.0" />
     <PackageReference Include="Silk.NET.Maths" Version="2.23.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />

--- a/sakura.sln.DotSettings
+++ b/sakura.sln.DotSettings
@@ -48,6 +48,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comfortaa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ducker/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fmpeg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Noto/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=spirv/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=syncproc/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
First pass of SDL audio manager. Decode using FFmpeg, still missing `opus`, will bump nativelib later but already add `swscale` enable flag to build script. Now able to use but still not recommend to use it as default yet, but able to change `AudioBackend` to using `SDL`. Still noticing with if video (that's also using FFmpeg too) it can lead to video decoder stutter too.