### PR TITLE
Add better font heirarchy language support

### DIFF
--- a/Sakura.Framework.Tests/Text/FontFallbackChainTest.cs
+++ b/Sakura.Framework.Tests/Text/FontFallbackChainTest.cs
@@ -13,8 +13,8 @@ using Sakura.Framework.Statistic;
 namespace Sakura.Framework.Tests.Text;
 
 /// <summary>
-/// Tests for <see cref="RendererFontStore.GetFallbacks"/> — specifically that the chain is resolved one
-/// family at a time as it is walked
+/// Tests for <see cref="RendererFontStore.GetFallbacks(FontUsage,FontScript)"/> the priority tiers a
+/// chain is ordered by, and that it is resolved one family at a time as it is walked.
 /// </summary>
 [TestFixture]
 public class FontFallbackChainTest
@@ -130,6 +130,157 @@ public class FontFallbackChainTest
 
         Assert.That(walk().Select(f => f.Name), Is.EqualTo(new[] { "FallbackOne" }));
     }
+
+    /// <summary>
+    /// The priority inversion this whole mechanism exists to fix: the framework registers its own
+    /// families during <see cref="RendererFontStore.LoadDefaultFont"/>, which runs before any
+    /// application code, so with one ordered list an application could never reach its own font for a
+    /// script the framework already covers.
+    /// </summary>
+    [Test]
+    public void AnApplicationClaimOutranksTheFrameworkFamilyForTheSameScript()
+    {
+        store.LoadDefaultFont(frameworkFonts());
+        store.AddFallbackFamily("FallbackOne", FontScript.Japanese);
+
+        Assert.That(firstFallbackFor(FontScript.Japanese), Is.EqualTo("FallbackOne"));
+    }
+
+    /// <summary>
+    /// A claim is scoped to its script: it must not become the answer for every script the family
+    /// happens to cover, which is what inserting it at the front of a single list would do.
+    /// </summary>
+    [Test]
+    public void AClaimDoesNotApplyToOtherScripts()
+    {
+        store.AddFallbackFamily("FallbackOne", FontScript.Thai);
+        store.AddFallbackFamily("FallbackTwo");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(firstFallbackFor(FontScript.Thai), Is.EqualTo("FallbackOne"));
+            Assert.That(firstFallbackFor(FontScript.Latin), Is.EqualTo("FallbackTwo"));
+        }
+    }
+
+    /// <summary>
+    /// An application shipping one CJK family should not have to claim ideographs separately: kana and
+    /// kanji sit in the same sentence and must be drawn by the same font.
+    /// </summary>
+    [Test]
+    public void IdeographsDrawOnTheApplicationsCjkClaim()
+    {
+        store.AddFallbackFamily("FallbackOne", FontScript.Japanese);
+        store.AddFallbackFamily("FallbackTwo");
+
+        Assert.That(firstFallbackFor(FontScript.Han), Is.EqualTo("FallbackOne"));
+    }
+
+    /// <summary>
+    /// With no application claim to go on, ideographs follow the configured language.
+    /// </summary>
+    [Test]
+    public void HanScriptDecidesWhichFrameworkFamilyDrawsIdeographs()
+    {
+        store.LoadDefaultFont(frameworkFonts());
+
+        store.HanScript = FontScript.Japanese;
+        string? japanese = firstFallbackFor(FontScript.Han);
+
+        store.HanScript = FontScript.Korean;
+        string? korean = firstFallbackFor(FontScript.Han);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(japanese, Does.StartWith("NotoSansJP"));
+            Assert.That(korean, Does.StartWith("NotoSansKR"), "changing the preference must invalidate the resolved chain");
+        }
+    }
+
+    /// <summary>
+    /// Auto derives claims from what the font covers, so a family that cannot draw a script never leads
+    /// that script's chain.
+    /// </summary>
+    [Test]
+    public void AutoClaimsOnlyScriptsTheFontCovers()
+    {
+        // Comfortaa covers Latin, Cyrillic and Greek, and nothing else.
+        store.AddFallbackFamily("FallbackOne", FontScript.Auto);
+        store.AddFallbackFamily("FallbackTwo");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(firstFallbackFor(FontScript.Cyrillic), Is.EqualTo("FallbackOne"));
+            Assert.That(firstFallbackFor(FontScript.Thai), Is.EqualTo("FallbackTwo"));
+        }
+    }
+
+    /// <summary>
+    /// Latin is deliberately excluded from what Auto claims. Nearly every font covers it, so claiming it
+    /// would let a font registered for its Japanese or Thai coverage supply Latin glyphs to labels that
+    /// asked for a different family — the over-claiming the script tiers exist to prevent.
+    /// </summary>
+    [Test]
+    public void AutoNeverClaimsLatin()
+    {
+        store.AddFallbackFamily("FallbackOne", FontScript.Auto);
+        store.AddFallbackFamily("FallbackTwo");
+
+        Assert.That(firstFallbackFor(FontScript.Latin), Is.EqualTo("FallbackTwo"));
+    }
+
+    /// <summary>
+    /// An explicit claim is not overwritten by a derived one, so two auto-registered families resolve in
+    /// registration order rather than fighting.
+    /// </summary>
+    [Test]
+    public void AnExplicitClaimBeatsADerivedOne()
+    {
+        store.AddFallbackFamily("FallbackTwo", FontScript.Cyrillic);
+        store.AddFallbackFamily("FallbackOne", FontScript.Auto);
+
+        Assert.That(firstFallbackFor(FontScript.Cyrillic), Is.EqualTo("FallbackTwo"));
+    }
+
+    /// <summary>
+    /// Scripts nobody claimed still resolve through every registered family, so an unclaimed script
+    /// renders in a wrong-but-present font rather than as missing glyphs.
+    /// </summary>
+    [Test]
+    public void AnUnclaimedScriptStillReachesEveryFamily()
+    {
+        store.AddFallbackFamily("FallbackOne", FontScript.Thai);
+        store.AddFallbackFamily("FallbackTwo", FontScript.Hebrew);
+
+        Assert.That(store.GetFallbacks(FontUsage.Default, FontScript.Arabic).Select(f => f.Name),
+            Is.EquivalentTo(new[] { "FallbackOne", "FallbackTwo" }));
+    }
+
+    /// <summary>
+    /// The chain is asked for on every layout, so a claim must not cost a font load until something
+    /// actually walks it.
+    /// </summary>
+    [Test]
+    public void AskingForAScriptChainLoadsNothing()
+    {
+        store.AddFallbackFamily("FallbackOne", FontScript.Thai);
+
+        int before = loadedFonts;
+
+        store.GetFallbacks(FontUsage.Default, FontScript.Thai);
+
+        Assert.That(loadedFonts, Is.EqualTo(before));
+    }
+
+    /// <summary>
+    /// The name of the first font a script's chain resolves to. Enumerated lazily so the assertion does
+    /// not load the rest of the chain.
+    /// </summary>
+    private string? firstFallbackFor(FontScript script)
+        => store.GetFallbacks(FontUsage.Default, script).Select(f => f.Name).FirstOrDefault();
+
+    private static Storage frameworkFonts()
+        => new EmbeddedResourceStorage(typeof(RendererFontStore).Assembly, "Sakura.Framework.Resources").GetStorageForDirectory("Fonts");
 
     private List<Font> walk() => store.GetFallbacks(FontUsage.Default).ToList();
 }

--- a/Sakura.Framework.Tests/Text/FontScriptTest.cs
+++ b/Sakura.Framework.Tests/Text/FontScriptTest.cs
@@ -1,0 +1,104 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Text;
+
+namespace Sakura.Framework.Tests.Text;
+
+/// <summary>
+/// Tests for <see cref="FontScripts.FromCodepoint"/> the classification the fallback chain is
+/// selected by, and which run segmentation is broken on.
+/// </summary>
+[TestFixture]
+public class FontScriptTest
+{
+    [TestCase('A', FontScript.Latin)]
+    [TestCase('z', FontScript.Latin)]
+    [TestCase('А', FontScript.Cyrillic)] // U+0410
+    [TestCase('α', FontScript.Greek)]
+    [TestCase('あ', FontScript.Japanese)]
+    [TestCase('カ', FontScript.Japanese)]
+    [TestCase('한', FontScript.Korean)]
+    [TestCase('漢', FontScript.Han)]
+    [TestCase('ก', FontScript.Thai)]
+    [TestCase('ا', FontScript.Arabic)]
+    [TestCase('א', FontScript.Hebrew)]
+    [TestCase('अ', FontScript.Devanagari)]
+    public void ScriptIsClassifiedFromTheCodepoint(char codepoint, FontScript expected)
+        => Assert.That(FontScripts.FromCodepoint(codepoint), Is.EqualTo(expected));
+
+    /// <summary>
+    /// Characters Unicode attributes to no script of their own continue the run they appear in, so the
+    /// comma in a Japanese sentence is drawn by the Japanese font rather than sending the run back to
+    /// the primary font (and splitting it in two while doing so)
+    /// </summary>
+    [TestCase('、', FontScript.Japanese)]
+    [TestCase(' ', FontScript.Japanese)]
+    [TestCase('1', FontScript.Japanese)]
+    [TestCase('.', FontScript.Japanese)]
+    public void ScriptLessCharactersContinueTheRun(char codepoint, FontScript expected)
+        => Assert.That(FontScripts.FromCodepoint(codepoint, FontScript.Japanese), Is.EqualTo(expected));
+
+    /// <summary>
+    /// Emoji are pictographs regardless of the surrounding text. Unicode calls most of them
+    /// <c>Common</c>, so classifying them by script property alone would hand them to whichever font is
+    /// drawing the surrounding words.
+    /// </summary>
+    [TestCase(0x1F600u)] // grinning face
+    [TestCase(0x1F1EFu)] // regional indicator J
+    [TestCase(0x2764u)] // heavy black heart
+    [TestCase(0x2B50u)] // white medium star
+    public void EmojiAreClassifiedAsEmojiInsideTextOfAnotherScript(uint codepoint)
+        => Assert.That(FontScripts.FromCodepoint(codepoint, FontScript.Japanese), Is.EqualTo(FontScript.Emoji));
+
+    /// <summary>
+    /// Characters that live near the emoji blocks but read as text belong to the text font.
+    /// </summary>
+    [TestCase('©')]
+    [TestCase('®')]
+    [TestCase('™')]
+    public void TextSymbolsAreNotEmoji(char codepoint)
+        => Assert.That(FontScripts.FromCodepoint(codepoint, FontScript.Latin), Is.Not.EqualTo(FontScript.Emoji));
+
+    /// <summary>
+    /// A space after an emoji belongs with the text that follows, not with the emoji font.
+    /// </summary>
+    [Test]
+    public void AnEmojiRunIsNotContinued()
+        => Assert.That(FontScripts.FromCodepoint(' ', FontScript.Emoji), Is.EqualTo(FontScript.Any));
+
+    /// <summary>
+    /// The one thing a codepoint cannot settle: which language's forms an ideograph should be drawn in.
+    /// </summary>
+    [Test]
+    public void ALanguageHintResolvesIdeographs()
+        => Assert.That(FontScripts.FromCodepoint('漢', FontScript.Any, FontScript.Japanese), Is.EqualTo(FontScript.Japanese));
+
+    /// <summary>
+    /// Everything else is settled by the codepoint, so a hint must not be able to relabel it — a
+    /// mislabeled string would otherwise render in the wrong language's font entirely.
+    /// </summary>
+    [Test]
+    public void ALanguageHintDoesNotOverrideAnUnambiguousScript()
+        => Assert.That(FontScripts.FromCodepoint('ก', FontScript.Any, FontScript.Japanese), Is.EqualTo(FontScript.Thai));
+
+    /// <summary>
+    /// Kana and kanji alternate constantly in Japanese text, and one font normally serves both, so they
+    /// must not break the run into one per character class. A complex script must, since a run is shaped
+    /// with properties guessed from its contents and Thai marks shaped as Latin sit in the wrong place.
+    /// </summary>
+    [Test]
+    public void ShapingRunsAreSharedWithinAScriptGroupOnly()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FontScripts.ShareShapingRun(FontScript.Japanese, FontScript.Han), Is.True);
+            Assert.That(FontScripts.ShareShapingRun(FontScript.Latin, FontScript.Cyrillic), Is.True);
+            Assert.That(FontScripts.ShareShapingRun(FontScript.Latin, FontScript.Any), Is.True);
+            Assert.That(FontScripts.ShareShapingRun(FontScript.Latin, FontScript.Thai), Is.False);
+            Assert.That(FontScripts.ShareShapingRun(FontScript.Thai, FontScript.Arabic), Is.False);
+            Assert.That(FontScripts.ShareShapingRun(FontScript.Latin, FontScript.Emoji), Is.False);
+        }
+    }
+}

--- a/Sakura.Framework.Tests/Text/IdeographFontSelectionTest.cs
+++ b/Sakura.Framework.Tests/Text/IdeographFontSelectionTest.cs
@@ -1,0 +1,107 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Graphics.Rendering;
+using Sakura.Framework.Graphics.Text;
+using Sakura.Framework.Graphics.Textures;
+using Sakura.Framework.Logging;
+using Sakura.Framework.Platform;
+using Sakura.Framework.Statistic;
+
+namespace Sakura.Framework.Tests.Text;
+
+/// <summary>
+/// Unified CJK ideographs are the one script resolved per word rather than per codepoint, because the
+/// chain for them is ordered by an assumed language: resolving each character on its own draws a word
+/// half in one language's font and half in another's wherever their coverage differs.
+/// </summary>
+[TestFixture]
+public class IdeographFontSelectionTest
+{
+    /// <summary>
+    /// 好 is in both bundled CJK families; 东 is simplified-only, so NotoSansJP cannot draw it.
+    /// </summary>
+    private const string mixed_coverage_word = "好东";
+
+    private static long shapedRuns => GlobalStatistics.Get<long>("Fonts", "Shaped Runs").Value;
+
+    private HeadlessTextureManager textureManager = null!;
+    private RendererFontStore store = null!;
+
+    [OneTimeSetUp]
+    public void InitializeLogger() => Logger.Initialize();
+
+    [OneTimeTearDown]
+    public void ShutdownLogger() => Logger.Shutdown();
+
+    [SetUp]
+    public void SetUp()
+    {
+        textureManager = new HeadlessTextureManager();
+        store = new RendererFontStore(new HeadlessRenderer(textureManager));
+
+        store.LoadDefaultFont(new EmbeddedResourceStorage(typeof(RendererFontStore).Assembly, "Sakura.Framework.Resources")
+            .GetStorageForDirectory("Fonts"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        store.Dispose();
+        textureManager.Dispose();
+    }
+
+    /// <summary>
+    /// One font for the whole word, even though the preferred one covers only part of it.
+    /// </summary>
+    [Test]
+    public void AWordOfIdeographsIsDrawnByOneFont()
+    {
+        long before = shapedRuns;
+
+        store.Shape(new FontUsage("NotoSansJP", 16), mixed_coverage_word, 1f);
+
+        Assert.That(shapedRuns - before, Is.EqualTo(1), "a word split across two fonts would shape as two runs");
+    }
+
+    /// <summary>
+    /// And it is the font covering the whole word that wins, not the one asked for — a character the
+    /// requested font can draw still moves, so the word does not change face halfway through.
+    /// </summary>
+    [Test]
+    public void TheCoveringFontWinsOverThePreferredOne()
+    {
+        var usage = new FontUsage("NotoSansJP", 16);
+
+        // 好 on its own is drawn by the requested font, which covers it.
+        var alone = store.Shape(usage, "好", 1f);
+        // In the word it must come from the family that also covers 东, so both characters match.
+        var inWord = store.Shape(usage, mixed_coverage_word, 1f);
+
+        Assert.That(alone.Glyphs, Is.Not.Empty);
+        Assert.That(inWord.Glyphs, Has.Count.EqualTo(2));
+
+        // Glyphs are cached per font, so a different texture instance means a different font drew it.
+        Assert.That(inWord.Glyphs[0].Texture, Is.Not.SameAs(alone.Glyphs[0].Texture));
+    }
+
+    /// <summary>
+    /// With nothing to disambiguate them, ideographs follow the configured language.
+    /// </summary>
+    [Test]
+    public void ACoveredWordStaysWithTheLanguagesFont()
+    {
+        var usage = new FontUsage("NotoSans", 16);
+
+        store.HanScript = FontScript.Japanese;
+        var japanese = store.Shape(usage, "好", 1f);
+
+        store.HanScript = FontScript.ChineseSimplified;
+        var chinese = store.Shape(usage, "好", 1f);
+
+        Assert.That(japanese.Glyphs, Is.Not.Empty);
+        Assert.That(chinese.Glyphs, Is.Not.Empty);
+        Assert.That(chinese.Glyphs[0].Texture, Is.Not.SameAs(japanese.Glyphs[0].Texture));
+    }
+}

--- a/Sakura.Framework/Graphics/Text/Font.cs
+++ b/Sakura.Framework/Graphics/Text/Font.cs
@@ -266,7 +266,125 @@ public class Font : IDisposable
     /// </summary>
     private readonly INativeBytes fontData;
 
-    public ShapedText ProcessText(string text, float fontSize, float dpiScale = 1.0f, IEnumerable<Font>? fallbacks = null, FontVariation variation = default)
+    /// <summary>
+    /// The script of every code unit in <paramref name="text"/>, with both halves of a surrogate pair
+    /// carrying the same value so the array can be indexed by string position.
+    /// </summary>
+    private static FontScript[] classifyScripts(string text, FontScript? languageHint)
+    {
+        var scripts = new FontScript[text.Length];
+        var current = FontScript.Any;
+
+        int i = 0;
+
+        while (i < text.Length)
+        {
+            int charLen;
+            uint codepoint;
+
+            if (char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+            {
+                codepoint = (uint)char.ConvertToUtf32(text[i], text[i + 1]);
+                charLen = 2;
+            }
+            else
+            {
+                codepoint = text[i];
+                charLen = 1;
+            }
+
+            current = FontScripts.FromCodepoint(codepoint, current, languageHint);
+
+            for (int n = 0; n < charLen; n++)
+                scripts[i + n] = current;
+
+            i += charLen;
+        }
+
+        return scripts;
+    }
+
+    /// <summary>
+    /// Picks one font for the whole stretch of unified ideographs starting at <paramref name="start"/>,
+    /// or null if no single font covers all of it.
+    /// </summary>
+    /// <remarks>
+    /// the fallback chain for them is ordered by an assumed language (see
+    /// <see cref="IFontStore.HanScript"/>), so a word whose characters are unevenly covered would be drawn half
+    /// in one language's font and half in another's e.g. 你好 with a Japanese font ahead of a Chinese one
+    /// puts 你 in the Chinese face and 好 in the Japanese one. Preferring a font that covers the whole
+    /// stretch keeps a word in one face and makes the chain order decide the language rather than the
+    /// coverage gaps. Other scripts keep resolving per codepoint, where one missing character must not
+    /// drag its neighbors into another font.
+    /// </remarks>
+    private Font? chooseIdeographFont(string text, FontScript[] scripts, int start, IFontFallbackSource? fallbacks)
+    {
+        int end = start;
+
+        while (end < text.Length && scripts[end] == FontScript.Han)
+            end++;
+
+        if (covers(this, text, start, end))
+            return this;
+
+        if (fallbacks == null)
+            return null;
+
+        foreach (var fallback in fallbacks.GetFallbacks(FontScript.Han))
+        {
+            if (covers(fallback, text, start, end))
+                return fallback;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="font"/> has a glyph for every codepoint in <c>[start, end)</c>.
+    /// </summary>
+    private static bool covers(Font font, string text, int start, int end)
+    {
+        int i = start;
+
+        while (i < end)
+        {
+            uint codepoint;
+            int charLen;
+
+            if (char.IsHighSurrogate(text[i]) && i + 1 < end && char.IsLowSurrogate(text[i + 1]))
+            {
+                codepoint = (uint)char.ConvertToUtf32(text[i], text[i + 1]);
+                charLen = 2;
+            }
+            else
+            {
+                codepoint = text[i];
+                charLen = 1;
+            }
+
+            if (!font.HasGlyph(codepoint))
+                return false;
+
+            i += charLen;
+        }
+
+        return true;
+    }
+
+    /// <param name="text">The text to shape.</param>
+    /// <param name="fontSize">The logical font size.</param>
+    /// <param name="dpiScale">Physical pixels per logical pixel.</param>
+    /// <param name="fallbacks">
+    /// Where to look for glyphs this font is missing. Consulted per script, so a family claimed for
+    /// one writing system is not pulled into another.
+    /// </param>
+    /// <param name="variation">Variable-font axis coordinates to render at.</param>
+    /// <param name="languageHint">
+    /// The language the text is known to be in, when the caller knows it. Only affects unified CJK
+    /// ideographs, which no codepoint can attribute to a language on its own.
+    /// </param>
+    public ShapedText ProcessText(string text, float fontSize, float dpiScale = 1.0f, IFontFallbackSource? fallbacks = null, FontVariation variation = default,
+                                  FontScript? languageHint = null)
     {
         if (string.IsNullOrEmpty(text))
             return ShapedText.Empty;
@@ -275,7 +393,7 @@ public class Font : IDisposable
 
         // Determine base vertical metrics from the PRIMARY font so line height stays consistent
         float ascenderPx = 0;
-        float lineHeightPx = Size;
+        float lineHeightPx;
 
         lock (stateLock)
         {
@@ -300,6 +418,16 @@ public class Font : IDisposable
         int currentRunStart = 0;
         Font? currentFont = null;
 
+        // The script of each code unit, resolved up front so a stretch of ideographs can be looked at as
+        // a whole before a font is picked for it (see chooseIdeographFont).
+        var scripts = classifyScripts(text, languageHint);
+
+        var currentRunScript = FontScript.Any;
+
+        // The font chosen for the stretch of ideographs currently being walked, if one font covers all
+        // of it. Null outside such a stretch, and inside one no single font can cover.
+        Font? ideographFont = null;
+
         int i = 0;
         while (i < text.Length)
         {
@@ -319,13 +447,25 @@ public class Font : IDisposable
                 charLen = 1;
             }
 
-            // Find which font supports this codepoint
+            var runScript = scripts[i];
+
+            if (runScript == FontScript.Han)
+            {
+                if (i == 0 || scripts[i - 1] != FontScript.Han)
+                    ideographFont = chooseIdeographFont(text, scripts, i, fallbacks);
+            }
+            else
+                ideographFont = null;
+
+            // Find which font supports this codepoint, preferring the families claimed for its script
             Font assignedFont = this;
-            if (!HasGlyph(codepoint))
+            if (ideographFont != null && ideographFont.HasGlyph(codepoint))
+                assignedFont = ideographFont;
+            else if (!HasGlyph(codepoint))
             {
                 if (fallbacks != null)
                 {
-                    foreach (var fallback in fallbacks)
+                    foreach (var fallback in fallbacks.GetFallbacks(runScript))
                     {
                         if (fallback.HasGlyph(codepoint))
                         {
@@ -336,17 +476,21 @@ public class Font : IDisposable
                 }
             }
 
-            // If the font changed, process the previous run
-            if (currentFont != assignedFont)
+            // Break the run when the font changes, or when the script changes to one that cannot be
+            // shaped with the same properties even though the same font serves it (a Thai mark shaped
+            // as Latin would be positioned wrongly).
+            if (currentFont != assignedFont || !FontScripts.ShareShapingRun(currentRunScript, runScript))
             {
-                if (currentFont != null)
+                if (currentFont != null && currentRunStart < i)
                 {
                     string runText = text.Substring(currentRunStart, i - currentRunStart);
                     var runGlyphs = currentFont.shapeRun(runText, renderFontSize, dpiScale, ascenderPx, variation, currentRunStart, ref cursorX);
                     glyphs.AddRange(runGlyphs);
+                    currentRunStart = i;
                 }
+
                 currentFont = assignedFont;
-                currentRunStart = i;
+                currentRunScript = runScript;
             }
 
             i += charLen;

--- a/Sakura.Framework/Graphics/Text/FontScript.cs
+++ b/Sakura.Framework/Graphics/Text/FontScript.cs
@@ -1,0 +1,292 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Collections.Generic;
+
+namespace Sakura.Framework.Graphics.Text;
+
+/// <summary>
+/// A writing system a font family can be registered for, so the fallback chain can prefer a
+/// different family per script rather than "whichever registered font happens to have the glyph".
+/// </summary>
+/// <remarks>
+/// Registering a family for a script is a "claim", not a restriction. It only affects the order
+/// of the fallback chain walked for glyphs the primary font is missing. A family remains usable as a
+/// primary font for any text, so a family claimed for <see cref="Japanese"/> still renders Latin when
+/// a <see cref="FontUsage"/> asks for it by name.
+/// </remarks>
+public enum FontScript
+{
+    /// <summary>
+    /// Not script-specific. As a claim, the family applies to every script (after any claim made for
+    /// the specific script being resolved); as a classification, the script could not be determined.
+    /// </summary>
+    Any,
+
+    Latin,
+    Cyrillic,
+    Greek,
+
+    /// <summary>
+    /// Unified CJK ideographs, whose language cannot be determined from the codepoint alone — 漢 is
+    /// the same character in Japanese, Korean and both Chinese variants while being drawn differently
+    /// in each. Resolved through the app's CJK claims and <see cref="IFontStore.HanScript"/>; a single
+    /// label can override it with <see cref="FontUsage.Script"/>.
+    /// </summary>
+    Han,
+
+    /// <summary>
+    /// Hiragana and katakana. Kanji in the same text classify as <see cref="Han"/>, so a family
+    /// claiming <see cref="Japanese"/> is also consulted for <see cref="Han"/>.
+    /// </summary>
+    Japanese,
+
+    /// <summary>
+    /// Hangul.
+    /// </summary>
+    Korean,
+
+    ChineseSimplified,
+    ChineseTraditional,
+    Thai,
+    Arabic,
+    Hebrew,
+    Devanagari,
+
+    /// <summary>
+    /// Pictographs and emoji. Classified from codepoint ranges rather than the Unicode script
+    /// property, which reports most emoji as <c>Common</c>.
+    /// </summary>
+    Emoji,
+
+    /// <summary>
+    /// Registration-time sentinel: claim every non-Latin script the family actually covers that no
+    /// earlier claim has taken. Only meaningful as an argument to
+    /// <see cref="IFontStore.AddFontFamily"/> / <see cref="IFontStore.AddFallbackFamily"/>; never
+    /// returned by classification, and treated as <see cref="Any"/> if it reaches a chain lookup.
+    /// </summary>
+    Auto
+}
+
+/// <summary>
+/// Classification of codepoints into <see cref="FontScript"/>, and the script relationships the
+/// fallback chain and run segmentation are built on.
+/// </summary>
+public static class FontScripts
+{
+    /// <summary>
+    /// The CJK scripts, in the order the framework's own families were historically registered.
+    /// A claim for any of these is consulted when resolving <see cref="FontScript.Han"/>.
+    /// </summary>
+    public static readonly FontScript[] CJK_SCRIPTS =
+    {
+        FontScript.Han,
+        FontScript.ChineseSimplified,
+        FontScript.ChineseTraditional,
+        FontScript.Japanese,
+        FontScript.Korean
+    };
+
+    /// <summary>
+    /// One codepoint that any family genuinely covering the script must have. Used to verify a claim
+    /// (and to derive claims for <see cref="FontScript.Auto"/>) with a single <c>FT_Get_Char_Index</c>
+    /// rather than by walking the whole character map.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="FontScript.Any"/> and <see cref="FontScript.Emoji"/> are deliberately absent: the
+    /// former makes no coverage promise, and emoji coverage is too fragmented across fonts for one
+    /// codepoint to stand in for it.
+    /// </remarks>
+    private static readonly (FontScript Script, uint Probe)[] script_probes =
+    {
+        (FontScript.Latin, 'A'),
+        (FontScript.Cyrillic, 'А'), // U+0410 CYRILLIC CAPITAL LETTER A
+        (FontScript.Greek, 'α'),
+        (FontScript.Han, '漢'),
+        (FontScript.ChineseSimplified, '汉'),
+        (FontScript.ChineseTraditional, '漢'),
+        (FontScript.Japanese, 'あ'),
+        (FontScript.Korean, '한'),
+        (FontScript.Thai, 'ก'),
+        (FontScript.Arabic, 'ا'),
+        (FontScript.Hebrew, 'א'),
+        (FontScript.Devanagari, 'अ')
+    };
+
+    /// <summary>
+    /// The scripts <see cref="FontScript.Auto"/> considers, in claim order. Latin is excluded on
+    /// purpose: nearly every font covers it, so auto-claiming it would let a Japanese or Thai family
+    /// supply Latin glyphs for a label that asked for another family, which is the over-claiming this
+    /// whole mechanism exists to avoid.
+    /// </summary>
+    private static readonly FontScript[] auto_claimable =
+    {
+        FontScript.Japanese,
+        FontScript.Korean,
+        FontScript.Han,
+        FontScript.Thai,
+        FontScript.Arabic,
+        FontScript.Hebrew,
+        FontScript.Devanagari,
+        FontScript.Cyrillic,
+        FontScript.Greek
+    };
+
+    public static IReadOnlyList<FontScript> AutoClaimable => auto_claimable;
+
+    /// <summary>
+    /// Maps the Unicode script property (as HarfBuzz reports it) onto the scripts the fallback chain
+    /// distinguishes. Anything absent resolves to <see cref="FontScript.Any"/> and is served by the
+    /// generic tail of the chain.
+    /// </summary>
+    private static readonly Dictionary<uint, FontScript> script_map = new Dictionary<uint, FontScript>
+    {
+        [HarfBuzzSharp.Script.Latin] = FontScript.Latin,
+        [HarfBuzzSharp.Script.Cyrillic] = FontScript.Cyrillic,
+        [HarfBuzzSharp.Script.Greek] = FontScript.Greek,
+        [HarfBuzzSharp.Script.Han] = FontScript.Han,
+        [HarfBuzzSharp.Script.Hiragana] = FontScript.Japanese,
+        [HarfBuzzSharp.Script.Katakana] = FontScript.Japanese,
+        [HarfBuzzSharp.Script.Hangul] = FontScript.Korean,
+        [HarfBuzzSharp.Script.Bopomofo] = FontScript.ChineseTraditional,
+        [HarfBuzzSharp.Script.Thai] = FontScript.Thai,
+        [HarfBuzzSharp.Script.Arabic] = FontScript.Arabic,
+        [HarfBuzzSharp.Script.Hebrew] = FontScript.Hebrew,
+        [HarfBuzzSharp.Script.Devanagari] = FontScript.Devanagari
+    };
+
+    /// <summary>
+    /// The probe codepoint for <paramref name="script"/>, or 0 when the script makes no coverage
+    /// promise a single codepoint can verify.
+    /// </summary>
+    public static uint ProbeFor(FontScript script)
+    {
+        foreach ((var candidate, uint probe) in script_probes)
+        {
+            if (candidate == script)
+                return probe;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Classifies <paramref name="codepoint"/> for font selection.
+    /// </summary>
+    /// <param name="codepoint">The codepoint to classify.</param>
+    /// <param name="current">
+    /// The script of the text preceding it. Characters the Unicode script property calls
+    /// <c>Common</c> or <c>Inherited</c> — spaces, digits, ASCII punctuation, 、, combining marks,
+    /// emoji variation selectors — carry no script of their own and continue this one, so a comma in
+    /// a Japanese sentence stays with the Japanese font instead of bouncing back to the primary.
+    /// </param>
+    /// <param name="languageHint">
+    /// The language the text is known to be in, when the caller knows (<see cref="FontUsage.Script"/>).
+    /// Only consulted for <see cref="FontScript.Han"/>, the one case a codepoint cannot settle.
+    /// </param>
+    public static FontScript FromCodepoint(uint codepoint, FontScript current = FontScript.Any, FontScript? languageHint = null)
+    {
+        var script = classify(codepoint, current);
+
+        // A hint only disambiguates the ambiguous case. Letting it override kana or Hangul would let
+        // a mislabelled string render in the wrong language's font, which is worse than ignoring it.
+        if (script == FontScript.Han && languageHint.HasValue && IsCJK(languageHint.Value))
+            return languageHint.Value;
+
+        return script;
+    }
+
+    private static FontScript classify(uint codepoint, FontScript current)
+    {
+        // ASCII is the overwhelming majority of what gets shaped, and it needs no native call:
+        // letters are Latin, everything else (digits, punctuation, whitespace) continues the run.
+        if (codepoint < 0x80)
+        {
+            if ((codepoint >= 'A' && codepoint <= 'Z') || (codepoint >= 'a' && codepoint <= 'z'))
+                return FontScript.Latin;
+
+            return inherit(current);
+        }
+
+        // Checked before the script property, which reports most emoji as Common and would therefore
+        // hand them to whichever font the surrounding text uses.
+        if (isEmoji(codepoint))
+            return FontScript.Emoji;
+
+        uint unicodeScript = HarfBuzzSharp.UnicodeFunctions.Default.GetScript(codepoint);
+
+        if (script_map.TryGetValue(unicodeScript, out var mapped))
+            return mapped;
+
+        // Common / Inherited / Unknown, plus every script the chain does not distinguish.
+        if (unicodeScript == HarfBuzzSharp.Script.Common || unicodeScript == HarfBuzzSharp.Script.Inherited)
+            return inherit(current);
+
+        return FontScript.Any;
+    }
+
+    /// <summary>
+    /// Continues the preceding run's script. An emoji run is not continued: the following space or
+    /// digit belongs with the text around it, not with the emoji font.
+    /// </summary>
+    private static FontScript inherit(FontScript current) => current == FontScript.Emoji ? FontScript.Any : current;
+
+    /// <summary>
+    /// Whether <paramref name="codepoint"/> is a pictograph. Covers the emoji blocks proper plus the
+    /// older symbol/dingbat ranges emoji presentation reaches into. Deliberately excludes the
+    /// text-first characters that live in those ranges' neighbourhood (©, ®, ™, ASCII digits used in
+    /// keycaps), which read better in the text font.
+    /// </summary>
+    private static bool isEmoji(uint codepoint)
+        => codepoint is >= 0x1F000 and <= 0x1FAFF // Mahjong/dominoes/cards through Symbols Extended-A
+            or >= 0x2600 and <= 0x27BF // Miscellaneous Symbols + Dingbats
+            or >= 0x2B00 and <= 0x2BFF; // Miscellaneous Symbols and Arrows (★, ⭐)
+
+    public static bool IsCJK(FontScript script)
+    {
+        foreach (var cjk in CJK_SCRIPTS)
+        {
+            if (cjk == script)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether two scripts can share one HarfBuzz shaping run when the same font serves both.
+    /// </summary>
+    /// <remarks>
+    /// A run is shaped with properties guessed from its contents, so a run must not mix a complex
+    /// script with anything else — Thai marks shaped as Latin position wrongly. Within a group the
+    /// distinction does not affect shaping, which keeps Japanese text (constantly alternating kana and
+    /// kanji) at one run per font instead of one per character class.
+    /// </remarks>
+    public static bool ShareShapingRun(FontScript a, FontScript b) => a == b || shapingGroup(a) == shapingGroup(b);
+
+    /// <summary>
+    /// 0 = simple LTR alphabetic, 1 = CJK, and one group per script needing its own shaping
+    /// properties.
+    /// </summary>
+    private static int shapingGroup(FontScript script)
+    {
+        switch (script)
+        {
+            case FontScript.Any:
+            case FontScript.Latin:
+            case FontScript.Cyrillic:
+            case FontScript.Greek:
+                return 0;
+
+            case FontScript.Han:
+            case FontScript.Japanese:
+            case FontScript.Korean:
+            case FontScript.ChineseSimplified:
+            case FontScript.ChineseTraditional:
+                return 1;
+
+            default:
+                return 2 + (int)script;
+        }
+    }
+}

--- a/Sakura.Framework/Graphics/Text/FontUsage.cs
+++ b/Sakura.Framework/Graphics/Text/FontUsage.cs
@@ -39,6 +39,18 @@ public readonly struct FontUsage : IEquatable<FontUsage>
     public float? OpticalSize { get; }
 
     /// <summary>
+    /// The language this text is known to be in, when the caller knows it. Only affects unified CJK
+    /// ideographs, the one case a codepoint cannot attribute to a language on its own: a label set to
+    /// <see cref="FontScript.Japanese"/> renders 漢 with the Japanese family even on a machine whose
+    /// <see cref="IFontStore.HanScript"/> says otherwise. Null leaves resolution to the store.
+    /// </summary>
+    /// <remarks>
+    /// This is a hint about the text, not a font selection. Every other script is settled by the
+    /// codepoint, so setting this does nothing for them.
+    /// </remarks>
+    public FontScript? Script { get; }
+
+    /// <summary>
     /// Gets the default font usage (NotoSans-Regular, 24px).
     /// </summary>
     public static FontUsage Default => new FontUsage("NotoSans", weight: FontWeights.Regular);
@@ -50,7 +62,7 @@ public readonly struct FontUsage : IEquatable<FontUsage>
     /// constructor without overload ambiguity.
     /// </summary>
     public FontUsage(string family = DEFAULT_FONT_FAMILY, float size = DEFAULT_FONT_SIZE, FontWeight weight = default, bool italics = false,
-                     float? fill = null, float? grade = null, float? opticalSize = null)
+                     float? fill = null, float? grade = null, float? opticalSize = null, FontScript? script = null)
     {
         Family = family;
         Size = size;
@@ -59,10 +71,11 @@ public readonly struct FontUsage : IEquatable<FontUsage>
         Fill = fill;
         Grade = grade;
         OpticalSize = opticalSize;
+        Script = script;
     }
 
     public FontUsage With(string? family = null, float? size = null, FontWeight? weight = null, bool? italics = null,
-                          float? fill = null, float? grade = null, float? opticalSize = null)
+                          float? fill = null, float? grade = null, float? opticalSize = null, FontScript? script = null)
     {
         return new FontUsage(
             family ?? Family,
@@ -71,7 +84,8 @@ public readonly struct FontUsage : IEquatable<FontUsage>
             italics ?? Italics,
             fill ?? Fill,
             grade ?? Grade,
-            opticalSize ?? OpticalSize
+            opticalSize ?? OpticalSize,
+            script ?? Script
         );
     }
 
@@ -106,6 +120,7 @@ public readonly struct FontUsage : IEquatable<FontUsage>
         if (Fill.HasValue) s += $", Fill: {Fill}";
         if (Grade.HasValue) s += $", Grade: {Grade}";
         if (OpticalSize.HasValue) s += $", opsz: {OpticalSize}";
+        if (Script.HasValue) s += $", Script: {Script}";
         return s + ")";
     }
 
@@ -117,12 +132,13 @@ public readonly struct FontUsage : IEquatable<FontUsage>
                Italics == other.Italics &&
                Nullable.Equals(Fill, other.Fill) &&
                Nullable.Equals(Grade, other.Grade) &&
-               Nullable.Equals(OpticalSize, other.OpticalSize);
+               Nullable.Equals(OpticalSize, other.OpticalSize) &&
+               Nullable.Equals(Script, other.Script);
     }
 
     public override bool Equals(object? obj) => obj is FontUsage other && Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(Family, Size, Weight, Italics, Fill, Grade, OpticalSize);
+    public override int GetHashCode() => HashCode.Combine(Family, Size, Weight, Italics, Fill, Grade, OpticalSize, Script);
 
     public static bool operator ==(FontUsage left, FontUsage right) => left.Equals(right);
 

--- a/Sakura.Framework/Graphics/Text/HeadlessFontStore.cs
+++ b/Sakura.Framework/Graphics/Text/HeadlessFontStore.cs
@@ -31,12 +31,22 @@ public class HeadlessFontStore : IFontStore
 
     }
 
-    public void AddFontFamily(Storage storage, string family, bool hasItalics = false)
+    public void AddFontFamily(Storage storage, string family, bool hasItalics = false, FontScript? script = null)
     {
 
     }
 
     public void AddFallbackFamily(string familyName)
+    {
+
+    }
+
+    public void AddFallbackFamily(string familyName, FontScript script)
+    {
+
+    }
+
+    public void SetScriptFamily(FontScript script, string familyName)
     {
 
     }
@@ -51,9 +61,29 @@ public class HeadlessFontStore : IFontStore
 
     }
 
+    public FontScript HanScript { get; set; } = FontScript.ChineseSimplified;
+
     public IEnumerable<Font> GetFallbacks(FontUsage usage)
     {
         return Array.Empty<Font>();
+    }
+
+    public IEnumerable<Font> GetFallbacks(FontUsage usage, FontScript script)
+    {
+        return Array.Empty<Font>();
+    }
+
+    public IFontFallbackSource GetFallbackSource(FontUsage usage) => EmptyFontFallbackSource.INSTANCE;
+
+    /// <summary>
+    /// Stands in for a real chain when there are no fonts to fall back to, so consumers do not have to
+    /// null-check the source.
+    /// </summary>
+    private sealed class EmptyFontFallbackSource : IFontFallbackSource
+    {
+        public static readonly EmptyFontFallbackSource INSTANCE = new EmptyFontFallbackSource();
+
+        public IEnumerable<Font> GetFallbacks(FontScript script) => Array.Empty<Font>();
     }
 
     public Font Get(FontUsage usage)
@@ -72,7 +102,7 @@ public class HeadlessFontStore : IFontStore
 
     public void Dispose()
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 
     public void ClearCaches()

--- a/Sakura.Framework/Graphics/Text/IFontFallbackSource.cs
+++ b/Sakura.Framework/Graphics/Text/IFontFallbackSource.cs
@@ -1,0 +1,24 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Collections.Generic;
+
+namespace Sakura.Framework.Graphics.Text;
+
+/// <summary>
+/// Supplies the fonts to try, in order, for glyphs a primary font is missing — per script, so a
+/// family claimed for one writing system is not consulted for another.
+/// </summary>
+/// <remarks>
+/// <see cref="Font.ProcessText"/> takes this rather than a flat font list because it classifies each
+/// codepoint as it segments the text, and only the store knows which families were claimed for the
+/// resulting script. Implementations are expected to cache each chain, since a chain is asked for on
+/// every layout but only walked for a codepoint the primary font lacks.
+/// </remarks>
+public interface IFontFallbackSource
+{
+    /// <summary>
+    /// The fallback fonts for <paramref name="script"/>, most preferred first.
+    /// </summary>
+    IEnumerable<Font> GetFallbacks(FontScript script);
+}

--- a/Sakura.Framework/Graphics/Text/IFontStore.cs
+++ b/Sakura.Framework/Graphics/Text/IFontStore.cs
@@ -42,17 +42,53 @@ public interface IFontStore : IDisposable
     /// <param name="storage">The storage containing the font file(s).</param>
     /// <param name="family">The family name (e.g. "Nunito"), used to locate files and build lookup keys.</param>
     /// <param name="hasItalics">Whether to also load the italic variant of the family.</param>
-    void AddFontFamily(Storage storage, string family, bool hasItalics = false);
+    /// <param name="script">
+    /// The writing system this family should serve when another font is missing a glyph — the family a
+    /// Japanese label falls back to, for instance. Claiming a script does not restrict the family: it
+    /// stays usable as a primary font for any text. <see cref="FontScript.Auto"/> derives the claims
+    /// from what the font covers; null (the default) registers the family without claiming anything, so
+    /// only a <see cref="FontUsage"/> naming it directly will reach it.
+    /// </param>
+    void AddFontFamily(Storage storage, string family, bool hasItalics = false, FontScript? script = null);
 
     /// <summary>
-    /// Adds a font family to be used as a fallback.
+    /// Adds a font family to be used as a fallback for every script, after any family claimed for the
+    /// specific script being resolved and before the framework's own bundled families.
     /// </summary>
     void AddFallbackFamily(string familyName);
 
     /// <summary>
-    /// Inserts a fallback family at a specific priority level.
+    /// Claims <paramref name="script"/> for an already-registered family, so glyphs belonging to that
+    /// script resolve here before reaching the framework's bundled families. A family may hold several
+    /// claims. Pass <see cref="FontScript.Auto"/> to derive them from the font's own coverage.
     /// </summary>
+    void AddFallbackFamily(string familyName, FontScript script);
+
+    /// <summary>
+    /// Claims <paramref name="script"/> for a family ahead of every existing claim, so the last caller
+    /// wins. Use it to override a claim made elsewhere; <see cref="AddFallbackFamily(string,FontScript)"/>
+    /// is the normal way to make one.
+    /// </summary>
+    void SetScriptFamily(FontScript script, string familyName);
+
+    /// <summary>
+    /// Inserts a script-agnostic fallback family at a specific position among the application's own
+    /// fallbacks.
+    /// </summary>
+    /// <remarks>
+    /// Priority is decided by script claim first and position second (see
+    /// <see cref="AddFallbackFamily(string,FontScript)"/>), so this only breaks ties between families
+    /// registered for no particular script. It cannot be used to overtake a claim.
+    /// </remarks>
     void InsertFallbackFamily(int index, string familyName);
+
+    /// <summary>
+    /// Which language's forms to prefer for unified CJK ideographs, which no codepoint can attribute to
+    /// a language on its own. Defaults to the OS UI language, and is consulted only after the
+    /// application's own CJK claims, so an application shipping a single CJK family never needs to set
+    /// it. A single label can override it through <see cref="FontUsage.Script"/>.
+    /// </summary>
+    FontScript HanScript { get; set; }
 
     /// <summary>
     /// Clears all currently registered fallback families.
@@ -60,9 +96,22 @@ public interface IFontStore : IDisposable
     void ClearFallbackFamilies();
 
     /// <summary>
-    /// Retrieves all registered fallback fonts configured for the requested usage (Weight/Italics).
+    /// Retrieves all registered fallback fonts configured for the requested usage (Weight/Italics),
+    /// ordered for the script the usage names, or script-agnostically when it names none.
     /// </summary>
     IEnumerable<Font> GetFallbacks(FontUsage usage);
+
+    /// <summary>
+    /// Retrieves the fallback fonts for the requested usage, ordered for glyphs belonging to
+    /// <paramref name="script"/>.
+    /// </summary>
+    IEnumerable<Font> GetFallbacks(FontUsage usage, FontScript script);
+
+    /// <summary>
+    /// Retrieves the per-script fallback chains for the requested usage, as
+    /// <see cref="Font.ProcessText"/> consumes them while segmenting text.
+    /// </summary>
+    IFontFallbackSource GetFallbackSource(FontUsage usage);
 
     /// <summary>
     /// Retrieves a font matching the specified usage.

--- a/Sakura.Framework/Graphics/Text/RendererFontStore.cs
+++ b/Sakura.Framework/Graphics/Text/RendererFontStore.cs
@@ -7,7 +7,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
+using Sakura.Framework.Extensions.ObjectExtensions;
 using Sakura.Framework.Graphics.Rendering;
 using Sakura.Framework.Graphics.Textures;
 using Sakura.Framework.IO;
@@ -22,13 +24,94 @@ public class RendererFontStore : IFontStore
 {
     private readonly TextureAtlas atlas;
     private readonly Dictionary<string, Lazy<Font>> fontCache = new Dictionary<string, Lazy<Font>>();
-    private readonly List<string> fallbackFamilies = new List<string>();
+
+    /// <summary>
+    /// One registered fallback family and the script it was claimed for. <see cref="FontScript.Any"/>
+    /// means the family applies to every script, which is what the script-less
+    /// <see cref="AddFallbackFamily(string)"/> registers.
+    /// </summary>
+    /// <param name="Family">The family name, as registered in the font cache.</param>
+    /// <param name="Script">The script claimed, or <see cref="FontScript.Any"/> for every script.</param>
+    /// <param name="Framework">
+    /// True for the framework's own bundled families. An application claim always outranks these for
+    /// the script it claims, regardless of registration order — the framework registers its fonts
+    /// during <see cref="LoadDefaultFont"/>, which runs before any application code, so ordering alone
+    /// would make an application claim unreachable.
+    /// </param>
+    private readonly record struct FallbackEntry(string Family, FontScript Script, bool Framework);
+
+    private readonly List<FallbackEntry> fallbackEntries = new List<FallbackEntry>();
+
+    /// <summary>
+    /// Families registered with <see cref="FontScript.Auto"/>, whose claims are derived from what the
+    /// font actually covers. Resolution needs the font loaded, so it is deferred until a chain is
+    /// first built rather than done at registration time.
+    /// </summary>
+    private readonly List<string> pendingAutoClaims = new List<string>();
 
     /// <summary>
     /// Fallback family names we have already warned about being unloaded, so the warning in
     /// GetFallbacks fires once per family rather than on every text layout.
     /// </summary>
     private readonly HashSet<string> warnedMissingFallbacks = new HashSet<string>();
+
+    /// <summary>
+    /// Claims we have already warned do not match the font's coverage, so the warning fires once per
+    /// (family, script) rather than on every text layout.
+    /// </summary>
+    private readonly HashSet<(string Family, FontScript Script)> warnedUncoveredClaims = new HashSet<(string, FontScript)>();
+
+    private FontScript hanScript = defaultHanScript();
+
+    /// <summary>
+    /// Which language's forms to prefer for unified CJK ideographs, the one thing a codepoint cannot
+    /// settle: 漢 is drawn differently in Japanese, Korean and the two Chinese variants while being the
+    /// same character. Defaults to the OS UI language, and is only consulted after the application's
+    /// own CJK claims — an application shipping a single CJK family never needs to set it.
+    /// </summary>
+    public FontScript HanScript
+    {
+        get => hanScript;
+        set
+        {
+            if (hanScript == value)
+                return;
+
+            hanScript = value;
+            invalidateFallbackCache();
+        }
+    }
+
+    /// <summary>
+    /// The CJK language to assume from the OS UI language. Falls back to simplified Chinese, which is
+    /// the order the framework's own families were historically registered in.
+    /// </summary>
+    private static FontScript defaultHanScript()
+    {
+        var culture = CultureInfo.CurrentUICulture;
+
+        switch (culture.TwoLetterISOLanguageName)
+        {
+            case "ja":
+                return FontScript.Japanese;
+
+            case "ko":
+                return FontScript.Korean;
+
+            case "zh":
+                string name = culture.Name;
+
+                bool traditional = name.Contains("Hant", StringComparison.OrdinalIgnoreCase)
+                                   || name.EndsWith("-TW", StringComparison.OrdinalIgnoreCase)
+                                   || name.EndsWith("-HK", StringComparison.OrdinalIgnoreCase)
+                                   || name.EndsWith("-MO", StringComparison.OrdinalIgnoreCase);
+
+                return traditional ? FontScript.ChineseTraditional : FontScript.ChineseSimplified;
+
+            default:
+                return FontScript.ChineseSimplified;
+        }
+    }
 
     public int CacheVersion { get; private set; }
 
@@ -55,24 +138,30 @@ public class RendererFontStore : IFontStore
             Logger.Warning("[FontLoader] NotoSans-Regular.ttf was not found. Default font is missing.");
         }
 
-        // fallback families for various languages
-        string[] fallbackFamiliesList = new[]
+        // The base font is a fallback in its own right, not just the default primary: it is the only
+        // bundled family covering Cyrillic, Greek and Vietnamese, so a label asking for a Latin-only
+        // application font needs to reach it. Registered first so it leads the generic tail.
+        addFrameworkFallback("NotoSans", FontScript.Any);
+
+        // Per-script fallback families. Each is claimed for the script it is drawn for, so a request
+        // for Japanese reaches NotoSansJP instead of whichever family happens to have the codepoint.
+        (string Family, FontScript Script)[] fallbackFamiliesList =
         {
-            "NotoSansSC",
-            "NotoSansTC",
-            "NotoSansJP",
-            "NotoSansKR",
-            "NotoSansThai",
-            "NotoSansArabic",
-            "NotoSansDevanagari",
-            "NotoSansHebrew"
+            ("NotoSansSC", FontScript.ChineseSimplified),
+            ("NotoSansTC", FontScript.ChineseTraditional),
+            ("NotoSansJP", FontScript.Japanese),
+            ("NotoSansKR", FontScript.Korean),
+            ("NotoSansThai", FontScript.Thai),
+            ("NotoSansArabic", FontScript.Arabic),
+            ("NotoSansDevanagari", FontScript.Devanagari),
+            ("NotoSansHebrew", FontScript.Hebrew)
         };
 
-        foreach (string family in fallbackFamiliesList)
+        foreach ((string family, var script) in fallbackFamiliesList)
         {
             // These families don't have italics
             loadFamily(resourceStorage, family, hasItalics: false);
-            AddFallbackFamily(family);
+            addFrameworkFallback(family, script);
         }
 
         loadEmojiFonts(resourceStorage);
@@ -84,7 +173,7 @@ public class RendererFontStore : IFontStore
         loadMaterialSymbol(resourceStorage, "MaterialSymbolsOutlined");
         loadMaterialSymbol(resourceStorage, "MaterialSymbolsRounded");
         loadMaterialSymbol(resourceStorage, "MaterialSymbolsSharp");
-        AddFallbackFamily("MaterialSymbolsOutlined");
+        addFrameworkFallback("MaterialSymbolsOutlined", FontScript.Any);
     }
 
     /// <summary>
@@ -104,10 +193,16 @@ public class RendererFontStore : IFontStore
 
     /// <summary>
     /// Public entry point for applications to register their own font family with the same
-    /// variable-aware loading the framework uses for its built-in fonts. Delegates to <see cref="loadFamily"/>.
+    /// variable-aware loading the framework uses for its built-in fonts. Delegates to <see cref="loadFamily"/>,
+    /// and claims <paramref name="script"/> for the family when one is given.
     /// </summary>
-    public void AddFontFamily(Storage storage, string family, bool hasItalics = false)
-        => loadFamily(storage, family, hasItalics);
+    public void AddFontFamily(Storage storage, string family, bool hasItalics = false, FontScript? script = null)
+    {
+        loadFamily(storage, family, hasItalics);
+
+        if (script.HasValue)
+            AddFallbackFamily(family, script.Value);
+    }
 
     private void loadFamily(Storage storage, string family, bool hasItalics)
     {
@@ -242,7 +337,7 @@ public class RendererFontStore : IFontStore
                     continue;
 
                 AddFontFromFile(path, alias: "AppleColorEmoji");
-                AddFallbackFamily("AppleColorEmoji");
+                addFrameworkFallback("AppleColorEmoji", FontScript.Emoji);
                 colorEmojiInChain = true;
                 Logger.Debug($"Using system Apple Color Emoji font from {path}");
                 break;
@@ -254,13 +349,13 @@ public class RendererFontStore : IFontStore
         // https://github.com/googlefonts/noto-emoji/blob/main/fonts/NotoColorEmoji.ttf
         if (notoColorAvailable)
         {
-            AddFallbackFamily("NotoColorEmoji");
+            addFrameworkFallback("NotoColorEmoji", FontScript.Emoji);
             colorEmojiInChain = true;
         }
 
         // Monochrome NotoEmoji
         loadFamily(resourceStorage, "NotoEmoji", hasItalics: false);
-        AddFallbackFamily("NotoEmoji");
+        addFrameworkFallback("NotoEmoji", FontScript.Emoji);
 
         if (!colorEmojiInChain)
             Logger.Debug("No color emoji font available; falling back to monochrome NotoEmoji.");
@@ -461,62 +556,343 @@ public class RendererFontStore : IFontStore
     }
 
     /// <summary>
+    /// Resolves <paramref name="family"/> at the usage's weight/italics through registered keys only,
+    /// returning null when the family was never loaded rather than standing in the default font.
+    /// </summary>
+    /// <remarks>
+    /// Fallback resolution needs this distinction: <see cref="Get(FontUsage)"/> answers with the default
+    /// font both for a family that failed to load and for the base family itself, so a chain built on it
+    /// can never contain the base family.
+    /// </remarks>
+    private Font getRegistered(FontUsage usage, string family)
+    {
+        if (string.IsNullOrEmpty(family))
+            return null;
+
+        string weighted = $"{family}-{usage.Weight}";
+
+        if (usage.Italics && tryGetLoaded(weighted + "Italic", out var italic))
+            return italic;
+
+        if (tryGetLoaded(weighted, out var font))
+            return font;
+
+        return tryGetLoaded(family, out var bare) ? bare : null;
+    }
+
+    private bool tryGetLoaded(string key, out Font font)
+    {
+        font = fontCache.TryGetValue(key, out var lazy) ? lazy.Value : null;
+        return font != null;
+    }
+
+    /// <summary>
     /// Derives the <see cref="FontVariation"/> for the requested usage (weight → <c>wght</c>, plus any
     /// Fill/Grade/OpticalSize overrides). Applied at render time; harmlessly ignored by static fonts.
     /// </summary>
     public FontVariation GetVariation(FontUsage usage) => usage.ToVariation();
 
-    public void AddFallbackFamily(string familyName)
+    public void AddFallbackFamily(string familyName) => AddFallbackFamily(familyName, FontScript.Any);
+
+    public void AddFallbackFamily(string familyName, FontScript script)
     {
-        if (fallbackFamilies.Contains(familyName))
+        if (script == FontScript.Auto)
+        {
+            if (!pendingAutoClaims.Contains(familyName))
+            {
+                pendingAutoClaims.Add(familyName);
+                invalidateFallbackCache();
+            }
+
+            return;
+        }
+
+        addEntry(new FallbackEntry(familyName, script, Framework: false));
+    }
+
+    public void SetScriptFamily(FontScript script, string familyName)
+    {
+        if (script == FontScript.Auto)
+        {
+            AddFallbackFamily(familyName, FontScript.Auto);
+            return;
+        }
+
+        var entry = new FallbackEntry(familyName, script, Framework: false);
+
+        if (fallbackEntries.Contains(entry))
+            fallbackEntries.Remove(entry);
+
+        // Ahead of every existing claim, so the last caller wins for this script. Claims for other
+        // scripts are unaffected: ordering within the list only decides ties inside one tier.
+        fallbackEntries.Insert(0, entry);
+        invalidateFallbackCache();
+    }
+
+    /// <summary>
+    /// Registers one of the framework's own bundled families. Kept separate from
+    /// <see cref="AddFallbackFamily(string,FontScript)"/> so an application claim can outrank it for the
+    /// same script even though the framework registers first.
+    /// </summary>
+    private void addFrameworkFallback(string familyName, FontScript script)
+        => addEntry(new FallbackEntry(familyName, script, Framework: true));
+
+    private void addEntry(FallbackEntry entry)
+    {
+        // A family may hold more than one claim (a CJK family covering both kana and ideographs), so
+        // duplicates are rejected per (family, script) rather than per family.
+        if (fallbackEntries.Contains(entry))
             return;
 
-        fallbackFamilies.Add(familyName);
+        fallbackEntries.Add(entry);
         invalidateFallbackCache();
     }
 
     public void InsertFallbackFamily(int index, string familyName)
     {
-        if (fallbackFamilies.Contains(familyName))
+        var entry = new FallbackEntry(familyName, FontScript.Any, Framework: false);
+
+        if (fallbackEntries.Contains(entry))
             return;
 
-        fallbackFamilies.Insert(index, familyName);
+        fallbackEntries.Insert(Math.Clamp(index, 0, fallbackEntries.Count), entry);
         invalidateFallbackCache();
     }
 
     public void ClearFallbackFamilies()
     {
-        fallbackFamilies.Clear();
+        fallbackEntries.Clear();
+        pendingAutoClaims.Clear();
         invalidateFallbackCache();
     }
 
     /// <summary>
-    /// Fallback chains, keyed by the only parts of a <see cref="FontUsage"/> that affect the result (the
-    /// family is substituted per fallback, and size plays no part in resolution).
+    /// Turns every <see cref="FontScript.Auto"/> registration into concrete claims, by probing what the
+    /// font actually covers. Runs once per registration, the first time a chain is built — probing needs
+    /// the font loaded, and doing it eagerly would defeat the store's lazy loading.
     /// </summary>
-    private readonly Dictionary<(string weight, bool italics), FallbackChain> fallbackCache = new Dictionary<(string, bool), FallbackChain>();
-
-    /// <summary>
-    /// The fallback fonts to try, in order, for glyphs the primary font does not cover.
-    /// </summary>
-    public IEnumerable<Font> GetFallbacks(FontUsage usage)
+    /// <remarks>
+    /// A script already claimed by the application is left alone, so an explicit claim always beats a
+    /// derived one and two auto-registered families resolve in registration order. Latin is never
+    /// auto-claimed (see <see cref="FontScripts.AutoClaimable"/>).
+    /// </remarks>
+    private void resolvePendingAutoClaims()
     {
-        var key = (usage.Weight, usage.Italics);
+        if (pendingAutoClaims.Count == 0)
+            return;
 
-        if (!fallbackCache.TryGetValue(key, out var chain))
-            fallbackCache[key] = chain = new FallbackChain(this, usage);
+        // Taken by value: addEntry invalidates, and the pending list is emptied as we go.
+        string[] pending = pendingAutoClaims.ToArray();
+        pendingAutoClaims.Clear();
 
-        return chain;
+        foreach (string family in pending)
+        {
+            var font = Get(family);
+
+            if (font.IsNull() || (font == defaultFont && family != "NotoSans"))
+            {
+                Logger.Warning($"[FontLoader] '{family}' was registered with FontScript.Auto but is not loaded, so no script could be claimed for it.");
+                continue;
+            }
+
+            var claimed = new List<FontScript>();
+
+            foreach (var script in FontScripts.AutoClaimable)
+            {
+                if (isClaimedByApplication(script))
+                    continue;
+
+                uint probe = FontScripts.ProbeFor(script);
+
+                if (probe == 0 || !font.HasGlyph(probe))
+                    continue;
+
+                addEntry(new FallbackEntry(family, script, Framework: false));
+                claimed.Add(script);
+            }
+
+            if (claimed.Count == 0)
+                Logger.Debug($"[FontLoader] '{family}' (FontScript.Auto) covers no unclaimed script; it stays available as a primary font only.");
+            else
+                Logger.Debug($"[FontLoader] '{family}' (FontScript.Auto) claimed {string.Join(", ", claimed)}.");
+        }
+    }
+
+    private bool isClaimedByApplication(FontScript script)
+    {
+        foreach (var entry in fallbackEntries)
+        {
+            if (!entry.Framework && entry.Script == script)
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>
-    /// A fallback chain for one (weight, italics) combination, resolved one family at a time as a
-    /// consumer walks it, and remembering what it resolved so later layouts pay nothing.
+    /// The fallback entries to consult for <paramref name="script"/>, most preferred first.
+    /// </summary>
+    /// <remarks>
+    /// <para>The tiers, in order:</para>
+    /// <list type="number">
+    /// <item>application claims for the script itself, then for the scripts related to it</item>
+    /// <item>application families registered for no particular script</item>
+    /// <item>the framework's family for the script (for ideographs, the one matching <see cref="HanScript"/>)</item>
+    /// <item>everything else in registration order</item>
+    /// </list>
+    /// <para>
+    /// An application claim outranking the framework's family is the whole point: the framework loads
+    /// its fonts before any application code runs, so a single ordered list can never let an
+    /// application override one script without also overriding every script that family happens to
+    /// cover. The last tier is what keeps text rendering at all for scripts nobody claimed — dropping
+    /// it would turn a wrong-font glyph into a missing one.
+    /// </para>
+    /// </remarks>
+    private List<FallbackEntry> orderedEntriesFor(FontScript script)
+    {
+        var ordered = new List<FallbackEntry>();
+        var used = new HashSet<FallbackEntry>();
+
+        void emit(Func<FallbackEntry, bool> match)
+        {
+            foreach (var entry in fallbackEntries)
+            {
+                if (match(entry) && used.Add(entry))
+                    ordered.Add(entry);
+            }
+        }
+
+        bool han = script == FontScript.Han;
+        bool cjk = FontScripts.IsCJK(script);
+
+        emit(e => !e.Framework && e.Script == script);
+
+        // Ideographs draw on every CJK claim the application made, in registration order: a game
+        // shipping one Japanese family gets its kanji from that family without having to say so twice.
+        // Conversely kana and hangul draw on a family claimed only for ideographs, which is normally a
+        // full CJK family.
+        if (han)
+            emit(e => !e.Framework && FontScripts.IsCJK(e.Script));
+        else if (cjk)
+            emit(e => !e.Framework && e.Script == FontScript.Han);
+
+        emit(e => !e.Framework && e.Script == FontScript.Any);
+
+        emit(e => e.Framework && e.Script == script);
+
+        if (han)
+        {
+            emit(e => e.Framework && e.Script == HanScript);
+            emit(e => e.Framework && FontScripts.IsCJK(e.Script));
+        }
+        else if (cjk)
+            emit(e => e.Framework && e.Script == FontScript.Han);
+
+        emit(_ => true);
+
+        return ordered;
+    }
+
+    /// <summary>
+    /// Warns once when a family was claimed for a script it does not actually cover — a typo in a
+    /// claim, or a font that only looked like it covered the script. The claim is left in place: a
+    /// chain entry that has no glyph is skipped per codepoint anyway, so honouring it costs nothing,
+    /// while dropping it would make the mistake harder to see rather than easier.
+    /// </summary>
+    private void verifyClaim(FallbackEntry entry, Font font)
+    {
+        // The framework's own families are verified by the resource build, and a missing file already
+        // warns through the not-loaded path above.
+        if (entry.Framework || font == null)
+            return;
+
+        uint probe = FontScripts.ProbeFor(entry.Script);
+
+        if (probe == 0 || font.HasGlyph(probe))
+            return;
+
+        if (warnedUncoveredClaims.Add((entry.Family, entry.Script)))
+            Logger.Warning($"[FontLoader] '{entry.Family}' is registered for FontScript.{entry.Script} but has no glyph for U+{probe:X4}, so the claim will contribute nothing. Did you mean a different script or a different family?");
+    }
+
+    /// <summary>
+    /// Fallback sources, keyed by the only parts of a <see cref="FontUsage"/> that affect the result (the
+    /// family is substituted per fallback, and size plays no part in resolution).
+    /// </summary>
+    private readonly Dictionary<(string weight, bool italics), FallbackSource> fallbackSources = new Dictionary<(string, bool), FallbackSource>();
+
+    /// <summary>
+    /// The per-script fallback chains for this usage, as <see cref="Font.ProcessText"/> needs them: it
+    /// classifies each codepoint while segmenting and asks for the chain matching the script it found.
+    /// </summary>
+    public IFontFallbackSource GetFallbackSource(FontUsage usage)
+    {
+        resolvePendingAutoClaims();
+
+        var key = (usage.Weight, usage.Italics);
+
+        if (!fallbackSources.TryGetValue(key, out var source))
+            fallbackSources[key] = source = new FallbackSource(this, usage);
+
+        return source;
+    }
+
+    /// <summary>
+    /// The fallback fonts to try, in order, for glyphs the primary font does not cover. Resolves for the
+    /// script the usage names, or the script-agnostic chain when it names none.
+    /// </summary>
+    public IEnumerable<Font> GetFallbacks(FontUsage usage) => GetFallbacks(usage, usage.Script ?? FontScript.Any);
+
+    /// <summary>
+    /// The fallback fonts to try, in order, for a glyph belonging to <paramref name="script"/>.
+    /// </summary>
+    public IEnumerable<Font> GetFallbacks(FontUsage usage, FontScript script) => GetFallbackSource(usage).GetFallbacks(script);
+
+    /// <summary>
+    /// The fallback chains for one (weight, italics) combination, one per script, each built on first
+    /// use. Holding them together means a layout that mixes scripts resolves each script once for the
+    /// whole application run rather than once per label.
+    /// </summary>
+    private sealed class FallbackSource : IFontFallbackSource
+    {
+        private readonly RendererFontStore store;
+        private readonly FontUsage usage;
+
+        private readonly Dictionary<FontScript, FallbackChain> chains = new Dictionary<FontScript, FallbackChain>();
+
+        public FallbackSource(RendererFontStore store, FontUsage usage)
+        {
+            this.store = store;
+            this.usage = usage;
+        }
+
+        public IEnumerable<Font> GetFallbacks(FontScript script)
+        {
+            // Auto is a registration-time sentinel; if one reaches here it describes no script.
+            if (script == FontScript.Auto)
+                script = FontScript.Any;
+
+            if (!chains.TryGetValue(script, out var chain))
+                chains[script] = chain = new FallbackChain(store, usage, store.orderedEntriesFor(script));
+
+            return chain;
+        }
+    }
+
+    /// <summary>
+    /// A fallback chain for one (weight, italics, script) combination, resolved one family at a time as
+    /// a consumer walks it, and remembering what it resolved so later layouts pay nothing.
     /// </summary>
     private sealed class FallbackChain : IEnumerable<Font>
     {
         private readonly RendererFontStore store;
         private readonly FontUsage usage;
+
+        /// <summary>
+        /// The families to try, in priority order for this chain's script. Ordering is pure string work
+        /// so it happens up front; loading the fonts they name is what stays lazy.
+        /// </summary>
+        private readonly List<FallbackEntry> entries;
 
         /// <summary>
         /// Fonts resolved so far, in chain order. Append-only.
@@ -526,14 +902,15 @@ public class RendererFontStore : IFontStore
         private readonly HashSet<Font> seen = new HashSet<Font>();
 
         /// <summary>
-        /// How far into <see cref="fallbackFamilies"/> resolution has reached.
+        /// How far into <see cref="entries"/> resolution has reached.
         /// </summary>
         private int nextFamily;
 
-        public FallbackChain(RendererFontStore store, FontUsage usage)
+        public FallbackChain(RendererFontStore store, FontUsage usage, List<FallbackEntry> entries)
         {
             this.store = store;
             this.usage = usage;
+            this.entries = entries;
         }
 
         public IEnumerator<Font> GetEnumerator()
@@ -555,26 +932,30 @@ public class RendererFontStore : IFontStore
         /// </summary>
         private bool resolveNext()
         {
-            while (nextFamily < store.fallbackFamilies.Count)
+            while (nextFamily < entries.Count)
             {
-                string family = store.fallbackFamilies[nextFamily++];
+                var entry = entries[nextFamily++];
+                string family = entry.Family;
 
-                var fallbackFont = store.Get(usage.With(family: family));
+                // Resolved through the registered keys only. Get(FontUsage) would answer with the
+                // default font for a family that was never loaded, which is indistinguishable from a
+                // family that legitimately *is* the default font — and the base family is a fallback in
+                // its own right (it is the only bundled one covering Cyrillic and Greek).
+                var fallbackFont = store.getRegistered(usage, family);
 
-                if (fallbackFont == store.defaultFont || fallbackFont == null)
-                    fallbackFont = store.Get(family);
-
-                // A registered fallback family that resolves to the default font was never loaded (its
-                // file is missing, or AddFallbackFamily was called without a matching AddFont/loadFamily).
-                // Such a family contributes nothing to glyph coverage, warn once so the misconfiguration
-                // is visible instead of silently rendering missing glyphs as .notdef ("tofu").
-                if (fallbackFont == null || fallbackFont == store.defaultFont)
+                // A registered fallback family that resolves to nothing was never loaded (its file is
+                // missing, or AddFallbackFamily was called without a matching AddFont/loadFamily). Such
+                // a family contributes nothing to glyph coverage, warn once so the misconfiguration is
+                // visible instead of silently rendering missing glyphs as .notdef ("tofu").
+                if (fallbackFont == null)
                 {
                     if (store.warnedMissingFallbacks.Add(family))
                         Logger.Debug($"Fallback family '{family}' is registered but not loaded, it will not contribute glyphs. Did you forget to load it?");
 
                     continue;
                 }
+
+                store.verifyClaim(entry, fallbackFont);
 
                 if (!seen.Add(fallbackFont))
                     continue;
@@ -645,10 +1026,10 @@ public class RendererFontStore : IFontStore
         stat_shape_misses.Value++;
 
         var font = Get(usage);
-        if (font == null)
+        if (font.IsNull())
             return ShapedText.Empty;
 
-        var shaped = font.ProcessText(text, usage.Size, dpiScale, GetFallbacks(usage), GetVariation(usage));
+        var shaped = font.ProcessText(text, usage.Size, dpiScale, GetFallbackSource(usage), GetVariation(usage), usage.Script);
 
         var node = shapeLru.AddFirst((key, shaped));
         shapeCache[key] = node;
@@ -693,7 +1074,7 @@ public class RendererFontStore : IFontStore
     /// </summary>
     private void invalidateFallbackCache()
     {
-        fallbackCache.Clear();
+        fallbackSources.Clear();
         invalidateShapeCache();
     }
 


### PR DESCRIPTION
Since sakura already have set of Noto font embedded into the framework resource with fallback support so almost all language sakura can render it properly. But there are really some case that you really want to "customize" like use custom font per language. There are an project that I need to do this.

But we already have `FontStore.AddFallbackFont()`? It's not work since it's add at the end of the fallback hierarchy so Noto will get first before reaching your custom font.

So add support for more font family adding support with "per language" registration like this. So you can have custom font with sakura's set of NotoSans still have your back

```csharp
        FontStore.AddFontFamily(fontStore, "Quicksand");
        FontStore.AddFontFamily(fontStore, "Nunito", hasItalics: true);
        FontStore.AddFontFamily(fontStore, "MPLUSRounded1c", script: FontScript.Japanese);
        FontStore.AddFontFamily(fontStore, "IBMPlexSansThai", script: FontScript.Thai);
````