### PR TITLE
Second pass of SDL audio backend

### DIFF
--- a/.github/workflows/build-sakura-audio.yml
+++ b/.github/workflows/build-sakura-audio.yml
@@ -287,6 +287,20 @@ jobs:
             exit 1
           }
 
+          # And that it has an ABI at all. PE exports nothing unless asked, so a missing export
+          # directive produces a DLL that builds, links, packages and passes every other check here
+          # while exporting nothing -- the managed side then loads it and throws
+          # EntryPointNotFoundException on the first call, which reads as "this platform has no native
+          # library" rather than as a broken build. That shipped on all three Windows RIDs undetected,
+          # because this step only ever asked what the library links against.
+          $exports = & $dumpbin.FullName /exports "$PWD/out/sakura-audio.dll"
+
+          if (-not ($exports | Select-String -Pattern 'sakura_audio_abi_version' -Quiet)) {
+            $exports | Write-Host
+            Write-Host "::error::sakura-audio.dll does not export sakura_audio_abi_version, so the managed side cannot use it."
+            exit 1
+          }
+
       - name: Upload ${{ matrix.rid }} artifact
         uses: actions/upload-artifact@v7
         with:

--- a/Sakura.Framework.Tests/Audio/AudioBackendConformanceTest.cs
+++ b/Sakura.Framework.Tests/Audio/AudioBackendConformanceTest.cs
@@ -1,0 +1,465 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using ManagedBass;
+using NUnit.Framework;
+using Sakura.Framework.Audio;
+using Sakura.Framework.Audio.BassEngine;
+using Sakura.Framework.Audio.SdlEngine;
+using static SDL.SDL3;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// Behavior test for all audio backend sakura shipped.
+/// </summary>
+[TestFixture]
+public class AudioBackendConformanceTest
+{
+    /// <summary>
+    /// How long to allow for a state change to be reflected, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Generous, and deliberately not a tight bound on any backend's latency: every one of these
+    /// engines marshals transport changes onto its own thread, and this is the budget for that
+    /// round-trip plus the polling interval the tests use. A tight value here would measure scheduler
+    /// luck.
+    /// </remarks>
+    private const int settle_ms = 400;
+
+    /// <summary>
+    /// Tolerance for a position assertion, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// One BASS playback buffer (100 ms) is the largest single quantum any shipped backend reports
+    /// positions in, so that is the floor for a cross-backend comparison; 150 ms leaves room for the
+    /// polling interval on top. Anything the suite is trying to catch — a seek to the wrong place, a
+    /// loop to the wrong point, a rate applied the wrong way round — is wrong by far more than this.
+    /// </remarks>
+    private const double position_tolerance_ms = 150;
+
+    public enum Backend
+    {
+        Bass,
+        SdlNative,
+        SdlManaged
+    }
+
+    private static IAudioManager create(Backend backend)
+    {
+        switch (backend)
+        {
+            case Backend.Bass:
+                return new BassAudioManager(Bass.NoSoundDevice);
+
+            case Backend.SdlNative:
+            case Backend.SdlManaged:
+                SDL_SetHint(SDL_HINT_AUDIO_DRIVER, "dummy");
+
+                if (backend == Backend.SdlNative && !SakuraAudioEngine.IsAvailable)
+                    Assert.Ignore("libsakura-audio is not available for this platform.");
+
+                var manager = new SDLAudioManager(backend == Backend.SdlNative);
+
+                Assert.That(manager.UsesNativeMixEngine, Is.EqualTo(backend == Backend.SdlNative),
+                    "Asked for one SDL mix engine and got the other, which would make this a duplicate run of the "
+                    + "other parameterization rather than a test of what it claims.");
+
+                return manager;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(backend));
+        }
+    }
+
+    private static Stream open(string resource) =>
+        Assembly.GetExecutingAssembly().GetManifestResourceStream($"Sakura.Framework.Tests.Resources.{resource}")
+        ?? throw new InvalidOperationException($"Missing embedded test resource '{resource}'.");
+
+    /// <summary>
+    /// The BASS backend takes a path, not a stream, for tracks, so the shared tests use files.
+    /// </summary>
+    private static string writeTempCopy(string resource)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"sakura-conformance-{Path.GetRandomFileName()}.mp3");
+
+        using var source = open(resource);
+        using var destination = File.Create(path);
+        source.CopyTo(destination);
+
+        return path;
+    }
+
+    /// <summary>
+    /// Pumps the manager until <paramref name="condition"/> holds, since every backend marshals its
+    /// events onto a thread a test has to drive.
+    /// </summary>
+    private static bool waitUntil(IAudioManager manager, Func<bool> condition, int timeoutMs = 10_000)
+    {
+        var timeout = Stopwatch.StartNew();
+
+        while (timeout.ElapsedMilliseconds < timeoutMs)
+        {
+            manager.Update(16);
+
+            if (condition())
+                return true;
+
+            Thread.Sleep(8);
+        }
+
+        manager.Update(16);
+        return condition();
+    }
+
+    private static void settle(IAudioManager manager)
+    {
+        var timeout = Stopwatch.StartNew();
+
+        while (timeout.ElapsedMilliseconds < settle_ms)
+        {
+            manager.Update(16);
+            Thread.Sleep(8);
+        }
+    }
+
+    #region Length and playback
+
+    [Test]
+    public void ReportsATrackLength([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var track = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+
+        Assert.That(track.Length, Is.GreaterThan(1000),
+            "Every backend has to agree roughly on how long a file is, or seeking and progress bars mean different "
+            + "things per backend.");
+    }
+
+    [Test]
+    public void PlayingAdvancesThePosition([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3")).GetChannel();
+        channel.Play();
+
+        Assert.That(waitUntil(audio, () => channel.CurrentTime > 300), Is.True,
+            $"Position did not advance past 300 ms. Reached {channel.CurrentTime} ms.");
+    }
+
+    #endregion
+
+    #region Transport
+
+    [Test]
+    public void SeekLandsWhereItWasSent([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var track = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+        var channel = track.GetChannel();
+
+        channel.Play();
+        waitUntil(audio, () => channel.CurrentTime > 200);
+
+        channel.CurrentTime = 2000;
+        settle(audio);
+
+        Assert.That(channel.CurrentTime, Is.EqualTo(2000).Within(position_tolerance_ms + settle_ms),
+            "A seek has to land where it was sent on every backend, or gameplay synced to one backend is wrong on "
+            + "the other.");
+    }
+
+    [Test]
+    public void SeekIsVisibleImmediately([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3")).GetChannel();
+
+        channel.Play();
+        waitUntil(audio, () => channel.CurrentTime > 200);
+
+        channel.CurrentTime = 5000;
+
+        // No settle: the very next read must not still be reporting the old position. A backend that
+        // reports the pre-seek cursor for a frame makes TrackClock see a jump backwards and then
+        // forwards, which it turns into audible desync.
+        Assert.That(channel.CurrentTime, Is.EqualTo(5000).Within(position_tolerance_ms),
+            $"Read {channel.CurrentTime} ms straight after seeking to 5000 ms.");
+    }
+
+    [Test]
+    public void StopRewindsAndPauseDoesNot([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3")).GetChannel();
+
+        channel.Play();
+        waitUntil(audio, () => channel.CurrentTime > 400);
+
+        channel.Pause();
+        settle(audio);
+
+        double paused = channel.CurrentTime;
+        Assert.That(paused, Is.GreaterThan(0), "Pause rewound, which is Stop's job.");
+
+        settle(audio);
+
+        Assert.That(channel.CurrentTime, Is.EqualTo(paused).Within(position_tolerance_ms),
+            "A paused channel kept moving.");
+
+        channel.Stop();
+        settle(audio);
+
+        Assert.That(channel.CurrentTime, Is.EqualTo(0).Within(position_tolerance_ms),
+            "Stop must rewind on every backend.");
+    }
+
+    [Test]
+    public void ReplayingAfterStopStartsOver([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3")).GetChannel();
+
+        channel.Play();
+        waitUntil(audio, () => channel.CurrentTime > 400);
+
+        channel.Stop();
+        settle(audio);
+
+        channel.Play();
+
+        Assert.That(waitUntil(audio, () => channel.CurrentTime > 200), Is.True,
+            "A stopped-then-replayed channel did not start producing audio again.");
+    }
+
+    #endregion
+
+    #region Looping
+
+    [Test]
+    public void LoopingReturnsToTheRestartPoint([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var track = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+        var channel = track.GetChannel();
+
+        channel.Looping = true;
+        channel.RestartPoint = 1000;
+
+        // Start close enough to the end that the wrap happens inside the test's patience.
+        channel.CurrentTime = Math.Max(0, track.Length - 400);
+        channel.Play();
+
+        Assert.That(waitUntil(audio, () => channel.CurrentTime < track.Length - 1000), Is.True,
+            $"The track never wrapped. Position sat at {channel.CurrentTime} ms against a length of {track.Length} ms.");
+
+        // Where it wrapped *to* is the part that matters and the part a listen cannot check.
+        Assert.That(channel.CurrentTime, Is.GreaterThanOrEqualTo(1000 - position_tolerance_ms),
+            $"Looped back to {channel.CurrentTime} ms, before the RestartPoint of 1000 ms.");
+    }
+
+    [Test]
+    public void ANonLoopingChannelReportsItsEnd([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var sample = audio.CreateSample(open("Samples.test.wav"));
+        var channel = sample.Play();
+
+        Assert.That(channel, Is.Not.Null);
+
+        bool ended = false;
+        channel.OnEnd += () => ended = true;
+
+        Assert.That(waitUntil(audio, () => ended), Is.True,
+            "OnEnd never fired. Anything driving a sequence off sample completion breaks silently on this backend.");
+    }
+
+    #endregion
+
+    #region Rate
+
+    [TestCase(Backend.Bass, 2.0)]
+    [TestCase(Backend.Bass, 0.5)]
+    [TestCase(Backend.SdlNative, 2.0)]
+    [TestCase(Backend.SdlNative, 0.5)]
+    [TestCase(Backend.SdlManaged, 2.0)]
+    [TestCase(Backend.SdlManaged, 0.5)]
+    public void FrequencyScalesHowFastThePositionMoves(Backend backend, double rate)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3")).GetChannel();
+
+        channel.Frequency.Value = rate;
+        channel.Play();
+
+        waitUntil(audio, () => channel.CurrentTime > 200);
+
+        double startPosition = channel.CurrentTime;
+        var wall = Stopwatch.StartNew();
+
+        waitUntil(audio, () => wall.ElapsedMilliseconds > 1000, 3000);
+
+        double advanced = channel.CurrentTime - startPosition;
+        double expected = wall.Elapsed.TotalMilliseconds * rate;
+
+        // The failure worth catching is the ratio being inverted or ignored, which is a factor of two
+        // or four out — hence a percentage band rather than a millisecond one.
+        Assert.That(advanced, Is.EqualTo(expected).Within(30).Percent,
+            $"At rate {rate} the position advanced {advanced:F0} ms over {wall.Elapsed.TotalMilliseconds:F0} ms of "
+            + $"wall clock; {expected:F0} ms was expected.");
+    }
+
+    #endregion
+
+    #region Mixing and polyphony
+
+    [Test]
+    public void ManyConcurrentSamplesAllPlay([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        const int voices = 16;
+
+        var channels = new IAudioChannel[voices];
+
+        for (int i = 0; i < voices; i++)
+        {
+            var sample = audio.CreateSample(open("Samples.long.mp3"));
+            channels[i] = sample.Play()!;
+
+            Assert.That(channels[i], Is.Not.Null, $"Voice {i} would not start.");
+        }
+
+        settle(audio);
+
+        int running = 0;
+
+        foreach (var channel in channels)
+        {
+            if (channel.IsRunning.Value)
+                running++;
+        }
+
+        Assert.That(running, Is.EqualTo(voices),
+            $"{running} of {voices} concurrent samples were still running. Hitsound polyphony is the thing this "
+            + "measures, and a backend that silently drops voices under load loses notes.");
+    }
+
+    [Test]
+    public void MixerVolumeIsIndependentOfChannelVolume([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3")).GetChannel();
+        channel.Play();
+
+        channel.Volume.Value = 0.5;
+        audio.TrackVolume.Value = 0.25;
+
+        settle(audio);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(channel.Volume.Value, Is.EqualTo(0.5).Within(1e-6),
+                "Setting a mixer's volume changed a channel's own volume, so the two are the same control on this "
+                + "backend and an app cannot use them separately.");
+            Assert.That(audio.TrackVolume.Value, Is.EqualTo(0.25).Within(1e-6));
+        }
+    }
+
+    [Test]
+    public void StopAllStopsEveryChannel([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var track = audio.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3")).GetChannel();
+        var sample = audio.CreateSample(open("Samples.long.mp3")).Play();
+
+        track.Play();
+        settle(audio);
+
+        audio.StopAll();
+        settle(audio);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(track.IsRunning.Value, Is.False, "A track kept playing through StopAll.");
+            Assert.That(sample?.IsRunning.Value, Is.False, "A sample kept playing through StopAll.");
+        }
+    }
+
+    #endregion
+
+    #region Metering
+
+    [Test]
+    public void AmplitudesRespondToAudio([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.loud.mp3")).GetChannel();
+        channel.Play();
+
+        bool sawSignal = waitUntil(audio,
+            () => channel.CurrentAmplitudes.AmplitudeLeft > 0.01f || channel.CurrentAmplitudes.AmplitudeRight > 0.01f);
+
+        Assert.That(sawSignal, Is.True,
+            "Peak levels never rose above nothing while a deliberately loud track was playing, so any visualiser "
+            + "bound to this backend renders a flat line.");
+    }
+
+    [Test]
+    public void SpectrumHasContentWhilePlaying([Values] Backend backend)
+    {
+        using var manager = (IDisposable)create(backend);
+        var audio = (IAudioManager)manager;
+
+        var channel = audio.CreateTrackFromFile(writeTempCopy("Tracks.loud.mp3")).GetChannel();
+        channel.Play();
+
+        bool sawSpectrum = waitUntil(audio, () =>
+        {
+            var frequencies = channel.CurrentAmplitudes.FrequencyAmplitudes.Span;
+
+            for (int i = 0; i < frequencies.Length; i++)
+            {
+                if (frequencies[i] > 0.001f)
+                    return true;
+            }
+
+            return false;
+        });
+
+        Assert.That(sawSpectrum, Is.True,
+            "The spectrum stayed empty on a loud track. AudioVisualizer would show nothing on this backend.");
+    }
+
+    #endregion
+}

--- a/Sakura.Framework.Tests/Audio/AudioBackendsTest.cs
+++ b/Sakura.Framework.Tests/Audio/AudioBackendsTest.cs
@@ -1,0 +1,59 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Sakura.Framework.Audio;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// What a settings UI is allowed to offer.
+/// </summary>
+[TestFixture]
+public class AudioBackendsTest
+{
+    [Test]
+    public void SuitableBackendsExcludeTheManagedMixer()
+    {
+        Assert.That(AudioBackends.GetSuitableBackends(), Does.Not.Contain(AudioBackend.SDLManaged),
+            "SDLManaged is not a backend choice, it is SDL with its native mix engine switched off. It costs roughly "
+            + "twenty times the output latency and exists to be diffed against, so it belongs in framework.ini rather "
+            + "than in a dropdown.");
+    }
+
+    [Test]
+    public void SuitableBackendsOfferEveryBackendAUserWouldWant()
+    {
+        Assert.That(AudioBackends.GetSuitableBackends(),
+            Is.EqualTo(new[] { AudioBackend.Automatic, AudioBackend.BASS, AudioBackend.SDL }),
+            "Automatic first, matching RendererTypes.GetSuitableRenderers.");
+    }
+
+    /// <summary>
+    /// A new backend should be a deliberate decision about whether users see it, not an omission.
+    /// </summary>
+    [Test]
+    public void EveryBackendIsEitherOfferedOrDeliberatelyHidden()
+    {
+        AudioBackend[] hidden = [AudioBackend.SDLManaged];
+
+        var accounted = AudioBackends.GetSuitableBackends().Concat(hidden).ToArray();
+
+        Assert.That(accounted, Is.EquivalentTo(Enum.GetValues<AudioBackend>()),
+            "A backend was added to the AudioBackend enum without deciding whether GetSuitableBackends should offer "
+            + "it. Add it to the list, or to this test's `hidden` array with a reason.");
+    }
+
+    /// <summary>
+    /// Hiding it from the dropdown must not make it unreachable.
+    /// </summary>
+    [Test]
+    public void TheHiddenBackendIsStillAValidSetting()
+    {
+        Assert.That(Enum.IsDefined(AudioBackend.SDLManaged), Is.True,
+            "SDLManaged has to stay a parseable framework.ini value: it is what a bug report is asked to try, and what "
+            + "the parity tests select.");
+    }
+}

--- a/Sakura.Framework.Tests/Audio/DeviceStarvationTrackerTest.cs
+++ b/Sakura.Framework.Tests/Audio/DeviceStarvationTrackerTest.cs
@@ -1,0 +1,109 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// The managed mixer's starvation measurement, which has to survive the thread doing the measuring
+/// being stopped for the whole event.
+/// </summary>
+[TestFixture]
+public class DeviceStarvationTrackerTest
+{
+    [Test]
+    public void CountsNothingWhenTheQueueOutlastsTheGap()
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        tracker.Observe(gapMs: 5, playableMs: 80, anythingPlaying: true);
+
+        Assert.That(tracker.StarvedMilliseconds, Is.Zero,
+            "80 ms of queued audio covers a 5 ms gap with plenty to spare. This is every normal iteration.");
+    }
+
+    [Test]
+    public void CountsTheGapBeyondWhatWasQueued()
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        tracker.Observe(gapMs: 100, playableMs: 80, anythingPlaying: true);
+
+        Assert.That(tracker.StarvedMilliseconds, Is.EqualTo(20).Within(0.01),
+            "The device can play at most what it was holding; the rest of the gap is silence.");
+    }
+
+    /// <summary>
+    /// A case that GC pause long enough to empty the queue also suspends the mix loop.
+    /// </summary>
+    [Test]
+    public void ReportsALongFreezeInFullRatherThanAsOneTick()
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        tracker.Observe(gapMs: 700, playableMs: 80, anythingPlaying: true);
+
+        Assert.That(tracker.StarvedMilliseconds, Is.EqualTo(620).Within(0.01),
+            "A 700 ms freeze against an 80 ms queue is 620 ms of silence, and the whole point is that the thread "
+            + "reporting it was not running for any of it.");
+    }
+
+    [Test]
+    public void IgnoresAnIdleDevice()
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        tracker.Observe(gapMs: 700, playableMs: 0, anythingPlaying: false);
+
+        Assert.That(tracker.StarvedMilliseconds, Is.Zero,
+            "An empty queue with nothing playing is a device with nothing to do, not a dropout.");
+    }
+
+    [Test]
+    public void Accumulates()
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        tracker.Observe(gapMs: 100, playableMs: 80, anythingPlaying: true);
+        tracker.Observe(gapMs: 50, playableMs: 10, anythingPlaying: true);
+        tracker.Observe(gapMs: 5, playableMs: 80, anythingPlaying: true);
+
+        Assert.That(tracker.StarvedMilliseconds, Is.EqualTo(60).Within(0.01));
+    }
+
+    [Test]
+    public void TreatsAnImpossibleQueueDepthAsEmpty()
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        // SDL_GetAudioStreamQueued returns -1 on error, and the manager's conversion could in principle
+        // pass a negative through. It must not be able to hide starvation by making the gap look covered.
+        tracker.Observe(gapMs: 30, playableMs: -100, anythingPlaying: true);
+
+        Assert.That(tracker.StarvedMilliseconds, Is.EqualTo(30).Within(0.01));
+    }
+
+    [TestCase(620.0, 10.0, 62)]
+    [TestCase(620.0, 21.33, 29)]
+    [TestCase(5.0, 10.0, 0)]
+    public void ExpressesStarvationAsACountOfMissedPeriods(double starvedMs, double periodMs, long expected)
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        tracker.Observe(starvedMs, 0, anythingPlaying: true);
+
+        Assert.That(tracker.CountIn(periodMs), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void CountIsZeroForANonsensePeriod()
+    {
+        var tracker = new DeviceStarvationTracker();
+
+        tracker.Observe(gapMs: 620, playableMs: 0, anythingPlaying: true);
+
+        Assert.That(tracker.CountIn(0), Is.Zero, "A zero-length period would otherwise divide by zero.");
+    }
+}

--- a/Sakura.Framework.Tests/Audio/OutputLatencyCompensatorTest.cs
+++ b/Sakura.Framework.Tests/Audio/OutputLatencyCompensatorTest.cs
@@ -1,0 +1,115 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// The maths that turns a mix cursor into an audible position, on its own.
+/// </summary>
+/// <remarks>
+/// Tested apart from either channel because both use it and because the interesting cases — a rate
+/// change mid-buffer, a missed reset — are awkward to provoke through a real voice and trivial to
+/// state here.
+/// </remarks>
+[TestFixture]
+public class OutputLatencyCompensatorTest
+{
+    [Test]
+    public void SubtractsTheQueueDepth()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        Assert.That(compensator.Compensate(100, 20, 1.0), Is.EqualTo(80).Within(1e-9),
+            "A position 100 ms into the source with 20 ms still queued is 80 ms of audible music.");
+    }
+
+    [Test]
+    public void ReportsZeroRatherThanNegativeBeforeAnythingIsAudible()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        Assert.That(compensator.Compensate(5, 20, 1.0), Is.Zero,
+            "For the first buffer of a track nothing has reached the listener, and the position for that is zero, not -15.");
+    }
+
+    [Test]
+    public void ScalesTheSubtractionByPlaybackRate()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        Assert.That(compensator.Compensate(1000, 20, 2.0), Is.EqualTo(960).Within(1e-9),
+            "At double speed a 20 ms buffer of output was made from 40 ms of the song.");
+
+        compensator.Reset();
+
+        Assert.That(compensator.Compensate(1000, 20, 0.5), Is.EqualTo(990).Within(1e-9),
+            "And at half speed, from 10 ms of it.");
+    }
+
+    [Test]
+    public void AdvancesAsTheQueueDrainsEvenWhileTheCursorIsStill()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        // What a paused-but-still-draining device looks like: the mixer has stopped producing, but
+        // what it already produced is still being heard.
+        Assert.That(compensator.Compensate(100, 20, 1.0), Is.EqualTo(80).Within(1e-9));
+        Assert.That(compensator.Compensate(100, 10, 1.0), Is.EqualTo(90).Within(1e-9));
+        Assert.That(compensator.Compensate(100, 0, 1.0), Is.EqualTo(100).Within(1e-9));
+    }
+
+    [Test]
+    public void HoldsPositionRatherThanSteppingBackwards()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        double before = compensator.Compensate(1000, 20, 1.0);
+
+        // A rate change applies to the whole queue at once, even though the queued audio was mixed at
+        // the old rate. Uncorrected that reads as the song jumping backwards by most of a buffer.
+        double after = compensator.Compensate(1000, 20, 2.0);
+
+        Assert.That(after, Is.EqualTo(before),
+            "A clock fed a position that moves backwards snaps instead of interpolating.");
+    }
+
+    [Test]
+    public void ResumesAdvancingOnceTheRealPositionCatchesUp()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        compensator.Compensate(1000, 20, 1.0);
+        compensator.Compensate(1000, 20, 2.0);
+
+        Assert.That(compensator.Compensate(1060, 20, 2.0), Is.EqualTo(1020).Within(1e-9),
+            "The hold is a floor, not a freeze: once the source has moved past it the real value is reported again.");
+    }
+
+    [Test]
+    public void ResetLetsThePositionJumpBackwards()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        compensator.Compensate(50_000, 20, 1.0);
+        compensator.Reset();
+
+        Assert.That(compensator.Compensate(1000, 20, 1.0), Is.EqualTo(980).Within(1e-9),
+            "A seek is the position genuinely moving, and Reset is how a caller says so.");
+    }
+
+    [Test]
+    public void RecoversWithinOneBufferFromAMissedReset()
+    {
+        var compensator = new OutputLatencyCompensator();
+
+        compensator.Compensate(50_000, 20, 1.0);
+
+        // Deliberately no Reset: this is the bug being guarded against, not the supported path.
+        Assert.That(compensator.Compensate(1000, 20, 1.0), Is.EqualTo(980).Within(1e-9),
+            "A backwards jump larger than the window that could have produced it is a real reposition, "
+            + "so a forgotten Reset costs a glitch rather than freezing the position for the rest of the track.");
+    }
+}

--- a/Sakura.Framework.Tests/Audio/SakuraAudioNativeTest.cs
+++ b/Sakura.Framework.Tests/Audio/SakuraAudioNativeTest.cs
@@ -37,6 +37,12 @@ public class SakuraAudioNativeTest
     {
         public int SampleRate => rate;
         public int Channels => channels;
+
+        /// <summary>
+        /// Output latency to report, so a test can pin position compensation.
+        /// </summary>
+        public double OutputLatencyMs { get; set; }
+
         public void EnqueueAction(Action action) => action();
         public void WakeDecoder() { }
     }

--- a/Sakura.Framework.Tests/Audio/SdlAudioChannelTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlAudioChannelTest.cs
@@ -27,17 +27,22 @@ public class SdlAudioChannelTest
         public int SampleRate => rate;
         public int Channels => channels;
 
-        public readonly Queue<Action> Pending = new Queue<Action>();
+        /// <summary>
+        /// Output latency to report, so a test can pin position compensation.
+        /// </summary>
+        public double OutputLatencyMs { get; set; }
+
+        private readonly Queue<Action> pending = new Queue<Action>();
         public int WakeCount;
 
-        public void EnqueueAction(Action action) => Pending.Enqueue(action);
+        public void EnqueueAction(Action action) => pending.Enqueue(action);
         public void WakeDecoder() => WakeCount++;
 
         /// <summary>Runs everything queued, including anything queued while draining.</summary>
         public void Drain()
         {
-            while (Pending.Count > 0)
-                Pending.Dequeue().Invoke();
+            while (pending.Count > 0)
+                pending.Dequeue().Invoke();
         }
     }
 
@@ -172,6 +177,50 @@ public class SdlAudioChannelTest
         context.Drain();
 
         Assert.That(channel.CurrentTime, Is.EqualTo(500).Within(1));
+    }
+
+    [Test]
+    public void CurrentTime_SubtractsWhatIsStillQueuedForTheDevice()
+    {
+        var context = new StubContext { OutputLatencyMs = 20 };
+        var channel = playing(context, constant(0.5f, 44100));
+
+        // 100 ms of source consumed, 20 ms of it still sitting in the device queue unheard.
+        channel.Fill(new float[4410 * channels]);
+
+        Assert.That(channel.CurrentTime, Is.EqualTo(80).Within(1),
+            "CurrentTime feeds TrackClock, so it has to mean what the listener is hearing rather than what the mixer has reached.");
+    }
+
+    [Test]
+    public void CurrentTime_KeepsAdvancingWhileTheQueueDrainsAfterAPause()
+    {
+        var context = new StubContext { OutputLatencyMs = 20 };
+        var channel = playing(context, constant(0.5f, 44100));
+
+        channel.Fill(new float[4410 * channels]);
+        channel.Pause();
+        context.Drain();
+
+        double whilePaused = channel.CurrentTime;
+
+        // The mixer has stopped producing, but the device is still playing what it was given.
+        context.OutputLatencyMs = 0;
+
+        Assert.That(channel.CurrentTime, Is.GreaterThan(whilePaused),
+            "Audio already handed to the device is still heard after a pause, so the audible position is still moving.");
+    }
+
+    [Test]
+    public void CurrentTime_IsUncompensatedWhereThereIsNothingQueued()
+    {
+        var context = new StubContext();
+        var channel = playing(context, constant(0.5f, 44100));
+
+        channel.Fill(new float[4410 * channels]);
+
+        Assert.That(channel.CurrentTime, Is.EqualTo(100).Within(1),
+            "With an empty queue the mix cursor and the audible position are the same thing.");
     }
 
     [Test]

--- a/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
@@ -171,10 +171,28 @@ public class SdlAudioEngineTest
     [OneTimeSetUp]
     public void UseDummyAudioDriver() => SDL_SetHint(SDL_HINT_AUDIO_DRIVER, "dummy");
 
-    [Test]
-    public void Manager_OpensADeviceAndReportsItsFormat()
+    /// <summary>
+    /// Opens a manager on one of the two mix engines. Every test below that is not specific to one of
+    /// them runs against both.
+    /// </summary>
+    private static SDLAudioManager createManager(bool native)
     {
-        using var manager = new SDLAudioManager();
+        if (native && !SakuraAudioEngine.IsAvailable)
+            Assert.Ignore("libsakura-audio is not available for this platform, so the native mix engine cannot be tested here.");
+
+        var manager = new SDLAudioManager(useNativeMixEngine: native);
+
+        Assert.That(manager.UsesNativeMixEngine, Is.EqualTo(native),
+            native ? "Expected the native mix engine, got the managed one." : "Expected the managed mix engine, got the native one.");
+
+        return manager;
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_OpensADeviceAndReportsItsFormat(bool native)
+    {
+        using var manager = createManager(native);
 
         // If the hint did not take, these tests would be silently relying on real hardware and
         // would not survive CI.
@@ -189,10 +207,13 @@ public class SdlAudioEngineTest
         }
     }
 
+    /// <summary>
+    /// The managed mixer's own property: it pushes, so there is a queue to keep full.
+    /// </summary>
     [Test]
-    public void Manager_KeepsTheDeviceQueueFed()
+    public void Manager_ManagedMixerKeepsTheDeviceQueueFed()
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native: false);
 
         // The mix thread should have pushed audio without anything playing at all — silence still
         // has to reach the device or the queue starves.
@@ -204,10 +225,11 @@ public class SdlAudioEngineTest
         Assert.That(queued, Is.GreaterThan(0), "The mix thread is not filling the device queue.");
     }
 
-    [Test]
-    public void Manager_PlaysASampleThroughToCompletion()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_PlaysASampleThroughToCompletion(bool native)
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native);
 
         var sample = manager.CreateSample(open("Samples.test.wav"));
         Assert.That(sample.Length, Is.EqualTo(424.6).Within(5).Percent);
@@ -229,10 +251,11 @@ public class SdlAudioEngineTest
         Assert.That(ended, Is.True, "Sample never reported reaching its end.");
     }
 
-    [Test]
-    public void Manager_PlaysAStreamingTrackAndAdvancesItsPosition()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_PlaysAStreamingTrackAndAdvancesItsPosition(bool native)
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native);
 
         var track = manager.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
         Assert.That(track.Length, Is.GreaterThan(1000));
@@ -254,10 +277,11 @@ public class SdlAudioEngineTest
         manager.Update(0);
     }
 
-    [Test]
-    public void Manager_PublishesItsStatistics()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_PublishesItsStatistics(bool native)
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native);
 
         var sample = manager.CreateSample(open("Samples.long.mp3"));
         sample.Play();
@@ -273,18 +297,30 @@ public class SdlAudioEngineTest
         Assert.Multiple(() =>
         {
             Assert.That(GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value, Is.GreaterThan(0));
-            Assert.That(GlobalStatistics.Get<long>("Audio", "SDL Mix Block (µs)").Value, Is.GreaterThan(0));
-            Assert.That(GlobalStatistics.Get<double>("Audio", "SDL Queued (ms)").Value, Is.GreaterThan(0));
+
+            if (native)
+            {
+                // Renamed rather than reused: there is a real device callback to time now, where the
+                // managed mixer could only time a block it chose to push.
+                Assert.That(GlobalStatistics.Get<long>("Audio", "SDL Callback (µs)").Value, Is.GreaterThan(0));
+                Assert.That(GlobalStatistics.Get<long>("Audio", "SDL Put Failures").Value, Is.Zero);
+            }
+            else
+            {
+                Assert.That(GlobalStatistics.Get<long>("Audio", "SDL Mix Block (µs)").Value, Is.GreaterThan(0));
+                Assert.That(GlobalStatistics.Get<double>("Audio", "SDL Queued (ms)").Value, Is.GreaterThan(0));
+            }
         });
     }
 
     /// <summary>
     /// A steady multi-second play with no underrunning is the whole point of the decode-ahead design.
     /// </summary>
-    [Test]
-    public void Manager_PlaysWithoutUnderrunning()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_PlaysWithoutUnderrunning(bool native)
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native);
 
         long before = GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value;
 
@@ -313,10 +349,11 @@ public class SdlAudioEngineTest
     /// <see cref="AudioChannelExtensions.AddLowPassFilter"/> has to recognise this backend's channels
     /// too, or filtering silently becomes a no-op the moment the backend is switched.
     /// </summary>
-    [Test]
-    public void AddLowPassFilter_AttachesToAnSdlChannel()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AddLowPassFilter_AttachesToAnSdlChannel(bool native)
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native);
 
         var sample = manager.CreateSample(open("Samples.long.mp3"));
         var channel = sample.GetChannel();
@@ -338,10 +375,11 @@ public class SdlAudioEngineTest
         manager.Update(0);
     }
 
-    [Test]
-    public void Manager_MasterVolumeScalesBothMixers()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_MasterVolumeScalesBothMixers(bool native)
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native);
 
         manager.TrackVolume.Value = 0.5;
         manager.SampleVolume.Value = 0.25;
@@ -354,10 +392,11 @@ public class SdlAudioEngineTest
         }
     }
 
-    [Test]
-    public void Manager_StopAllStopsEveryChannel()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_StopAllStopsEveryChannel(bool native)
     {
-        using var manager = new SDLAudioManager();
+        using var manager = createManager(native);
 
         var sample = manager.CreateSample(open("Samples.long.mp3"));
         var first = sample.Play();
@@ -375,10 +414,11 @@ public class SdlAudioEngineTest
         }
     }
 
-    [Test]
-    public void Manager_DisposeIsCleanWhileAudioIsPlaying()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_DisposeIsCleanWhileAudioIsPlaying(bool native)
     {
-        var manager = new SDLAudioManager();
+        var manager = createManager(native);
 
         var sample = manager.CreateSample(open("Samples.long.mp3"));
         sample.Play();
@@ -391,6 +431,137 @@ public class SdlAudioEngineTest
         Assert.DoesNotThrow(() => manager.Dispose());
         Assert.DoesNotThrow(() => manager.Dispose());
     }
+
+    #region Native mix engine only
+
+    /// <summary>
+    /// A seek on a streaming voice is the only place all three threads have to cooperate: this side
+    /// moves the decoder, the audio thread performs the ring discard, and neither may write until the
+    /// other has finished.
+    /// </summary>
+    [Test]
+    public void NativeEngine_SeekLandsAndPlaybackResumesFromTheNewPosition()
+    {
+        using var manager = createManager(native: true);
+
+        var track = manager.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+        var channel = track.GetChannel();
+        channel.Play();
+
+        var timeout = Stopwatch.StartNew();
+
+        while (channel.CurrentTime < 200 && timeout.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        Assert.That(channel.CurrentTime, Is.GreaterThanOrEqualTo(200));
+
+        channel.CurrentTime = 1000;
+
+        // Immediately, with no pumping at all. The audio thread has not applied the seek yet, and
+        // reporting the old cursor against the new base here is what would read as a jump backwards.
+        Assert.That(channel.CurrentTime, Is.EqualTo(1000).Within(1), "The seek was not reported until it had been applied.");
+
+        timeout.Restart();
+
+        while (channel.CurrentTime < 1200 && timeout.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        // Past the target rather than merely at it: the ring was discarded, the decoder moved, and the
+        // device is being fed from the new position.
+        Assert.That(channel.CurrentTime, Is.GreaterThanOrEqualTo(1200), "Playback did not resume after the seek.");
+
+        channel.Dispose();
+        manager.Update(0);
+    }
+
+    /// <summary>
+    /// A looping stream cannot wrap itself inside the engine — only this side can move a decoder — so
+    /// the voice publishes the end and waits to be told where to go.
+    /// </summary>
+    [Test]
+    public void NativeEngine_LoopingTrackWrapsAndKeepsPlaying()
+    {
+        using var manager = createManager(native: true);
+
+        var track = manager.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
+        var channel = track.GetChannel();
+
+        // Tracks loop by default on both backends.
+        Assert.That(channel.Looping, Is.True);
+
+        int ends = 0;
+        channel.OnEnd += () => ends++;
+
+        channel.Play();
+        channel.CurrentTime = Math.Max(0, track.Length - 300);
+
+        var timeout = Stopwatch.StartNew();
+
+        while (ends == 0 && timeout.Elapsed < TimeSpan.FromSeconds(15))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        Assert.That(ends, Is.GreaterThan(0), "A looping track never reported reaching its end.");
+        Assert.That(channel.IsRunning.Value, Is.True, "A looping track stopped at the loop point.");
+
+        timeout.Restart();
+
+        while (channel.CurrentTime > 1000 && timeout.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        Assert.That(channel.CurrentTime, Is.LessThan(1000), "A looping track did not wrap back to its restart point.");
+
+        channel.Dispose();
+        manager.Update(0);
+    }
+
+    /// <summary>
+    /// The engine holds the decoded PCM, and every voice playing it holds a reference — so evicting a
+    /// sample from a store mid-hitsound must not cut the hitsound off.
+    /// </summary>
+    [Test]
+    public void NativeEngine_SampleDisposedWhilePlayingKeepsItsVoiceAlive()
+    {
+        using var manager = createManager(native: true);
+
+        var sample = manager.CreateSample(open("Samples.test.wav"));
+        var channel = sample.Play();
+
+        Assert.That(channel, Is.Not.Null);
+
+        bool ended = false;
+        channel.OnEnd += () => ended = true;
+
+        manager.Update(0);
+
+        // The loader is done with it; the voice is not. (ISample does not carry IDisposable — a store
+        // evicting an entry is what does this in the real app.)
+        (sample as IDisposable)?.Dispose();
+        manager.Update(0);
+
+        var timeout = Stopwatch.StartNew();
+
+        while (!ended && timeout.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            manager.Update(0);
+            Thread.Sleep(10);
+        }
+
+        Assert.That(ended, Is.True, "A voice was cut off when the sample it shares was disposed.");
+    }
+
+    #endregion
 
     private static string writeTempCopy(string resource)
     {

--- a/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
+++ b/Sakura.Framework.Tests/Audio/SdlAudioEngineTest.cs
@@ -39,6 +39,12 @@ public class SdlAudioEngineTest
     {
         public int SampleRate => rate;
         public int Channels => channels;
+
+        /// <summary>
+        /// Output latency to report, so a test can pin position compensation.
+        /// </summary>
+        public double OutputLatencyMs { get; set; }
+
         public void EnqueueAction(Action action) => action();
         public void WakeDecoder() { }
     }
@@ -175,12 +181,12 @@ public class SdlAudioEngineTest
     /// Opens a manager on one of the two mix engines. Every test below that is not specific to one of
     /// them runs against both.
     /// </summary>
-    private static SDLAudioManager createManager(bool native)
+    private static SDLAudioManager createManager(bool native, int deviceBufferFrames = SDLAudioManager.DEFAULT_DEVICE_BUFFER_FRAMES)
     {
         if (native && !SakuraAudioEngine.IsAvailable)
             Assert.Ignore("libsakura-audio is not available for this platform, so the native mix engine cannot be tested here.");
 
-        var manager = new SDLAudioManager(useNativeMixEngine: native);
+        var manager = new SDLAudioManager(useNativeMixEngine: native, deviceBufferFrames);
 
         Assert.That(manager.UsesNativeMixEngine, Is.EqualTo(native),
             native ? "Expected the native mix engine, got the managed one." : "Expected the managed mix engine, got the native one.");
@@ -206,6 +212,200 @@ public class SdlAudioEngineTest
             Assert.That(manager.SampleMixer, Is.Not.Null);
         }
     }
+
+    #region Output latency
+
+    /// <summary>
+    /// The device buffer is a setting, and asking for a smaller one gets a
+    /// smaller one.
+    /// </summary>
+    /// <remarks>
+    /// Native only, because the hint is only applied there — the managed mixer's latency is its own
+    /// push queue and shrinking the device buffer underneath it would buy nothing.
+    /// </remarks>
+    [TestCase(128)]
+    [TestCase(256)]
+    [TestCase(512)]
+    public void Manager_AsksSdlForTheConfiguredDeviceBuffer(int frames)
+    {
+        using var manager = createManager(native: true, frames);
+
+        Assert.That(manager.DeviceBufferFrames, Is.EqualTo(frames),
+            "SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES did not take. On real hardware a driver may round this; the dummy driver has no excuse.");
+    }
+
+    /// <summary>
+    /// A nonsense buffer size is clamped rather than passed to a driver.
+    /// </summary>
+    [TestCase(1)]
+    [TestCase(1_000_000)]
+    public void Manager_ClampsAnOutOfRangeDeviceBuffer(int frames)
+    {
+        using var manager = createManager(native: true, frames);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(manager.DeviceBufferFrames, Is.GreaterThanOrEqualTo(32));
+            Assert.That(manager.DeviceBufferFrames, Is.LessThanOrEqualTo(8192));
+        }
+    }
+
+    /// <summary>
+    /// The shipped default is the low-latency one, and it is honoured.
+    /// </summary>
+    /// <remarks>
+    /// Pinned as its own test because the default is a decision with evidence behind it — see
+    /// AUDIO_SDL.md — rather than an arbitrary constant, and because changing it silently is exactly
+    /// the failure mode the risk table warns about in both directions.
+    /// </remarks>
+    [Test]
+    public void Manager_DefaultsToALowLatencyDeviceBuffer()
+    {
+        using var manager = createManager(native: true);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(SDLAudioManager.DEFAULT_DEVICE_BUFFER_FRAMES, Is.EqualTo(128));
+            Assert.That(manager.DeviceBufferFrames, Is.EqualTo(128));
+        }
+    }
+
+    /// <summary>
+    /// Zero means "whatever SDL was going to do", which is the escape hatch for a platform where the
+    /// hint makes things worse.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_LeavesTheDeviceBufferAloneWhenNotConfigured(bool native)
+    {
+        using var manager = createManager(native, deviceBufferFrames: 0);
+
+        Assert.That(manager.DeviceBufferFrames, Is.GreaterThan(0),
+            "The device still has a buffer; the setting only decides who chose its size.");
+    }
+
+    /// <summary>
+    /// The reported latency includes the device buffer, not just SDL's queue.
+    /// </summary>
+    /// <remarks>
+    /// This is the assertion that would have caught the first version of this code. In the callback
+    /// model SDL asks the callback for exactly what it needs and takes it immediately, so the stream
+    /// queue is empty whenever anything looks at it — a latency read from the queue alone is zero on
+    /// the native engine, and the compensation it feeds does nothing at all. On real CoreAudio the
+    /// numbers are 5.33 ms native at a 256-frame buffer against 106.67 ms managed; see AUDIO_SDL.md.
+    /// </remarks>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_ReportsOutputLatencyIncludingTheDeviceBuffer(bool native)
+    {
+        using var manager = createManager(native);
+
+        Thread.Sleep(200);
+        manager.Update(0);
+
+        double bufferMs = manager.DeviceBufferFrames / (double)manager.SampleRate * 1000.0;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(manager.OutputLatencyMs, Is.GreaterThanOrEqualTo(bufferMs).Within(0.01),
+                "Audio the device has been given but has not finished playing is still ahead of the listener.");
+            Assert.That(manager.OutputLatencyMs, Is.LessThan(1000),
+                "An output latency of a second is not a latency, it is a bug.");
+        }
+    }
+
+    /// <summary>
+    /// The managed mixer's latency is its push queue on top of the device buffer, and it is much
+    /// larger — which is the whole reason the native engine exists.
+    /// </summary>
+    [Test]
+    public void Manager_ManagedMixerCostsMuchMoreLatencyThanTheNativeOne()
+    {
+        using var managed = createManager(native: false);
+
+        Thread.Sleep(300);
+        managed.Update(0);
+
+        double bufferMs = managed.DeviceBufferFrames / (double)managed.SampleRate * 1000.0;
+
+        Assert.That(managed.OutputLatencyMs, Is.GreaterThan(bufferMs * 2),
+            "The push model keeps target_queue_ms ahead of the device on purpose; if that is not showing up in the "
+            + "reported latency then the queue term is not being counted.");
+    }
+
+    /// <summary>
+    /// A device that is keeping up never has its buffer raised behind the user's back.
+    /// </summary>
+    /// <remarks>
+    /// The failure this guards is the expensive one. A watchdog that fires spuriously does not crash
+    /// or log anything alarming — it quietly writes a larger buffer into every user's config and
+    /// gives back the latency this whole backend exists to win, and the only symptom is that the
+    /// numbers in AUDIO_SDL.md stop matching reality. The threshold logic is covered in
+    /// <see cref="UnderrunWatchdogTest"/>; this covers the wiring being pointed at a real counter.
+    /// </remarks>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_DoesNotRaiseTheBufferOnAHealthyDevice(bool native)
+    {
+        int persisted = 0;
+
+        using var manager = new SDLAudioManager(useNativeMixEngine: native,
+            SDLAudioManager.DEFAULT_DEVICE_BUFFER_FRAMES, next => persisted = next);
+
+        if (native && !manager.UsesNativeMixEngine)
+            Assert.Ignore("libsakura-audio is not available for this platform.");
+
+        // Well past several watchdog windows, on a device with nothing to complain about.
+        for (int i = 0; i < 10; i++)
+        {
+            Thread.Sleep(20);
+            manager.Update(UnderrunWatchdog.CHECK_INTERVAL_MS);
+        }
+
+        Assert.That(persisted, Is.Zero,
+            "The device was keeping up, so nothing should have been written to the user's configuration.");
+    }
+
+    /// <summary>
+    /// The backoff is optional wiring, not a requirement for the manager to run.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_RunsWithoutSomewhereToPersistABackoff(bool native)
+    {
+        using var manager = createManager(native);
+
+        for (int i = 0; i < 3; i++)
+            manager.Update(UnderrunWatchdog.CHECK_INTERVAL_MS);
+
+        Assert.That(manager.DeviceBufferFrames, Is.GreaterThan(0));
+    }
+
+    /// <summary>
+    /// The device-change poll runs and finds nothing to report on a device that has not changed.
+    /// </summary>
+    /// <remarks>
+    /// A weak assertion on purpose: swapping the output device out from under a running stream is not
+    /// something a test can stage, so what is covered here is that the poll executes, that it does not
+    /// mistake the first reading for a change, and that it leaves the recorded buffer size intact.
+    /// The behaviour on an actual device change is verified by hand — see AUDIO_SDL.md.
+    /// </remarks>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Manager_DeviceChangePollIsQuietWhenNothingChanged(bool native)
+    {
+        using var manager = createManager(native);
+
+        int before = manager.DeviceBufferFrames;
+
+        // Long enough a frame that the once-a-second poll fires, several times over.
+        manager.Update(2000);
+        manager.Update(2000);
+
+        Assert.That(manager.DeviceBufferFrames, Is.EqualTo(before));
+    }
+
+    #endregion
 
     /// <summary>
     /// The managed mixer's own property: it pushes, so there is a queue to keep full.
@@ -322,8 +522,6 @@ public class SdlAudioEngineTest
     {
         using var manager = createManager(native);
 
-        long before = GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value;
-
         var track = manager.CreateTrackFromFile(writeTempCopy("Tracks.test.mp3"));
         var channel = track.GetChannel();
         channel.Play();
@@ -337,9 +535,11 @@ public class SdlAudioEngineTest
         }
 
         manager.Update(0);
-        long after = GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value;
 
-        Assert.That(after - before, Is.Zero, "The device queue ran dry during steady playback.");
+        // This manager's own count, not the "SDL Underruns" statistic. That statistic is process-global
+        // and holds whatever manager updated last, so a delta taken across it is really a delta across
+        // whichever test ran before this one — which made this assertion flaky rather than wrong.
+        Assert.That(manager.Underruns, Is.Zero, "The device queue ran dry during steady playback.");
 
         channel.Dispose();
         manager.Update(0);

--- a/Sakura.Framework.Tests/Audio/UnderrunWatchdogTest.cs
+++ b/Sakura.Framework.Tests/Audio/UnderrunWatchdogTest.cs
@@ -1,0 +1,155 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// When a starving device means the buffer is wrong, and what to do about it.
+/// </summary>
+/// <remarks>
+/// The policy that lets the framework ship an aggressive device buffer. It is tested apart from the
+/// manager because provoking real underruns on demand is not something a test can do, while the
+/// decisions — ignore a burst, act on sustained starvation, act only once, know when doubling is not
+/// the answer — are pure counting and timing.
+/// </remarks>
+[TestFixture]
+public class UnderrunWatchdogTest
+{
+    private const double interval = UnderrunWatchdog.CHECK_INTERVAL_MS;
+
+    [Test]
+    public void SaysNothingOnAHealthyDevice()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        for (int i = 0; i < 10; i++)
+            Assert.That(watchdog.Poll(0, interval), Is.Null);
+    }
+
+    [Test]
+    public void SaysNothingBeforeTheWindowHasElapsed()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        Assert.That(watchdog.Poll(1000, interval - 1), Is.Null,
+            "A thousand underruns is plainly wrong, but reporting it before a full window means reporting a rate "
+            + "measured over an unknown amount of time.");
+    }
+
+    [Test]
+    public void IgnoresABurstBelowTheThreshold()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        Assert.That(watchdog.Poll(UnderrunWatchdog.THRESHOLD - 1, interval), Is.Null,
+            "Startup, a device change and a hitch elsewhere in the app all produce a few underruns and all recover "
+            + "on their own. Acting on those would make the warning meaningless.");
+    }
+
+    [Test]
+    public void ReportsSustainedStarvation()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        Assert.That(watchdog.Poll(UnderrunWatchdog.THRESHOLD, interval), Is.EqualTo(UnderrunWatchdog.THRESHOLD));
+    }
+
+    [Test]
+    public void ReportsOnlyOncePerRun()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        Assert.That(watchdog.Poll(100, interval), Is.Not.Null);
+
+        for (int i = 0; i < 10; i++)
+        {
+            Assert.That(watchdog.Poll(100 + (i + 1) * 100, interval), Is.Null,
+                "A device that is underrunning keeps underrunning. Reporting every window buries the log, and backing "
+                + "off every window would take a machine from 128 frames to 1024 in twenty seconds on one bad patch.");
+        }
+    }
+
+    [Test]
+    public void MeasuresARateRatherThanATotal()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        // A long-running session that accumulated underruns slowly: well past the threshold in total,
+        // never near it in any one window.
+        long total = 0;
+
+        for (int i = 0; i < 50; i++)
+        {
+            total += UnderrunWatchdog.THRESHOLD - 1;
+
+            Assert.That(watchdog.Poll(total, interval), Is.Null,
+                "Occasional underruns over an hour are not the same failure as steady crackling, and only the second "
+                + "one means the buffer is the wrong size.");
+        }
+    }
+
+    [Test]
+    public void AccumulatesPartialFramesUpToAWindow()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        // A realistic frame time rather than one poll per window.
+        for (double elapsed = 0; elapsed < interval - 16; elapsed += 16)
+            Assert.That(watchdog.Poll(100, 16), Is.Null);
+
+        Assert.That(watchdog.Poll(100, 16), Is.Not.Null, "The window should close on accumulated frame time.");
+    }
+
+    [TestCase(128, 256)]
+    [TestCase(256, 512)]
+    [TestCase(512, 1024)]
+    public void BacksOffByDoubling(int current, int expected)
+    {
+        Assert.That(UnderrunWatchdog.NextBufferSize(current), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void DoesNotBackOffPastTheCap()
+    {
+        Assert.That(UnderrunWatchdog.NextBufferSize(UnderrunWatchdog.MAX_AUTO_BACKOFF_FRAMES), Is.Null,
+            "1024 frames is roughly what SDL picks unprompted, so past it 'the buffer is too small' has stopped being "
+            + "a credible explanation and doubling trades latency for nothing.");
+    }
+
+    [Test]
+    public void DoesNotBackOffAboveTheCap()
+    {
+        Assert.That(UnderrunWatchdog.NextBufferSize(4096), Is.Null);
+    }
+
+    [Test]
+    public void DoesNotBackOffWhenTheBufferWasNeverOurs()
+    {
+        Assert.That(UnderrunWatchdog.NextBufferSize(0), Is.Null,
+            "Zero means SDL chose the buffer, so it is already the driver's own preference and there is nothing for "
+            + "us to correct.");
+    }
+
+    [Test]
+    public void BackoffConvergesRatherThanRunningAway()
+    {
+        // One doubling per launch, as the manager applies it: a machine that keeps failing walks up to
+        // the cap and then stops asking.
+        int size = 128;
+        int launches = 0;
+
+        while (UnderrunWatchdog.NextBufferSize(size) is { } next)
+        {
+            size = next;
+            launches++;
+
+            Assert.That(launches, Is.LessThan(10), "Backoff is not converging.");
+        }
+
+        Assert.That(size, Is.EqualTo(UnderrunWatchdog.MAX_AUTO_BACKOFF_FRAMES));
+        Assert.That(launches, Is.EqualTo(3), "128 to 1024 should take three bad launches, not more.");
+    }
+}

--- a/Sakura.Framework.Tests/Configurations/ConfigManagerTest.cs
+++ b/Sakura.Framework.Tests/Configurations/ConfigManagerTest.cs
@@ -1,6 +1,7 @@
 // This code is part of the Sakura framework project. Licensed under the MIT License.
 // See the LICENSE file for full license text.
 
+using System;
 using System.IO;
 using NUnit.Framework;
 using Sakura.Framework.Configurations;
@@ -156,6 +157,72 @@ public class ConfigManagerTest
         Mode,
         Enabled,
         Amount
+    }
+
+    /// <summary>
+    /// A setting the file never mentioned is written back with its default, rather than staying absent
+    /// until something unrelated happens to change.
+    /// </summary>
+    [Test]
+    public void MissingSettingIsWrittenBackOnLoad()
+    {
+        writeFile("Mode = Slow\nAmount = 5\n");
+
+        var manager = new TestConfigManager(storage);
+
+        // No Flush: Load must repair the file by itself. Flushing would write the file unconditionally
+        // and the assertion would hold whether the repair exists — which is exactly how the
+        // first version of this test passed against the unfixed code.
+        manager.Load();
+
+        string written = readFile();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(written, Does.Contain("Enabled = True"), "The absent setting should have been written back.");
+            Assert.That(written, Does.Contain("Mode = Slow"), "A value the file did have must survive the rewrite.");
+            Assert.That(written, Does.Contain("Amount = 5"));
+        }
+    }
+
+    /// <summary>
+    /// The value written back is the default, since that is what a missing line means.
+    /// </summary>
+    [Test]
+    public void MissingSettingComesBackAtItsDefault()
+    {
+        writeFile("Enabled = False\n");
+
+        var manager = new TestConfigManager(storage);
+        manager.Load();
+
+        Assert.That(manager.Get<TestMode>(TestSetting.Mode).Value, Is.EqualTo(TestMode.Fast));
+        Assert.That(readFile(), Does.Contain("Mode = Fast"));
+    }
+
+    /// <summary>
+    /// A complete file is not rewritten just for being read.
+    /// </summary>
+    [Test]
+    public void CompleteFileIsNotRewrittenOnLoad()
+    {
+        var manager = new TestConfigManager(storage);
+        manager.Load();
+        manager.Flush();
+
+        string canonical = readFile();
+
+        File.SetLastWriteTimeUtc(Path.Combine(tempDir, "test.ini"), new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var second = new TestConfigManager(storage);
+        second.Load();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(readFile(), Is.EqualTo(canonical));
+            Assert.That(File.GetLastWriteTimeUtc(Path.Combine(tempDir, "test.ini")), Is.EqualTo(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+                "Loading a file that needs no repair should not write to disk at all.");
+        }
     }
 
     private class TestConfigManager : ConfigManager<TestSetting>

--- a/Sakura.Framework.Tests/Sakura.Framework.Tests.csproj
+++ b/Sakura.Framework.Tests/Sakura.Framework.Tests.csproj
@@ -33,15 +33,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Sakura.Framework\Sakura.Framework.csproj" />
   </ItemGroup>
-  <!--
-    libsakura-audio is not in the published Sakura.Framework.NativeLibraries package yet (shipping it
-    per RID is the packaging phase's job), so copy whatever native/sakura-audio/build holds next to the
-    test binary. Wildcards, so a machine that has not built it is silently skipped and the native mix
-    engine's tests report inconclusive instead of failing. Delete this once the package ships it.
-  -->
-  <ItemGroup>
-    <None Include="..\native\sakura-audio\build\libsakura-audio*.dylib" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" Visible="false" />
-    <None Include="..\native\sakura-audio\build\libsakura-audio*.so" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" Visible="false" />
-    <None Include="..\native\sakura-audio\build\sakura-audio*.dll" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" Visible="false" />
-  </ItemGroup>
 </Project>

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -274,7 +274,7 @@ public partial class App : Container, IFocusManager, IInputManagerProvider
 
     /// <summary>
     /// Create the audio manager used for this app, selected by
-    /// <see cref="FrameworkSetting.AudioBackend"/> and default to <see cref="BassAudioManager"/>.
+    /// <see cref="FrameworkSetting.AudioBackend"/> and default to <see cref="SDLAudioManager"/>
     /// </summary>
     protected virtual IAudioManager CreateAudioManager()
     {
@@ -285,13 +285,14 @@ public partial class App : Container, IFocusManager, IInputManagerProvider
 
         switch (backend)
         {
+            case AudioBackend.Automatic:
             case AudioBackend.SDL:
             case AudioBackend.SDLManaged:
                 try
                 {
                     var deviceBufferFrames = Host.FrameworkConfigManager.Get<int>(FrameworkSetting.AudioDeviceBufferFrames);
 
-                    return new SDLAudioManager(backend == AudioBackend.SDL, deviceBufferFrames.Value,
+                    return new SDLAudioManager(backend != AudioBackend.SDLManaged, deviceBufferFrames.Value,
                         next => deviceBufferFrames.Value = next);
                 }
                 catch (Exception e)

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -285,10 +285,13 @@ public partial class App : Container, IFocusManager, IInputManagerProvider
 
         switch (backend)
         {
+            // TODO: The "managed" and "unmanaged" should be hide from the user
+            // it's for dev so should do the way like we done in graphic backend (have extension method for setting)
             case AudioBackend.SDL:
+            case AudioBackend.SDLManaged:
                 try
                 {
-                    return new SDLAudioManager();
+                    return new SDLAudioManager(backend == AudioBackend.SDL);
                 }
                 catch (Exception e)
                 {

--- a/Sakura.Framework/App.cs
+++ b/Sakura.Framework/App.cs
@@ -285,13 +285,14 @@ public partial class App : Container, IFocusManager, IInputManagerProvider
 
         switch (backend)
         {
-            // TODO: The "managed" and "unmanaged" should be hide from the user
-            // it's for dev so should do the way like we done in graphic backend (have extension method for setting)
             case AudioBackend.SDL:
             case AudioBackend.SDLManaged:
                 try
                 {
-                    return new SDLAudioManager(backend == AudioBackend.SDL);
+                    var deviceBufferFrames = Host.FrameworkConfigManager.Get<int>(FrameworkSetting.AudioDeviceBufferFrames);
+
+                    return new SDLAudioManager(backend == AudioBackend.SDL, deviceBufferFrames.Value,
+                        next => deviceBufferFrames.Value = next);
                 }
                 catch (Exception e)
                 {

--- a/Sakura.Framework/Audio/AudioBackend.cs
+++ b/Sakura.Framework/Audio/AudioBackend.cs
@@ -22,8 +22,14 @@ public enum AudioBackend
     BASS,
 
     /// <summary>
-    /// The SDL3 audio backend
+    /// The SDL3 audio backend, mixing in libsakura-audio where it is available.
     /// </summary>
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    SDL
+    SDL,
+
+    /// <summary>
+    /// The SDL3 audio backend with its managed reference mixer, never the native one.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    SDLManaged
 }

--- a/Sakura.Framework/Audio/AudioBackends.cs
+++ b/Sakura.Framework/Audio/AudioBackends.cs
@@ -1,0 +1,30 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System.Collections.Generic;
+using Sakura.Framework.Audio.BassEngine;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Audio;
+
+/// <summary>
+/// Helpers for determining which <see cref="AudioBackend"/> values make sense to offer a user.
+/// </summary>
+public static class AudioBackends
+{
+    /// <summary>
+    /// The backends a user can meaningfully select, in display order.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Managed <see cref="SDLAudioManager"/> still be selectable for testing selectable by writing <c>AudioBackend = SDLManaged</c> into <c>framework.ini</c>,
+    /// but should be really use in worst case (e.g. libsakura-audio buggy, something really wrong) but most fallback still <see cref="BassAudioManager"/>
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyList<AudioBackend> GetSuitableBackends() =>
+    [
+        AudioBackend.Automatic,
+        AudioBackend.BASS,
+        AudioBackend.SDL
+    ];
+}

--- a/Sakura.Framework/Audio/AudioChannelExtensions.cs
+++ b/Sakura.Framework/Audio/AudioChannelExtensions.cs
@@ -106,6 +106,9 @@ public static class AudioChannelExtensions
             case SDLAudioChannel sdlChannel:
                 return sdlChannel.AttachLowPassFilter();
 
+            case SDLNativeAudioChannel nativeChannel:
+                return nativeChannel.AttachLowPassFilter();
+
             default:
                 return null;
         }

--- a/Sakura.Framework/Audio/BassEngine/BassAudioChannel.cs
+++ b/Sakura.Framework/Audio/BassEngine/BassAudioChannel.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Threading;
 using ManagedBass;
 using ManagedBass.Mix;
 using Sakura.Framework.Reactive;
@@ -200,23 +201,63 @@ internal class BassAudioChannel : IAudioChannel
     public Reactive<double> Tempo { get; } = new Reactive<double>(1.0);
     private double restartPoint;
 
+    /// <summary>
+    /// Where a posted-but-not-yet-applied seek was sent, in microseconds, or -1 when none is outstanding.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A seek is queued onto the audio thread rather than applied inline, so for up to one frame
+    /// <c>Bass.ChannelGetPosition</c> still reports the position being left. Pairing the old cursor with
+    /// a caller that believes it has already seeked reads as the track jumping backwards and then
+    /// forwards, which <c>TrackClock</c> turns into audible desync — and this backend is the default, so
+    /// it is the one where that mattered most.
+    /// </para>
+    /// <para>
+    /// So the target is reported until the seek lands, which is the same thing the SDL backend's native
+    /// engine does with its seek epoch. Found by the cross-backend conformance suite, which asked all
+    /// three backends whether a read straight after a seek sees the new position; only the native SDL
+    /// engine said yes.
+    /// </para>
+    /// <para>
+    /// Microseconds in a <c>long</c> so that the field can be published and cleared atomically without a
+    /// lock, since the getter is called from whichever thread wants a position.
+    /// </para>
+    /// </remarks>
+    private long pendingSeekMicroseconds = -1;
+
     public double CurrentTime
     {
         get
         {
             if (isDisposed)
                 return 0;
+
+            long pending = Interlocked.Read(ref pendingSeekMicroseconds);
+
+            if (pending >= 0)
+                return pending / 1000.0;
+
             long pos = Bass.ChannelGetPosition(ChannelHandle);
             return Bass.ChannelBytes2Seconds(ChannelHandle, pos) * 1000.0;
         }
         set
         {
             if (isDisposed) return;
+
+            long target = (long)(Math.Max(0, value) * 1000.0);
+            Interlocked.Exchange(ref pendingSeekMicroseconds, target);
+
             manager.EnqueueAction(() =>
             {
                 if (isDisposed) return;
+
                 long pos = Bass.ChannelSeconds2Bytes(ChannelHandle, value / 1000.0);
                 Bass.ChannelSetPosition(ChannelHandle, pos);
+
+                // Only if this is still the outstanding seek: a second one posted in the meantime owns
+                // the reported position now, and clearing it here would briefly report the position this
+                // seek landed on rather than the one the caller last asked for.
+                Interlocked.CompareExchange(ref pendingSeekMicroseconds, -1, target);
             });
         }
     }

--- a/Sakura.Framework/Audio/BassEngine/BassAudioChannel.cs
+++ b/Sakura.Framework/Audio/BassEngine/BassAudioChannel.cs
@@ -225,6 +225,48 @@ internal class BassAudioChannel : IAudioChannel
     /// </remarks>
     private long pendingSeekMicroseconds = -1;
 
+    /// <summary>
+    /// This channel's position as the listener is hearing it, in bytes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Bass.ChannelGetPosition</c> on a channel plugged into a BASSmix mixer is the <em>decoding</em>
+    /// position: how far the mixer has pulled the source, which runs ahead of what is audible by
+    /// however much of the mixer's playback buffer is filled — 100 ms, set in
+    /// <see cref="BassAudioManager"/>. Reporting that as <see cref="CurrentTime"/> puts everything
+    /// synced to the music a tenth of a second ahead of the music, which for a rhythm game is the
+    /// difference between a chart that lines up and one that does not.
+    /// </para>
+    /// <para>
+    /// <c>BassMix.ChannelGetPosition</c> is BASS's own answer to the same question with the mixer's
+    /// buffering taken off, and it is available because <see cref="BassAudioMixer"/> adds every channel
+    /// with <c>MixerChanBuffer</c>. Measured on real hardware at ~115 ms behind the decoding position,
+    /// which is the 100 ms playback buffer plus the device's own 17 ms
+    /// </para>
+    /// </remarks>
+    private long audiblePosition()
+    {
+        // Only while it is actually playing. BASSmix answers from a record of where the source was in
+        // the mixer's output going back one buffer, so a channel that has just been stopped and rewound
+        // is still described by that record as being where it was before — Stop would stop rewinding as
+        // far as any caller could tell. It is also the right answer for a paused channel: the mixer's
+        // buffer plays its tail out rather than dropping it, so once that tail has drained the audible
+        // position has caught up with the decoding cursor, and the cursor is where playback resumes.
+        if (Mixer != null && IsRunning.Value)
+        {
+            long audible = BassMix.ChannelGetPosition(ChannelHandle);
+
+            // -1 is a channel BASSmix has no record of at this position: a source not (or no longer)
+            // plugged into a mixer, or one asked before the mixer has pulled it at all. The decoding
+            // position is the only answer available then, and it is the right one for a channel with no
+            // mixer buffer in front of it.
+            if (audible >= 0)
+                return audible;
+        }
+
+        return Bass.ChannelGetPosition(ChannelHandle);
+    }
+
     public double CurrentTime
     {
         get
@@ -237,8 +279,7 @@ internal class BassAudioChannel : IAudioChannel
             if (pending >= 0)
                 return pending / 1000.0;
 
-            long pos = Bass.ChannelGetPosition(ChannelHandle);
-            return Bass.ChannelBytes2Seconds(ChannelHandle, pos) * 1000.0;
+            return Bass.ChannelBytes2Seconds(ChannelHandle, audiblePosition()) * 1000.0;
         }
         set
         {

--- a/Sakura.Framework/Audio/BassEngine/BassAudioManager.cs
+++ b/Sakura.Framework/Audio/BassEngine/BassAudioManager.cs
@@ -34,9 +34,56 @@ internal class BassAudioManager : IAudioManager, IDisposable
     public Reactive<double> TrackVolume { get; } = new Reactive<double>(1.0);
     public Reactive<double> SampleVolume { get; } = new Reactive<double>(1.0);
 
-    public BassAudioManager()
+    /// <summary>
+    /// Output latency in milliseconds, as BASS measured it at initialisation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The counterpart to <see cref="SdlEngine.SDLAudioManager.OutputLatencyMs"/>, published so the two
+    /// backends can be compared on the number this framework's second audio backend exists to improve.
+    /// Comparing them needs one caveat kept in mind, because they are not measuring quite the same
+    /// thing.
+    /// </para>
+    /// <para>
+    /// BASS keeps a playback buffer — 100 ms here, see <see cref="Configuration.PlaybackBufferLength"/>
+    /// — but already accounts for it when reporting a channel's position, so it does not appear in this
+    /// figure and does not desync anything. What this figure is, is the part below that: the delay
+    /// between BASS handing audio to the device and the listener hearing it. The SDL backend's number
+    /// is the same quantity arrived at differently — its stream queue plus its device buffer — and it
+    /// is likewise subtracted from reported positions, by <c>OutputLatencyCompensator</c>.
+    /// </para>
+    /// <para>
+    /// Zero means BASS would not say. It only measures this when asked at init, which is why
+    /// <see cref="DeviceInitFlags.Latency"/> is passed below, and it cannot measure it at all when
+    /// attaching to a device someone else already initialised.
+    /// </para>
+    /// </remarks>
+    internal double OutputLatencyMs { get; private set; }
+
+    /// <summary>
+    /// The playback buffer BASS is keeping, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Not output latency — BASS compensates for this in its position reporting — but the closest
+    /// BASS analogue to the SDL backend's device buffer setting, and the knob that would be turned to
+    /// trade robustness for responsiveness here.
+    /// </remarks>
+    internal int PlaybackBufferMs { get; private set; }
+
+    /// <param name="device">
+    /// The BASS device index to open, or -1 for the system default. <see cref="Bass.NoSoundDevice"/>
+    /// initialises BASS without an output device: channels still decode and their positions still
+    /// advance in real time, but nothing is heard. That is what the cross-backend conformance suite
+    /// runs on — the alternative is a test run that plays music out loud — and it is also the right
+    /// mode for a headless host that only needs decoding.
+    /// </param>
+    public BassAudioManager(int device = -1)
     {
-        bool initSuccess = Bass.Init(-1, 44100, DeviceInitFlags.Default);
+        // DeviceInitFlags.Latency asks BASS to measure the device's output latency during Init, which is
+        // the only time it can be measured and the only way BassInfo.Latency is ever populated. It costs
+        // a little startup time — BASS plays a short test buffer to time it — and buys the one figure
+        // that makes this backend comparable with the SDL one.
+        bool initSuccess = Bass.Init(device, 44100, DeviceInitFlags.Latency);
         bool alreadyInitialised = !initSuccess && Bass.LastError == Errors.Already;
 
         if (!initSuccess && !alreadyInitialised)
@@ -106,6 +153,21 @@ internal class BassAudioManager : IAudioManager, IDisposable
             Logger.Verbose($"Update period: {updatePeriod} ms");
             Logger.Verbose($"Device buffer length: {deviceBuffer} ms");
             Logger.Verbose($"Playback buffer length: {playbackBuffer} ms");
+
+            PlaybackBufferMs = playbackBuffer;
+
+            if (Bass.GetInfo(out var info))
+            {
+                OutputLatencyMs = info.Latency;
+
+                // Said the same way round as the SDL backend's line, so a bug report from either one can
+                // be read against the other without converting anything.
+                Logger.Verbose(info.Latency > 0
+                    ? $"Output latency: {info.Latency} ms (device), plus a {playbackBuffer} ms playback buffer BASS compensates for"
+                    : $"Output latency: not measured by BASS{(alreadyInitialised ? " (attached to a device someone else initialised)" : string.Empty)}");
+
+                Logger.Verbose($"Minimum buffer: {info.MinBufferLength} ms");
+            }
         }
         channelEndSync = OnChannelEnded;
     }
@@ -219,6 +281,12 @@ internal class BassAudioManager : IAudioManager, IDisposable
         }
 
         GlobalStatistics.Get<double>("Audio", "BASS CPU Usage (%)").Value = Bass.CPUUsage;
+
+        // Named to line up with "SDL Output Latency (ms)" so the two backends can be read against each
+        // other in the same overlay. Constant for the life of the device, published every frame anyway
+        // because a statistic that only appears once is a statistic nobody sees.
+        GlobalStatistics.Get<double>("Audio", "BASS Output Latency (ms)").Value = OutputLatencyMs;
+        GlobalStatistics.Get<int>("Audio", "BASS Playback Buffer (ms)").Value = PlaybackBufferMs;
     }
 
     public void Dispose()

--- a/Sakura.Framework/Audio/SdlEngine/AmplitudeTap.cs
+++ b/Sakura.Framework/Audio/SdlEngine/AmplitudeTap.cs
@@ -19,14 +19,14 @@ internal sealed class AmplitudeTap
     /// Minimum interval between recomputing. Matches the BASS backend and means several visualizers
     /// reading the same tap in one frame share a single transform.
     /// </summary>
-    private const long cache_interval_ms = 15;
+    internal const long CACHE_INTERVAL_MS = 15;
 
     // Per-frame temporal damping of the spectrum so visualizers receive a smooth signal rather than
     // the raw, jittery FFT. Each refresh eases the stored value toward the new reading, retaining
     // this fraction of the old value per ~60fps frame. Copied from BassAudioChannel, including the
     // framerate-independence: the retained fraction shrinks as more time passes.
-    private const double amplitude_retain_per_frame = 0.4;
-    private const double amplitude_reference_frame_ms = 1000.0 / 60.0;
+    internal const double AMPLITUDE_RETAIN_PER_FRAME = 0.4;
+    internal const double AMPLITUDE_REFERENCE_FRAME_MS = 1000.0 / 60.0;
 
     /// <summary>
     /// Frames folded into one peak-hold segment, and how many segments the peak window spans.
@@ -150,7 +150,7 @@ internal sealed class AmplitudeTap
 
     /// <summary>
     /// Returns the current amplitude snapshot, recomputing at most once per
-    /// <see cref="cache_interval_ms"/>.
+    /// <see cref="CACHE_INTERVAL_MS"/>.
     /// </summary>
     /// <remarks>
     /// The returned <see cref="ChannelAmplitudes"/> wraps a buffer this tap reuses, matching the BASS
@@ -161,7 +161,7 @@ internal sealed class AmplitudeTap
         long now = Environment.TickCount64;
         long elapsed = now - lastReadTick;
 
-        if (elapsed < cache_interval_ms)
+        if (elapsed < CACHE_INTERVAL_MS)
             return cached;
 
         lastReadTick = now;
@@ -205,7 +205,7 @@ internal sealed class AmplitudeTap
 
         // Ease each bin toward its new reading instead of snapping, retaining less of the old value
         // the more time has passed since the previous read.
-        float retain = (float)Math.Pow(amplitude_retain_per_frame, elapsed / amplitude_reference_frame_ms);
+        float retain = (float)Math.Pow(AMPLITUDE_RETAIN_PER_FRAME, elapsed / AMPLITUDE_REFERENCE_FRAME_MS);
 
         for (int i = 0; i < dampedBins.Length; i++)
             dampedBins[i] = rawBins[i] + (dampedBins[i] - rawBins[i]) * retain;

--- a/Sakura.Framework/Audio/SdlEngine/AudioDecodeScheduler.cs
+++ b/Sakura.Framework/Audio/SdlEngine/AudioDecodeScheduler.cs
@@ -24,13 +24,13 @@ internal sealed class AudioDecodeScheduler : IDisposable
     /// </summary>
     private const int max_pumps_per_source = 8;
 
-    private readonly List<StreamingPcmSource> sources = new List<StreamingPcmSource>();
+    private readonly List<IDecodeSource> sources = new List<IDecodeSource>();
     private readonly Lock sync = new Lock();
     private readonly AutoResetEvent wakeup = new AutoResetEvent(false);
     private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
     private readonly Thread thread;
 
-    private StreamingPcmSource[] snapshot = Array.Empty<StreamingPcmSource>();
+    private IDecodeSource[] snapshot = Array.Empty<IDecodeSource>();
 
     public AudioDecodeScheduler()
     {
@@ -47,7 +47,7 @@ internal sealed class AudioDecodeScheduler : IDisposable
         thread.Start();
     }
 
-    public void Register(StreamingPcmSource source)
+    public void Register(IDecodeSource source)
     {
         lock (sync)
         {
@@ -59,7 +59,7 @@ internal sealed class AudioDecodeScheduler : IDisposable
         wakeup.Set();
     }
 
-    public void Unregister(StreamingPcmSource source)
+    public void Unregister(IDecodeSource source)
     {
         lock (sync)
         {
@@ -124,7 +124,7 @@ internal sealed class AudioDecodeScheduler : IDisposable
         lock (sync)
         {
             sources.Clear();
-            snapshot = Array.Empty<StreamingPcmSource>();
+            snapshot = Array.Empty<IDecodeSource>();
         }
 
         wakeup.Dispose();

--- a/Sakura.Framework/Audio/SdlEngine/DeviceStarvationTracker.cs
+++ b/Sakura.Framework/Audio/SdlEngine/DeviceStarvationTracker.cs
@@ -1,0 +1,76 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Threading;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Measures how long the output device spent with nothing to play, from a thread that may itself have
+/// been stopped for the whole of it.
+/// </summary>
+internal sealed class DeviceStarvationTracker
+{
+    private long starvedMicroseconds;
+    private long longestGapMicroseconds;
+
+    /// <summary>
+    /// Total time the device has spent with an empty queue while audio was playing.
+    /// </summary>
+    public double StarvedMilliseconds => Interlocked.Read(ref starvedMicroseconds) / 1000.0;
+
+    /// <summary>
+    /// The longest the mix loop went between iterations, whether it starved the device.
+    /// </summary>
+    /// <remarks>
+    /// Published because it is the direct answer to "was the mix thread stopped, and for how long",
+    /// which is the first thing worth knowing about a dropout and is otherwise only inferable. A large
+    /// gap with no starvation means the queue did its job; starvation with a small gap means something
+    /// else is wrong, and the two need telling apart.
+    /// </remarks>
+    public double LongestGapMilliseconds => Interlocked.Read(ref longestGapMicroseconds) / 1000.0;
+
+    /// <summary>
+    /// Records one interval of the mix loop.
+    /// </summary>
+    /// <param name="gapMs">Wall-clock length of the interval, top of one iteration to the top of the next.</param>
+    /// <param name="playableMs">
+    /// How much audio the device had available across that interval: what was queued when it began plus
+    /// anything pushed into it before it ended. The most it could have played before running out.
+    /// </param>
+    /// <param name="anythingPlaying">
+    /// Whether audio was expected. An empty queue with nothing playing is an idle device, not a
+    /// dropout.
+    /// </param>
+    public void Observe(double gapMs, double playableMs, bool anythingPlaying)
+    {
+        long gapMicroseconds = (long)(gapMs * 1000.0);
+
+        if (gapMicroseconds > Interlocked.Read(ref longestGapMicroseconds))
+            Interlocked.Exchange(ref longestGapMicroseconds, gapMicroseconds);
+
+        if (!anythingPlaying)
+            return;
+
+        double dry = gapMs - Math.Max(0, playableMs);
+
+        if (dry <= 0)
+            return;
+
+        Interlocked.Add(ref starvedMicroseconds, (long)(dry * 1000.0));
+    }
+
+    /// <summary>
+    /// The starvation expressed as a count of missed periods of <paramref name="periodMs"/>.
+    /// </summary>
+    /// <remarks>
+    /// So that the managed mixer reports an underrun count in the same shape the native engine
+    /// does, rather than the two statistics sharing a name and meaning different things. Neither count
+    /// is comparable to the other across engines since the native one is per voice per mix block, this one
+    /// is per block of missing output which is why <see cref="StarvedMilliseconds"/> is
+    /// published alongside it and is the figure to read.
+    /// </remarks>
+    public long CountIn(double periodMs) =>
+        periodMs <= 0 ? 0 : (long)(StarvedMilliseconds / periodMs);
+}

--- a/Sakura.Framework/Audio/SdlEngine/IDecodeSource.cs
+++ b/Sakura.Framework/Audio/SdlEngine/IDecodeSource.cs
@@ -1,0 +1,21 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Something the decode thread keeps topped up like a track's buffer, wherever that buffer lives.
+/// </summary>
+internal interface IDecodeSource
+{
+    /// <summary>
+    /// Whether the decode thread should spend time on this source right now.
+    /// </summary>
+    bool WantsDecode { get; }
+
+    /// <summary>
+    /// Does one unit of decoding work. Called only from the decode thread.
+    /// </summary>
+    /// <returns>True if there is more to do for this source right now.</returns>
+    bool PumpDecode();
+}

--- a/Sakura.Framework/Audio/SdlEngine/ISDLAudioContext.cs
+++ b/Sakura.Framework/Audio/SdlEngine/ISDLAudioContext.cs
@@ -29,6 +29,17 @@ internal interface ISDLAudioContext
     int Channels { get; }
 
     /// <summary>
+    /// How far ahead of the listener the audio already handed to the device is, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Sampled once a frame by the manager and read by every channel, so a channel subtracting it
+    /// from its own cursor reports what is audible rather than what has been mixed, and every
+    /// channel in a frame agrees. Zero is a valid answer and is what a stub or a drained device
+    /// gives.
+    /// </remarks>
+    double OutputLatencyMs { get; }
+
+    /// <summary>
     /// Queues work for the audio thread. Channel state changes and user-facing events go through
     /// here rather than firing on the mix thread, matching the BASS backend.
     /// </summary>

--- a/Sakura.Framework/Audio/SdlEngine/ISDLChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/ISDLChannel.cs
@@ -1,0 +1,49 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// The part of an SDL-backend channel the backend itself needs, over and above
+/// <see cref="IAudioChannel"/>: disposal notification, and a place to raise events that originated on
+/// the audio thread.
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal interface ISDLChannel : IAudioChannel
+{
+    /// <summary>
+    /// Raised once this channel has released its source. Whatever created the channel uses it to drop
+    /// its reference, keeping the underlying audio data alive until then.
+    /// </summary>
+    event Action? Disposed;
+
+    /// <summary>
+    /// Raises anything the audio side has signaled since the last call, on the update thread.
+    /// </summary>
+    /// <remarks>
+    /// Only the native engine needs this since its audio thread cannot raise a managed event, so an ended
+    /// or looped voice publishes a counter that this reads. The managed mixer marshals its own events
+    /// through <see cref="ISDLAudioContext.EnqueueAction"/> instead, and does nothing here.
+    /// </remarks>
+    void PollEvents();
+}
+
+/// <summary>
+/// An SDL-backend mixer, over and above <see cref="IAudioMixer"/>.
+/// </summary>
+/// <remarks>
+/// Exists for <see cref="RunningChannelCount"/>, which the manager reports as a statistic and which
+/// the managed mix loop uses to tell a dry device from an idle one. Not on
+/// <see cref="IAudioMixer"/> because it is a diagnostic, not something an app should route audio by.
+/// </remarks>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal interface ISDLMixer : IAudioMixer
+{
+    /// <summary>
+    /// The number of children currently producing audio.
+    /// </summary>
+    int RunningChannelCount { get; }
+}

--- a/Sakura.Framework/Audio/SdlEngine/NativeAmplitudeReader.cs
+++ b/Sakura.Framework/Audio/SdlEngine/NativeAmplitudeReader.cs
@@ -1,0 +1,75 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Reads a native node's metering and turns it into the <see cref="ChannelAmplitudes"/> a visualizer
+/// expects, the update thread's half of what <see cref="AmplitudeTap"/> does for the managed mixer.
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed class NativeAmplitudeReader
+{
+    private readonly float[] rawBins = new float[ChannelAmplitudes.AMPLITUDES_SIZE];
+    private readonly float[] dampedBins = new float[ChannelAmplitudes.AMPLITUDES_SIZE];
+
+    private long lastReadTick;
+    private ChannelAmplitudes cached = ChannelAmplitudes.Empty;
+
+    /// <summary>
+    /// Returns the current snapshot for <paramref name="node"/>, recomputing at most once per
+    /// <see cref="AmplitudeTap.CACHE_INTERVAL_MS"/>.
+    /// </summary>
+    /// <remarks>
+    /// The returned value wraps a buffer this instance reuses, matching the managed tap and the BASS
+    /// backend: callers must consume it before the next read rather than holding onto it.
+    /// </remarks>
+    public ChannelAmplitudes Read(SakuraAudioEngine engine, uint node)
+    {
+        long now = Environment.TickCount64;
+        long elapsed = now - lastReadTick;
+
+        if (elapsed < AmplitudeTap.CACHE_INTERVAL_MS)
+            return cached;
+
+        lastReadTick = now;
+
+        if (!engine.TryGetState(node, out var state))
+            return cached;
+
+        int bins = engine.ReadSpectrum(node, rawBins);
+
+        if (bins == 0)
+        {
+            // Nothing has passed through this node yet, so a visualizer should see an empty spectrum
+            // rather than a decaying one.
+            Array.Clear(dampedBins);
+            cached = new ChannelAmplitudes(state.AmplitudeLeft, state.AmplitudeRight, dampedBins);
+            return cached;
+        }
+
+        // Ease each bin toward its new reading instead of snapping, retaining less of the old value
+        // the more time has passed since the previous read.
+        float retain = (float)Math.Pow(AmplitudeTap.AMPLITUDE_RETAIN_PER_FRAME, elapsed / AmplitudeTap.AMPLITUDE_REFERENCE_FRAME_MS);
+
+        for (int i = 0; i < dampedBins.Length; i++)
+            dampedBins[i] = rawBins[i] + (dampedBins[i] - rawBins[i]) * retain;
+
+        cached = new ChannelAmplitudes(state.AmplitudeLeft, state.AmplitudeRight, dampedBins);
+        return cached;
+    }
+
+    /// <summary>
+    /// Drops the damping history and the cached snapshot, so a stopped or seeked channel does not
+    /// report a spectrum from where it used to be.
+    /// </summary>
+    public void Reset()
+    {
+        Array.Clear(dampedBins);
+        lastReadTick = 0;
+        cached = ChannelAmplitudes.Empty;
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/NativeStreamFeeder.cs
+++ b/Sakura.Framework/Audio/SdlEngine/NativeStreamFeeder.cs
@@ -143,6 +143,33 @@ internal sealed class NativeStreamFeeder : IDecodeSource, IDisposable
             converter = null;
             throw new InvalidOperationException("The native voice would not take a ring buffer.");
         }
+
+        // Prime the ring on the calling thread, before anything can play out of it.
+        //
+        // Doing it here rather than in Play is what makes it a guarantee rather than a smaller race
+        // constructing a track already opens and decodes a file on this thread, so one more decode pass
+        // is in keeping, and by the time a caller has a channel to press Play on, the ring is not empty.
+        primeRing();
+    }
+
+    /// <summary>
+    /// Decodes until the ring is reasonably full or the source runs out, whichever comes first.
+    /// </summary>
+    /// <remarks>
+    /// Bounded by passes rather than run to completion since the decode thread is perfectly capable of
+    /// filling the remaining 500 ms, and a track whose whole buffer had to be decoded before its
+    /// constructor returned would make loading a beatmap slower to no purpose. This only has to cover
+    /// the handful of milliseconds before the decode thread gets its first turn.
+    /// </remarks>
+    private void primeRing()
+    {
+        const int max_passes = 8;
+
+        for (int i = 0; i < max_passes && WantsDecode; i++)
+        {
+            if (!PumpDecode())
+                break;
+        }
     }
 
     /// <summary>

--- a/Sakura.Framework/Audio/SdlEngine/NativeStreamFeeder.cs
+++ b/Sakura.Framework/Audio/SdlEngine/NativeStreamFeeder.cs
@@ -1,0 +1,275 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Keeps one native voice's ring buffer fed: decodes, converts to the device format, and writes into
+/// libsakura-audio. The track paths decode side, and the native counterpart to
+/// <see cref="StreamingPcmSource"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three threads meet here, as they do in the managed source, but the mixing one is now the device
+/// callback and is on the other side of a P/Invoke boundary:
+/// </para>
+/// <list type="bullet">
+/// <item>the <b>decode thread</b> calls <see cref="PumpDecode"/>, the only place FFmpeg is touched
+/// and the only writer to this voice's ring;</item>
+/// <item>the <b>audio thread</b> drains the ring inside the native engine, and never enters managed
+/// code to do it which is the entire point of the native mixer;</item>
+/// <item>the <b>update thread</b> calls <see cref="Seek"/>, which never blocks on decoding.</item>
+/// </list>
+/// <para>
+/// A seek therefore cannot be applied where it is requested, and the discard cannot be done by this
+/// side at all: only the audio thread knows where its read cursor is. So a seek here decodes from the
+/// new position, posts the discard, and then waits — by declining to write — until the audio thread
+/// acknowledges it. Writing before that would throw the new position's audio away along with the old.
+/// The wait costs one decode pass, which against a 500 ms buffer is nothing.
+/// </para>
+/// </remarks>
+internal sealed class NativeStreamFeeder : IDecodeSource, IDisposable
+{
+    /// <summary>
+    /// How far ahead to decode. Large enough that a GC pause or a slow read cannot starve the mixer,
+    /// and irrelevant to output latency, which is set by the device buffer alone.
+    /// </summary>
+    public const double TARGET_BUFFER_MS = 500;
+
+    /// <summary>
+    /// Don't wake the decoder for scraps; wait until this much of the buffer has drained.
+    /// </summary>
+    private const double refill_threshold_ms = 100;
+
+    private readonly Lock sync = new Lock();
+
+    /// <summary>
+    /// Held across all decoding, and by <see cref="Dispose"/>, so the decoder is never freed while
+    /// the decode thread is inside it.
+    /// </summary>
+    private readonly Lock decodeSync = new Lock();
+
+    private readonly SakuraAudioEngine engine;
+    private readonly uint voice;
+    private readonly int deviceSampleRate;
+    private readonly int deviceChannels;
+
+    private readonly float[] decodeScratch = new float[8192];
+    private readonly float[] convertScratch = new float[8192];
+
+    private FFmpegAudioDecoder? decoder;
+    private SDLAudioConverter? converter;
+
+    private double? pendingSeekMs;
+
+    /// <summary>
+    /// Set once the decoder has no more audio, and mirrored into the native voice, which is only
+    /// ended once it is drained <em>and</em> its ring is empty.
+    /// </summary>
+    private bool decoderDrained;
+
+    private bool isDisposed;
+
+    public double LengthMs { get; }
+
+    /// <summary>
+    /// Total capacity of the native ring, in frames.
+    /// </summary>
+    public int CapacityFrames { get; }
+
+    public bool WantsDecode
+    {
+        get
+        {
+            lock (sync)
+            {
+                if (isDisposed)
+                    return false;
+
+                if (pendingSeekMs.HasValue)
+                    return true;
+
+                // Keep coming back while a discard is outstanding: the audio thread applies it on its
+                // next callback, and until it has there is nothing this side may write.
+                if (engine.StreamFlushPending(voice))
+                    return true;
+
+                if (decoderDrained)
+                    return false;
+
+                return engine.StreamBuffered(voice) <= framesFor(TARGET_BUFFER_MS - refill_threshold_ms);
+            }
+        }
+    }
+
+    /// <param name="stream">The encoded source. Ownership passes to this instance.</param>
+    /// <param name="engine">The native engine holding <paramref name="voice"/>.</param>
+    /// <param name="voice">The voice whose ring this instance feeds.</param>
+    /// <exception cref="InvalidDataException">The source could not be decoded.</exception>
+    /// <exception cref="InvalidOperationException">The voice would not take a ring buffer.</exception>
+    public NativeStreamFeeder(Stream stream, SakuraAudioEngine engine, uint voice)
+    {
+        this.engine = engine;
+        this.voice = voice;
+
+        deviceSampleRate = engine.SampleRate;
+        deviceChannels = engine.Channels;
+
+        decoder = new FFmpegAudioDecoder(stream);
+
+        try
+        {
+            converter = new SDLAudioConverter(decoder.SampleRate, decoder.Channels, deviceSampleRate, deviceChannels);
+        }
+        catch
+        {
+            decoder.Dispose();
+            decoder = null;
+            throw;
+        }
+
+        LengthMs = decoder.Duration;
+        CapacityFrames = framesFor(TARGET_BUFFER_MS) / deviceChannels;
+
+        if (!engine.SetVoiceStream(voice, CapacityFrames))
+        {
+            decoder.Dispose();
+            decoder = null;
+            converter.Dispose();
+            converter = null;
+            throw new InvalidOperationException("The native voice would not take a ring buffer.");
+        }
+    }
+
+    /// <summary>
+    /// Milliseconds expressed as a whole number of interleaved floats.
+    /// </summary>
+    private int framesFor(double milliseconds) =>
+        Math.Max(deviceChannels, (int)(milliseconds / 1000.0 * deviceSampleRate) * deviceChannels);
+
+    /// <summary>
+    /// Records a seek for the decode thread to apply. Returns immediately; the audio thread's side of
+    /// it is the channel's <see cref="SakuraAudioEngine.Seek"/>.
+    /// </summary>
+    public void Seek(double milliseconds)
+    {
+        lock (sync)
+        {
+            if (isDisposed)
+                return;
+
+            pendingSeekMs = Math.Max(0, milliseconds);
+
+            // Cleared here as well as by the flush so that WantsDecode does not read a stale end and
+            // decline to refill the position we are seeking to.
+            decoderDrained = false;
+        }
+    }
+
+    public bool PumpDecode()
+    {
+        lock (decodeSync)
+        {
+            if (isDisposed || decoder == null || converter == null)
+                return false;
+
+            double? seek;
+
+            lock (sync)
+            {
+                seek = pendingSeekMs;
+                pendingSeekMs = null;
+            }
+
+            if (seek.HasValue)
+            {
+                decoder.Seek(seek.Value);
+                converter.Clear();
+
+                lock (sync)
+                    decoderDrained = false;
+
+                // Posts the discard. Everything buffered belongs to where we just left, and the audio
+                // thread is the only side that may drop it.
+                engine.StreamFlushBegin(voice);
+            }
+
+            // Nothing may be written while a discard is outstanding: it would be thrown away with the
+            // audio it is replacing. Come back on the next pass, by which point a running device has
+            // acknowledged it.
+            if (engine.StreamFlushPending(voice))
+                return false;
+
+            lock (sync)
+            {
+                if (decoderDrained || engine.StreamSpace(voice) * deviceChannels < convertScratch.Length)
+                    return false;
+            }
+
+            int read = decoder.Read(decodeScratch);
+
+            if (read == 0)
+            {
+                // Flush or the converter withholds its tail — the last few milliseconds of every
+                // track would silently go missing.
+                converter.Flush();
+            }
+            else
+            {
+                converter.Put(decodeScratch.AsSpan(0, read));
+            }
+
+            int converted = converter.Get(convertScratch);
+
+            lock (sync)
+            {
+                if (isDisposed)
+                    return false;
+
+                // A seek landed while this block was being decoded, so it is audio from a position we
+                // have already left. The next pass will discard the ring and start from the new one,
+                // so dropping this block is all that is needed — there is no generation counter here
+                // because the ring itself is about to be emptied.
+                if (pendingSeekMs.HasValue)
+                    return true;
+
+                if (converted > 0)
+                    engine.StreamWrite(voice, convertScratch.AsSpan(0, converted));
+
+                if (read == 0 && converted == 0)
+                {
+                    decoderDrained = true;
+                    engine.StreamSetDrained(voice, true);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (sync)
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+        }
+
+        // Outside the state lock but inside the decode lock: waits for any in-flight decode to finish
+        // rather than freeing FFmpeg state underneath it.
+        lock (decodeSync)
+        {
+            decoder?.Dispose();
+            decoder = null;
+            converter?.Dispose();
+            converter = null;
+        }
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/OutputLatencyCompensator.cs
+++ b/Sakura.Framework/Audio/SdlEngine/OutputLatencyCompensator.cs
@@ -1,0 +1,59 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Turns a channel's mix cursor into the position a listener is actually hearing, and keeps that
+/// answer moving forwards.
+/// </summary>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed class OutputLatencyCompensator
+{
+    /// <summary>
+    /// Slack on top of the compensation window, absorbing jitter in the queue reading when the queue
+    /// itself is near empty.
+    /// </summary>
+    private const double wobble_slack_ms = 1.0;
+
+    private double lastReported;
+    private bool primed;
+
+    /// <summary>
+    /// The audible position for a channel whose mix cursor is at <paramref name="rawMs"/>.
+    /// </summary>
+    /// <param name="rawMs">The channel's own cursor, in milliseconds of source time.</param>
+    /// <param name="latencyMs">Output latency, from <see cref="ISDLAudioContext.OutputLatencyMs"/>.</param>
+    /// <param name="rate">The channel's playback rate, as <see cref="IAudioChannel.Frequency"/>.</param>
+    public double Compensate(double rawMs, double latencyMs, double rate)
+    {
+        double window = Math.Max(0, latencyMs) * Math.Max(0, rate);
+        double audible = Math.Max(0, rawMs - window);
+
+        if (!primed)
+        {
+            primed = true;
+            lastReported = audible;
+            return audible;
+        }
+
+        double backwards = lastReported - audible;
+
+        // Anything larger than the window that produced it is not wobble, it is the position genuinely
+        // having moved, by something that should have called Reset and did not.
+        if (backwards > 0 && backwards <= window + wobble_slack_ms)
+            return lastReported;
+
+        lastReported = audible;
+        return audible;
+    }
+
+    /// <summary>
+    /// Forgets the monotonic floor, for when the position is meant to jump: a seek, a loop wrap, or a
+    /// stop that rewinds.
+    /// </summary>
+    public void Reset() => primed = false;
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file for full license text.
 
 using System;
+using System.Threading;
 using System.Diagnostics.CodeAnalysis;
 using Sakura.Framework.Reactive;
 
@@ -97,6 +98,19 @@ internal class SDLAudioChannel : ISDLChannel
     /// thread rather than repeatedly from inside the mix loop.
     /// </summary>
     private bool endHandled;
+
+    private readonly OutputLatencyCompensator latency = new OutputLatencyCompensator();
+
+    /// <summary>
+    /// Where a "posted but not yet applied" seek was sent, in microseconds, or -1 when none is outstanding.
+    /// </summary>
+    /// <remarks>
+    /// The managed mixer applies a seek on the audio thread, so without this the position reported in
+    /// between is the one being left — a jump backwards and then forwards as far as <c>TrackClock</c> is
+    /// concerned. The native engine solves the same problem with its seek epoch; this is the managed
+    /// half, and the cross-backend conformance suite is what noticed only one of the two had it.
+    /// </remarks>
+    private long pendingSeekMicroseconds = -1;
 
     public SDLAudioChannel(ISDLAudioContext context, IPcmSource? source)
     {
@@ -323,16 +337,43 @@ internal class SDLAudioChannel : ISDLChannel
         resampler?.Reset();
         filter?.ClearState();
         Tap.Reset();
+        latency.Reset();
         Context.WakeDecoder();
     }
 
+    /// <summary>
+    /// The audible position, which on this backend lags the mix cursor by a great deal more than it
+    /// does on the native engine.
+    /// </summary>
+    /// <remarks>
+    /// The managed mixer keeps a queue of tens of milliseconds ahead of the device by design. That
+    /// queue is what a GC pause hides behind so <see cref="IPcmSource.PositionMs"/> runs that far
+    /// ahead of the music. It is the same correction as the native path, and it matters more here.
+    /// </remarks>
     public double CurrentTime
     {
-        get => isDisposed ? 0 : source?.PositionMs ?? 0;
+        get
+        {
+            if (isDisposed || source == null)
+                return 0;
+
+            long pending = Interlocked.Read(ref pendingSeekMicroseconds);
+
+            // Reported uncompensated, as the native engine does for the same case: nothing of the new
+            // position has been mixed yet, let alone queued, so there is no output latency to subtract
+            // and subtracting one would report the seek as landing short of where it was sent.
+            if (pending >= 0)
+                return pending / 1000.0;
+
+            return latency.Compensate(source.PositionMs, Context.OutputLatencyMs, Frequency.Value);
+        }
         set
         {
             if (isDisposed)
                 return;
+
+            long target = (long)(Math.Max(0, value) * 1000.0);
+            Interlocked.Exchange(ref pendingSeekMicroseconds, target);
 
             Context.EnqueueAction(() =>
             {
@@ -341,6 +382,8 @@ internal class SDLAudioChannel : ISDLChannel
 
                 seekInternal(value);
                 endHandled = false;
+
+                Interlocked.CompareExchange(ref pendingSeekMicroseconds, -1, target);
             });
         }
     }

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioChannel.cs
@@ -25,17 +25,21 @@ namespace Sakura.Framework.Audio.SdlEngine;
 /// </para>
 /// </remarks>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-internal class SDLAudioChannel : IAudioChannel
+internal class SDLAudioChannel : ISDLChannel
 {
     public event Action OnStart = () => { };
     public event Action OnStop = () => { };
     public event Action OnEnd = () => { };
 
+    /// <inheritdoc cref="ISDLChannel.Disposed"/>
+    /// <remarks>Raised on the audio thread.</remarks>
+    public event Action? Disposed;
+
     /// <summary>
-    /// Raised once this channel has released its source, on the audio thread. Whatever created the
-    /// channel uses it to drop the reference, keeping the underlying audio data alive.
+    /// Nothing to do since this mixer raises its own events from the audio thread through
+    /// <see cref="ISDLAudioContext.EnqueueAction"/> as they happen.
     /// </summary>
-    internal event Action? Disposed;
+    public void PollEvents() { }
 
     public ReactiveBool IsRunning { get; } = new ReactiveBool();
 

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
@@ -41,6 +41,12 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// </remarks>
     private const double target_queue_ms = 80;
 
+    /// <summary>
+    /// Frames the native engine mixes at a time. Not the device buffer — SDL asks for whatever its
+    /// buffer needs and this is how finely that request is chopped up.
+    /// </summary>
+    private const int native_mix_block_frames = 128;
+
     private const int fallback_sample_rate = 44100;
     private const int output_channels = 2;
 
@@ -52,18 +58,53 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     public Reactive<double> TrackVolume { get; } = new Reactive<double>(1.0);
     public Reactive<double> SampleVolume { get; } = new Reactive<double>(1.0);
 
-    private readonly SDLAudioMixer trackMixer;
-    private readonly SDLAudioMixer sampleMixer;
+    private readonly ISDLMixer trackMixer;
+    private readonly ISDLMixer sampleMixer;
 
     public IAudioMixer TrackMixer => trackMixer;
     public IAudioMixer SampleMixer => sampleMixer;
 
+    /// <summary>
+    /// The native mix engine, or null when this manager is mixing in managed code.
+    /// </summary>
+    /// <remarks>
+    /// Null is a supported state, not a failure: the managed mixer is the reference implementation and
+    /// the fallback for any platform <c>libsakura-audio</c> has not been built for. A backend that
+    /// degrades to managed mixing is much better than one that refuses to start.
+    /// </remarks>
+    private readonly SakuraAudioEngine? nativeEngine;
+
+    internal SakuraAudioEngine? NativeEngine => nativeEngine;
+
+    /// <summary>
+    /// Whether the device callback is mixing inside <c>libsakura-audio</c> rather than on this
+    /// manager's own mix thread.
+    /// </summary>
+    internal bool UsesNativeMixEngine => nativeEngine != null;
+
+    // The same two mixers as above at their concrete type, set only in managed mode, because Fill is
+    // not part of the shared mixer surface.
+    private readonly SDLAudioMixer? managedTrackMixer;
+    private readonly SDLAudioMixer? managedSampleMixer;
+
     private readonly ConcurrentQueue<Action> audioThreadActions = new ConcurrentQueue<Action>();
-    private readonly List<SDLAudioChannel> activeChannels = new List<SDLAudioChannel>();
+    private readonly List<ISDLChannel> activeChannels = new List<ISDLChannel>();
+
+    /// <summary>
+    /// Immutable view of <see cref="activeChannels"/>, rebuilt only when membership changes, so the
+    /// per-frame walk in <see cref="Update"/> allocates nothing.
+    /// </summary>
+    private volatile ISDLChannel[] activeChannelSnapshot = Array.Empty<ISDLChannel>();
+
     private readonly AudioDecodeScheduler decodeScheduler = new AudioDecodeScheduler();
 
     private readonly SDL_AudioStream* deviceStream;
-    private readonly Thread mixThread;
+
+    /// <summary>
+    /// The push-model mix thread, or null when the native engine owns the device callback.
+    /// </summary>
+    private readonly Thread? mixThread;
+
     private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
 
     private readonly float[] mixBuffer = new float[mix_block_frames * output_channels];
@@ -78,8 +119,12 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
     private bool isDisposed;
 
+    /// <param name="useNativeMixEngine">
+    /// Whether to mix in <c>libsakura-audio</c> when it is available. False forces the managed
+    /// reference mixer, which is what <see cref="AudioBackend.SDLManaged"/> selects.
+    /// </param>
     /// <exception cref="InvalidOperationException">SDL audio could not be started.</exception>
-    public SDLAudioManager()
+    public SDLAudioManager(bool useNativeMixEngine = true)
     {
         // Decoding runs through FFmpeg, so bring it up here rather than lazily on the first track:
         // a missing or mis-located native library should fail at startup, where it is diagnosable.
@@ -92,6 +137,9 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
         SampleRate = queryDeviceSampleRate();
 
+        if (useNativeMixEngine)
+            nativeEngine = tryCreateNativeEngine();
+
         var spec = new SDL_AudioSpec
         {
             format = SDLAudioConverter.SAMPLE_FORMAT,
@@ -99,18 +147,48 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
             freq = SampleRate
         };
 
-        // No callback: this backend pushes from its own mix thread, so nothing SDL calls can ever be
-        // waiting on managed code.
-        deviceStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, null, IntPtr.Zero);
+        if (nativeEngine != null)
+        {
+            // The callback is native, and reaching it involves no managed code at all: this is a raw
+            // function pointer straight into libsakura-audio, not a marshalled delegate. A delegate
+            // here would put a managed frame on the real-time thread and hand a GC pause the ability
+            // to underrun the device, which is the entire thing this backend exists to avoid.
+            var callback = (delegate* unmanaged[Cdecl]<IntPtr, SDL_AudioStream*, int, int, void>)SakuraAudioEngine.StreamCallback;
+            deviceStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, callback, nativeEngine.Handle);
+        }
+        else
+        {
+            // No callback: the managed mixer pushes from its own thread, so nothing SDL calls can ever
+            // be waiting on managed code either. It buys that with a much larger queue — see
+            // target_queue_ms.
+            deviceStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, null, IntPtr.Zero);
+        }
 
         if (deviceStream == null)
         {
+            nativeEngine?.Dispose();
             SDL_QuitSubSystem(SDL_InitFlags.SDL_INIT_AUDIO);
             throw new InvalidOperationException($"Failed to open an SDL audio device: {SDL_GetError()}");
         }
 
-        trackMixer = new SDLAudioMixer(this);
-        sampleMixer = new SDLAudioMixer(this);
+        if (nativeEngine != null)
+        {
+            trackMixer = createNativeMixer(nativeEngine);
+            sampleMixer = createNativeMixer(nativeEngine);
+        }
+        else
+        {
+            var managedTracks = new SDLAudioMixer(this);
+            var managedSamples = new SDLAudioMixer(this);
+
+            // Kept at their concrete type as well, because Fill is the managed mixer's alone: in
+            // native mode there is no mix loop here to call it.
+            managedTrackMixer = managedTracks;
+            managedSampleMixer = managedSamples;
+
+            trackMixer = managedTracks;
+            sampleMixer = managedSamples;
+        }
 
         trackMixer.IsRunning.Value = true;
         sampleMixer.IsRunning.Value = true;
@@ -126,19 +204,61 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
         if (!SDL_ResumeAudioStreamDevice(deviceStream))
             Logger.Error($"Failed to start the SDL audio device: {SDL_GetError()}");
 
-        mixThread = new Thread(runMixLoop)
+        if (nativeEngine == null)
         {
-            Name = "SdlAudioMix",
-            IsBackground = true,
+            mixThread = new Thread(runMixLoop)
+            {
+                Name = "SdlAudioMix",
+                IsBackground = true,
 
-            // The highest priority in the engine: everything else can be late by a frame, this
-            // cannot be late by a block.
-            Priority = ThreadPriority.Highest
-        };
+                // The highest priority in the engine: everything else can be late by a frame, this
+                // cannot be late by a block.
+                Priority = ThreadPriority.Highest
+            };
 
-        mixThread.Start();
+            mixThread.Start();
+        }
 
         logInitialisationDetails();
+    }
+
+    /// <summary>
+    /// Brings up the native mix engine, or returns null to fall back to managed mixing.
+    /// </summary>
+    /// <remarks>
+    /// Every failure here is a fallback rather than an exception. A platform the library has not been
+    /// built for, an ABI mismatch, an SDL export that could not be resolved: none of them are reasons
+    /// for the audio backend not to start, and all of them are reasons to say so in the log.
+    /// </remarks>
+    private SakuraAudioEngine? tryCreateNativeEngine()
+    {
+        if (!SakuraAudioEngine.IsAvailable)
+            return null;
+
+        // Without this the native engine has no way to hand frames to the device.
+        if (!SakuraAudioEngine.TrySetSdlPut())
+            return null;
+
+        var engine = SakuraAudioEngine.Create(SampleRate, output_channels, native_mix_block_frames);
+
+        if (engine == null)
+            return null;
+
+        return engine;
+    }
+
+    /// <summary>
+    /// Creates a master mixer node and routes it into the engine's root.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The node pool is exhausted.</exception>
+    private static SDLNativeAudioMixer createNativeMixer(SakuraAudioEngine engine)
+    {
+        uint node = engine.CreateMixer();
+
+        if (node == 0 || !engine.AddChild(engine.Root, node))
+            throw new InvalidOperationException("The native mix engine would not create a master mixer.");
+
+        return new SDLNativeAudioMixer(engine, node);
     }
 
     /// <summary>
@@ -179,8 +299,21 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
         }
 
         Logger.Verbose($"Mix format: {SampleRate} Hz, {output_channels} ch, {formatName(SDLAudioConverter.SAMPLE_FORMAT)}");
-        Logger.Verbose($"Mix block: {mix_block_frames} frames ({mix_block_frames / (double)SampleRate * 1000.0:F1} ms)");
-        Logger.Verbose($"Target queue length: {target_queue_ms} ms");
+
+        if (nativeEngine != null)
+        {
+            Logger.Verbose($"Mix engine: libsakura-audio (native, ABI {SakuraAudioNative.ABI_VERSION}), on the device callback");
+            Logger.Verbose($"Mix block: {native_mix_block_frames} frames ({native_mix_block_frames / (double)SampleRate * 1000.0:F1} ms)");
+        }
+        else
+        {
+            // Worth a warning rather than a note: this is the fallback, it is not what the backend is
+            // for, and its latency is an order of magnitude worse.
+            Logger.Verbose("Mix engine: managed reference mixer, pushing from its own thread"
+                           + (SakuraAudioEngine.IsAvailable ? " (native engine available but not selected)" : " (libsakura-audio unavailable)"));
+            Logger.Verbose($"Mix block: {mix_block_frames} frames ({mix_block_frames / (double)SampleRate * 1000.0:F1} ms)");
+            Logger.Verbose($"Target queue length: {target_queue_ms} ms");
+        }
 
         logDecoderSupport();
     }
@@ -282,8 +415,8 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
         try
         {
-            trackMixer.Fill(block);
-            sampleMixer.Fill(block);
+            managedTrackMixer?.Fill(block);
+            managedSampleMixer?.Fill(block);
         }
         catch (Exception e)
         {
@@ -322,33 +455,125 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     #region Channel lifetime
 
     /// <summary>
-    /// Builds a channel over <paramref name="source"/>, routes it into <paramref name="mixer"/>, and
-    /// registers it for decoding and shutdown.
+    /// Builds a managed-mixer channel over <paramref name="source"/>, routes it into
+    /// <paramref name="mixer"/>, and registers it for decoding and shutdown.
     /// </summary>
-    internal SDLAudioChannel CreateChannel(IPcmSource source, IAudioMixer mixer, bool streaming)
+    internal ISDLChannel CreateChannel(IPcmSource source, IAudioMixer mixer, bool streaming)
     {
         var channel = new SDLAudioChannel(this, source);
 
-        if (streaming && source is StreamingPcmSource streamingSource)
-            decodeScheduler.Register(streamingSource);
+        register(channel, mixer, streaming ? source as IDecodeSource : null);
+
+        return channel;
+    }
+
+    /// <summary>
+    /// Builds a native voice over a shared PCM buffer — the sample path — and routes it into
+    /// <paramref name="mixer"/>.
+    /// </summary>
+    /// <remarks>
+    /// The buffer's reference count is claimed by the engine for as long as the voice holds it, so the
+    /// caller may release its own claim whenever it likes without pulling audio out from under a
+    /// playing hitsound.
+    /// </remarks>
+    /// <returns>Null when the engine's voice pool is exhausted.</returns>
+    internal ISDLChannel? CreateNativeBufferChannel(uint buffer, double lengthMs, IAudioMixer mixer)
+    {
+        if (nativeEngine == null)
+            return null;
+
+        uint node = nativeEngine.CreateVoice();
+
+        if (node == 0)
+        {
+            Logger.Warning("The native mix engine is out of voices; a sample will not play.");
+            return null;
+        }
+
+        if (!nativeEngine.SetVoiceBuffer(node, buffer))
+        {
+            nativeEngine.DestroyNode(node);
+            return null;
+        }
+
+        var channel = new SDLNativeAudioChannel(nativeEngine, node, lengthMs);
+
+        register(channel, mixer, null);
+
+        return channel;
+    }
+
+    /// <summary>
+    /// Builds a native voice fed by a decode thread — the track path — and routes it into
+    /// <paramref name="mixer"/>.
+    /// </summary>
+    /// <param name="encoded">The encoded audio. Ownership passes to the returned channel.</param>
+    /// <param name="mixer">Where to route the voice.</param>
+    /// <returns>Null when the engine's voice pool is exhausted.</returns>
+    /// <exception cref="InvalidDataException">The source could not be decoded.</exception>
+    internal ISDLChannel? CreateNativeStreamingChannel(Stream encoded, IAudioMixer mixer)
+    {
+        if (nativeEngine == null)
+            return null;
+
+        uint node = nativeEngine.CreateVoice();
+
+        if (node == 0)
+        {
+            Logger.Warning("The native mix engine is out of voices; a track will not play.");
+            encoded.Dispose();
+            return null;
+        }
+
+        NativeStreamFeeder feeder;
+
+        try
+        {
+            feeder = new NativeStreamFeeder(encoded, nativeEngine, node);
+        }
+        catch
+        {
+            nativeEngine.DestroyNode(node);
+            throw;
+        }
+
+        var channel = new SDLNativeAudioChannel(nativeEngine, node, feeder.LengthMs, feeder);
+
+        register(channel, mixer, feeder);
+
+        return channel;
+    }
+
+    /// <summary>
+    /// The bookkeeping every channel needs whichever engine mixes it: routing, decode registration,
+    /// and undoing both when it is disposed.
+    /// </summary>
+    private void register(ISDLChannel channel, IAudioMixer mixer, IDecodeSource? decodeSource)
+    {
+        if (decodeSource != null)
+            decodeScheduler.Register(decodeSource);
 
         lock (activeChannels)
+        {
             activeChannels.Add(channel);
+            activeChannelSnapshot = activeChannels.ToArray();
+        }
 
         mixer.AddChannel(channel);
 
         channel.Disposed += () =>
         {
-            if (source is StreamingPcmSource registered)
-                decodeScheduler.Unregister(registered);
+            if (decodeSource != null)
+                decodeScheduler.Unregister(decodeSource);
 
             mixer.RemoveChannel(channel);
 
             lock (activeChannels)
+            {
                 activeChannels.Remove(channel);
+                activeChannelSnapshot = activeChannels.ToArray();
+            }
         };
-
-        return channel;
     }
 
     #endregion
@@ -385,6 +610,27 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
             }
         }
 
+        if (nativeEngine != null)
+        {
+            // The audio thread cannot raise a managed event, so anything a voice signalled — it ended,
+            // it wants its decoder moved to a loop point — is turned into events here. Walked over the
+            // snapshot because a channel with AutoDispose set removes itself from the list as it goes.
+            foreach (var channel in activeChannelSnapshot)
+                channel.PollEvents();
+
+            // The only place the native side frees anything. Skipping it leaks voices and sample PCM.
+            nativeEngine.Maintain();
+
+            var stats = nativeEngine.GetStats();
+
+            // "Callback", not "Mix Block": there is a real device callback to time now.
+            GlobalStatistics.Get<long>("Audio", "SDL Callback (µs)").Value = stats.CallbackMicroseconds;
+            GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value = stats.Starvations;
+            GlobalStatistics.Get<long>("Audio", "SDL Put Failures").Value = stats.PutFailures;
+            GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value = stats.ActiveVoices;
+            return;
+        }
+
         GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value = Interlocked.Read(ref underruns);
         GlobalStatistics.Get<long>("Audio", "SDL Mix Block (µs)").Value = mixMicroseconds;
         GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value = runningVoices();
@@ -393,12 +639,7 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
     public void StopAll()
     {
-        SDLAudioChannel[] toStop;
-
-        lock (activeChannels)
-            toStop = activeChannels.ToArray();
-
-        foreach (var channel in toStop)
+        foreach (var channel in activeChannelSnapshot)
             channel.Stop();
     }
 
@@ -413,15 +654,21 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
         cancellation.Cancel();
 
-        if (!mixThread.Join(TimeSpan.FromSeconds(2)))
+        if (mixThread != null && !mixThread.Join(TimeSpan.FromSeconds(2)))
             Logger.Error("[SDLAudioManager] Mix thread did not exit in time.");
 
-        SDLAudioChannel[] toDispose;
+        // Before anything is torn down: stop the device, so the native callback cannot be running
+        // while the graph it walks is being dismantled underneath it.
+        if (deviceStream != null && nativeEngine != null)
+            SDL_PauseAudioStreamDevice(deviceStream);
+
+        ISDLChannel[] toDispose;
 
         lock (activeChannels)
         {
             toDispose = activeChannels.ToArray();
             activeChannels.Clear();
+            activeChannelSnapshot = Array.Empty<ISDLChannel>();
         }
 
         foreach (var channel in toDispose)
@@ -438,6 +685,11 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
         if (deviceStream != null)
             SDL_DestroyAudioStream(deviceStream);
+
+        // Only once the stream is gone, and with it any possibility of another callback. The native
+        // side deliberately does not synchronise with a callback already in flight; that is the
+        // caller's job, and this is the caller.
+        nativeEngine?.Dispose();
 
         cancellation.Dispose();
 

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using Sakura.Framework.Extensions.ObjectExtensions;
@@ -19,7 +20,7 @@ using static SDL.SDL3;
 namespace Sakura.Framework.Audio.SdlEngine;
 
 /// <summary>
-/// SDL3 implementation of <see cref="IAudioManager"/>: owns the output device, the mix thread, and
+/// SDL3 implementation of <see cref="IAudioManager"/> that owns the output device, the mix thread, and
 /// the two master mixers.
 /// </summary>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
@@ -35,7 +36,7 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// How much audio to keep queued on the device.
     /// </summary>
     /// <remarks>
-    /// This is the output latency, and it is generous on purpose — see the class remarks. Phase 3
+    /// This is the output latency, and it is generous on purpose
     /// replaces this with <c>SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES</c> and a configurable target once
     /// the GC can no longer interrupt the mix loop.
     /// </remarks>
@@ -46,6 +47,29 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// buffer needs and this is how finely that request is chopped up.
     /// </summary>
     private const int native_mix_block_frames = 128;
+
+    /// <summary>
+    /// Device buffer size asked of SDL, in frames, when nothing else is configured.
+    /// </summary>
+    /// <remarks>
+    /// This is the output latency on the native engine, and therefore the single number this whole
+    /// backend exists to lower: 128 frames is 2.7 ms at 48 kHz where SDL's own default on the
+    /// reference machine was 1024 (21.3 ms).
+    /// </remarks>
+    internal const int DEFAULT_DEVICE_BUFFER_FRAMES = 128;
+
+    /// <summary>
+    /// Bounds on <c>FrameworkSetting.AudioDeviceBufferFrames</c>. Below the lower bound no
+    /// driver will honor the request anyway; above the upper one the setting has stopped being a
+    /// latency control.
+    /// </summary>
+    private const int min_device_buffer_frames = 32;
+    private const int max_device_buffer_frames = 8192;
+
+    /// <summary>
+    /// How often to re-read the output device's format, in milliseconds.
+    /// </summary>
+    private const double device_check_interval_ms = 1000;
 
     private const int fallback_sample_rate = 44100;
     private const int output_channels = 2;
@@ -82,6 +106,15 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// </summary>
     internal bool UsesNativeMixEngine => nativeEngine != null;
 
+    /// <summary>
+    /// The device buffer SDL granted, in frames, or 0 where it would not say.
+    /// </summary>
+    /// <remarks>
+    /// What was granted, not what was asked for — a driver is free to round the hint to its own
+    /// quantum or ignore it outright, and only the granted figure is the output latency.
+    /// </remarks>
+    internal int DeviceBufferFrames => deviceBufferFrames;
+
     // The same two mixers as above at their concrete type, set only in managed mode, because Fill is
     // not part of the shared mixer surface.
     private readonly SDLAudioMixer? managedTrackMixer;
@@ -113,9 +146,86 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
     // Written on the mix thread, published to GlobalStatistics from Update on the audio thread so
     // the mix loop does no dictionary work.
-    private long underruns;
     private long mixMicroseconds;
     private double queuedMilliseconds;
+
+    /// <summary>
+    /// The managed mixer's starvation measurement. Unused on the native engine, which counts its own
+    /// accurately from a thread the GC cannot stop.
+    /// </summary>
+    private readonly DeviceStarvationTracker starvation = new DeviceStarvationTracker();
+
+    /// <summary>
+    /// Frames the device buffer actually turned out to be, or 0 where SDL would not say.
+    /// </summary>
+    /// <remarks>
+    /// What was asked for and what was granted are different numbers: the hint is a request, and a
+    /// driver is free to round it, clamp it, or ignore it. Only the granted one is a latency figure,
+    /// so only the granted one is logged and published.
+    /// </remarks>
+    private int deviceBufferFrames;
+
+    /// <summary>
+    /// The device sample rate seen at the last <see cref="checkForDeviceChange"/>, used to notice
+    /// the output device being swapped under us.
+    /// </summary>
+    private int lastSeenDeviceRate;
+
+    private int lastSeenDeviceBufferFrames;
+
+    /// <summary>
+    /// The device buffer as a duration, from the device's own rate rather than the mix rate, since
+    /// the two can differ after a device change.
+    /// </summary>
+    /// <remarks>
+    /// Microseconds in an int rather than milliseconds in a double because this is
+    /// written on the update thread and read by <see cref="OutputLatencyMs"/> from wherever a channel
+    /// happens to be asked for its position, and a double is not guaranteed tear-free on the
+    /// 32-bit runtimes this framework ships to. Microseconds are three more digits than a buffer
+    /// period needs.
+    /// </remarks>
+    private volatile int deviceBufferMicroseconds;
+
+    private double sinceDeviceCheckMs;
+
+    private readonly UnderrunWatchdog underrunWatchdog = new UnderrunWatchdog();
+
+    /// <summary>
+    /// This manager's own underrun count, as of the last <see cref="Update"/>.
+    /// </summary>
+    /// <remarks>
+    /// The <c>SDL Underruns</c> statistic is process-global and is overwritten by whichever manager
+    /// updated most recently, which makes it useless for asking "did <em>this</em> device starve" —
+    /// a question both the watchdog and the tests need answered. This is the per-manager figure.
+    /// </remarks>
+    private long lastPublishedUnderruns;
+
+    internal long Underruns => Interlocked.Read(ref lastPublishedUnderruns);
+
+    /// <summary>
+    /// Milliseconds the device spent with nothing to play, and the longest single interval of the mix
+    /// loop. Both are zero on the native engine, which has no mix loop of its own to measure.
+    /// </summary>
+    internal double StarvedMilliseconds => nativeEngine == null ? starvation.StarvedMilliseconds : 0;
+
+    internal double LongestMixGapMilliseconds => nativeEngine == null ? starvation.LongestGapMilliseconds : 0;
+
+    /// <summary>
+    /// The buffer size that was asked for, kept so the watchdog knows what to double.
+    /// </summary>
+    private readonly int requestedDeviceBufferFrames;
+
+    /// <summary>
+    /// Where to record a buffer size the machine turned out to need, or null where nothing is
+    /// persisting settings — a test, or a host that configured the manager directly.
+    /// </summary>
+    private readonly Action<int>? persistDeviceBufferFrames;
+
+    /// <summary>
+    /// Sampled once per <see cref="Update"/> and read by every channel, so all positions in a frame
+    /// are compensated by the same figure and no channel pays a P/Invoke per read.
+    /// </summary>
+    private volatile int outputLatencyFrames;
 
     private bool isDisposed;
 
@@ -123,9 +233,22 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// Whether to mix in <c>libsakura-audio</c> when it is available. False forces the managed
     /// reference mixer, which is what <see cref="AudioBackend.SDLManaged"/> selects.
     /// </param>
+    /// <param name="requestedDeviceBufferFrames">
+    /// Device buffer size to ask SDL for, in frames, or 0 to leave SDL's own default alone. Only
+    /// meaningful on the native engine — see <see cref="applyDeviceBufferHint"/>.
+    /// </param>
+    /// <param name="persistDeviceBufferFrames">
+    /// Called with a larger buffer size when this machine turns out not to keep up with the one it was
+    /// given, so the next launch starts somewhere that works — see
+    /// <see cref="handleSustainedUnderruns"/>. Null disables the backoff and leaves it a warning.
+    /// </param>
     /// <exception cref="InvalidOperationException">SDL audio could not be started.</exception>
-    public SDLAudioManager(bool useNativeMixEngine = true)
+    public SDLAudioManager(bool useNativeMixEngine = true, int requestedDeviceBufferFrames = DEFAULT_DEVICE_BUFFER_FRAMES,
+                           Action<int>? persistDeviceBufferFrames = null)
     {
+        this.requestedDeviceBufferFrames = requestedDeviceBufferFrames;
+        this.persistDeviceBufferFrames = persistDeviceBufferFrames;
+
         // Decoding runs through FFmpeg, so bring it up here rather than lazily on the first track:
         // a missing or mis-located native library should fail at startup, where it is diagnosable.
         FFmpegLibrary.EnsureInitialized();
@@ -139,6 +262,8 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
         if (useNativeMixEngine)
             nativeEngine = tryCreateNativeEngine();
+
+        applyDeviceBufferHint(requestedDeviceBufferFrames);
 
         var spec = new SDL_AudioSpec
         {
@@ -219,7 +344,221 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
             mixThread.Start();
         }
 
-        logInitialisationDetails();
+        logInitialisationDetails(requestedDeviceBufferFrames);
+    }
+
+    /// <summary>
+    /// Asks SDL for a device buffer of <paramref name="requestedFrames"/>, which is the output
+    /// latency and therefore the point of this backend.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only applied when the native engine is mixing. In managed mode the device buffer is not what
+    /// sets the latency — the push model keeps <see cref="target_queue_ms"/> of audio ahead of the
+    /// device on purpose, because a managed mix loop can be interrupted by the GC and that queue is
+    /// what stops the interruption being audible. Shrinking the device buffer underneath a queue an
+    /// order of magnitude larger buys nothing and costs a callback per 5 ms, so the fallback is left
+    /// exactly as SDL configured it and the log says why.
+    /// </para>
+    /// <para>
+    /// The hint is global to SDL and is read when a device is opened, so it must be set before
+    /// <c>SDL_OpenAudioDeviceStream</c> and it affects any device opened after this point. It is a
+    /// request: drivers round it to their own quantum, clamp it to their own floor, or ignore it.
+    /// <see cref="deviceBufferFrames"/> is what was actually granted, and that is the number worth
+    /// reading.
+    /// </para>
+    /// </remarks>
+    private void applyDeviceBufferHint(int requestedFrames)
+    {
+        if (requestedFrames <= 0)
+            return;
+
+        if (nativeEngine == null)
+        {
+            Logger.Verbose($"Device buffer hint of {requestedFrames} frames not applied: the managed mixer's latency is its "
+                           + $"{target_queue_ms} ms queue, not the device buffer.");
+            return;
+        }
+
+        int frames = Math.Clamp(requestedFrames, min_device_buffer_frames, max_device_buffer_frames);
+
+        if (frames != requestedFrames)
+        {
+            Logger.Warning($"An audio device buffer of {requestedFrames} frames is outside the supported range "
+                           + $"{min_device_buffer_frames}-{max_device_buffer_frames}; using {frames}.");
+        }
+
+        if (!SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames.ToString(CultureInfo.InvariantCulture)))
+            Logger.Warning($"SDL would not accept a device buffer hint of {frames} frames: {SDL_GetError()}");
+    }
+
+    /// <summary>
+    /// How far ahead of the listener the audio already produced is, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A channel's position counts frames it has produced, and a produced frame is not an audible
+    /// frame until the device has played it. Subtracting this is what makes
+    /// <see cref="IAudioChannel.CurrentTime"/> mean "what the listener is hearing" rather than "what
+    /// the mixer has reached", which is the difference between music and gameplay agreeing and
+    /// drifting apart by a buffer.
+    /// </para>
+    /// <para>
+    /// Two terms, and both are needed. <see cref="SDL_GetAudioStreamQueued"/> is what is waiting in
+    /// the stream and has not been handed to the device — the managed mixer's whole latency, and
+    /// essentially zero on the native engine, because there SDL asks the callback for exactly what it
+    /// needs and takes it immediately, leaving nothing queued for a poll to find. The device buffer is
+    /// the rest: audio the device has been given but has not finished playing. Reading only the queue
+    /// would have compensated the managed path correctly and the native path not at all, which is the
+    /// wrong way round — the native path is the one whose position feeds gameplay.
+    /// </para>
+    /// <para>
+    /// Whatever the driver and the hardware hold below SDL is not reported by any portable API and is
+    /// not included, so this is a floor on the true output latency rather than all of it. That is
+    /// still the right number to subtract: it is the part that changes with the buffer size, and the
+    /// remainder is a fixed offset that belongs in a user-facing calibration rather than in the clock.
+    /// </para>
+    /// </remarks>
+    public double OutputLatencyMs => outputLatencyFrames / (double)SampleRate * 1000.0 + deviceBufferMicroseconds / 1000.0;
+
+    /// <summary>
+    /// Re-reads the queue depth so every channel in this frame compensates by the same figure.
+    /// </summary>
+    private void sampleOutputLatency()
+    {
+        int bytes = SDL_GetAudioStreamQueued(deviceStream);
+        outputLatencyFrames = bytes <= 0 ? 0 : bytes / (sizeof(float) * output_channels);
+    }
+
+    /// <summary>
+    /// Recomputes the device half of <see cref="OutputLatencyMs"/> after the device format is read.
+    /// </summary>
+    private void updateDeviceBufferDuration(int frames, int rate) =>
+        deviceBufferMicroseconds = rate > 0 ? (int)Math.Round(frames / (double)rate * 1_000_000.0) : 0;
+
+    /// <summary>
+    /// Acts, once, when the device is starving steadily rather than occasionally.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what makes an aggressive default shippable rather than a gamble. The shipped device
+    /// buffer is chosen on measurement from the machines anyone has actually run — see AUDIO_SDL.md —
+    /// and the thing measurement cannot rule out is scheduling jitter somewhere nobody has tried. So
+    /// the default is a starting point that retreats under evidence rather than a promise.
+    /// </para>
+    /// <para>
+    /// The retreat is persisted and takes effect next launch rather than being applied here. Growing
+    /// the buffer live would mean tearing down and reopening the device underneath a callback that is
+    /// very likely running, for an audible gap, on a code path that exists for nothing else — and the
+    /// session it would rescue is one the listener has already heard crackle. Writing the number down
+    /// costs one line of config and fixes the machine permanently.
+    /// </para>
+    /// </remarks>
+    private void handleSustainedUnderruns(long total, double frameTime)
+    {
+        long? since = underrunWatchdog.Poll(total, frameTime);
+
+        if (since == null)
+            return;
+
+        string observed = $"The audio device underran {since} times in the last {UnderrunWatchdog.CHECK_INTERVAL_MS / 1000:F0} seconds, "
+                          + $"which is audible as crackling. The device buffer is {deviceBufferFrames} frames "
+                          + $"({deviceBufferMicroseconds / 1000.0:F1} ms).";
+
+        int? next = UnderrunWatchdog.NextBufferSize(requestedDeviceBufferFrames);
+
+        if (next == null || persistDeviceBufferFrames == null)
+        {
+            // Nothing to do but say so. Either the buffer was SDL's own choice and is already the
+            // driver's preference, or it is large enough that "too small" has stopped explaining
+            // anything, or nobody gave this manager somewhere to write the answer down.
+            Logger.Warning($"{observed} Raising AudioDeviceBufferFrames in framework.ini may help, but this buffer is "
+                           + "already at or past the point where a larger one is the likely fix — something else is "
+                           + "competing for the audio device. Reported once per run.");
+            return;
+        }
+
+        persistDeviceBufferFrames(next.Value);
+
+        Logger.Warning($"{observed} AudioDeviceBufferFrames has been raised to {next} for the next launch, which will "
+                       + $"trade {(next.Value - requestedDeviceBufferFrames) / (double)SampleRate * 1000.0:F1} ms of extra "
+                       + "output latency for a device that keeps up. Set it back in framework.ini to retry the smaller "
+                       + "buffer. Reported once per run.");
+    }
+
+    /// <summary>
+    /// Notices the output device being swapped or reconfigured under a running stream.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Polled rather than driven by <c>SDL_EVENT_AUDIO_DEVICE_*</c>, because the event queue belongs
+    /// to the window and an audio backend that only works when a window is pumping events is a
+    /// backend that stops working in tests and headless hosts. A device change is a human-scale
+    /// event, so once a second is prompt enough and costs one struct fill.
+    /// </para>
+    /// <para>
+    /// Nothing is reopened. The stream was opened on the default playback device and SDL migrates it
+    /// itself, converting our fixed mix rate to whatever the new device wants — so pitch does not
+    /// break, which is the failure this was originally expected to be. What does break is quieter:
+    /// the latency figures are now measured against a buffer that no longer exists, and a mix rate
+    /// that no longer matches the device means SDL is resampling everything a second time, after the
+    /// voices already resampled it once. Both are worth a line in the log and neither is worth
+    /// tearing down a working stream for.
+    /// </para>
+    /// </remarks>
+    private void checkForDeviceChange(double frameTime)
+    {
+        sinceDeviceCheckMs += frameTime;
+
+        if (sinceDeviceCheckMs < device_check_interval_ms)
+            return;
+
+        sinceDeviceCheckMs = 0;
+
+        var device = SDL_GetAudioStreamDevice(deviceStream);
+
+        if (device == 0)
+        {
+            // The stream is bound to nothing, so nothing is playing and nothing will say so. This is
+            // the silent stop the poll exists to catch.
+            if (lastSeenDeviceRate != 0)
+            {
+                Logger.Warning("The SDL audio device went away and the stream is no longer bound to one. Audio has stopped.");
+                lastSeenDeviceRate = 0;
+                lastSeenDeviceBufferFrames = 0;
+            }
+
+            return;
+        }
+
+        SDL_AudioSpec spec;
+        int frames;
+
+        if (!SDL_GetAudioDeviceFormat(device, &spec, &frames))
+            return;
+
+        if (spec.freq == lastSeenDeviceRate && frames == lastSeenDeviceBufferFrames)
+            return;
+
+        bool first = lastSeenDeviceRate == 0 && lastSeenDeviceBufferFrames == 0;
+
+        lastSeenDeviceRate = spec.freq;
+        lastSeenDeviceBufferFrames = frames;
+        deviceBufferFrames = frames;
+        updateDeviceBufferDuration(frames, spec.freq);
+
+        if (first)
+            return;
+
+        double bufferMs = spec.freq > 0 ? frames / (double)spec.freq * 1000.0 : 0;
+        Logger.Verbose($"Audio output device changed: now {SDL_GetAudioDeviceName(device)}, {spec.freq} Hz, "
+                       + $"{frames} frames ({bufferMs:F1} ms). Any latency figure recorded before this line is stale.");
+
+        if (spec.freq != SampleRate)
+        {
+            Logger.Warning($"The new audio device runs at {spec.freq} Hz and the mixer is fixed at {SampleRate} Hz, so SDL is "
+                           + "resampling the output a second time. Restart to mix at the device's rate.");
+        }
     }
 
     /// <summary>
@@ -251,14 +590,14 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// Creates a master mixer node and routes it into the engine's root.
     /// </summary>
     /// <exception cref="InvalidOperationException">The node pool is exhausted.</exception>
-    private static SDLNativeAudioMixer createNativeMixer(SakuraAudioEngine engine)
+    private SDLNativeAudioMixer createNativeMixer(SakuraAudioEngine engine)
     {
         uint node = engine.CreateMixer();
 
         if (node == 0 || !engine.AddChild(engine.Root, node))
             throw new InvalidOperationException("The native mix engine would not create a master mixer.");
 
-        return new SDLNativeAudioMixer(engine, node);
+        return new SDLNativeAudioMixer(this, engine, node);
     }
 
     /// <summary>
@@ -271,7 +610,7 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// they depend on how the shipped FFmpeg was configured, which is exactly the thing that is
     /// awkward to diagnose after the fact.
     /// </remarks>
-    private void logInitialisationDetails()
+    private void logInitialisationDetails(int localRequestedDeviceBufferFrames)
     {
         Logger.Verbose("🔈 SDL audio initialised");
 
@@ -289,9 +628,21 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
         if (SDL_GetAudioDeviceFormat(device, &deviceSpec, &deviceFrames))
         {
+            deviceBufferFrames = deviceFrames;
+            lastSeenDeviceRate = deviceSpec.freq;
+            lastSeenDeviceBufferFrames = deviceFrames;
+            updateDeviceBufferDuration(deviceFrames, deviceSpec.freq);
+
             double deviceBufferMs = deviceSpec.freq > 0 ? deviceFrames / (double)deviceSpec.freq * 1000.0 : 0;
             Logger.Verbose($"Device format: {deviceSpec.freq} Hz, {deviceSpec.channels} ch, {formatName(deviceSpec.format)}");
-            Logger.Verbose($"Device buffer: {deviceFrames} frames ({deviceBufferMs:F1} ms)");
+
+            // Says both numbers, because a driver that ignored the hint is otherwise indistinguishable
+            // from one that honored it
+            string granted = localRequestedDeviceBufferFrames <= 0 || nativeEngine == null || deviceFrames == localRequestedDeviceBufferFrames
+                ? string.Empty
+                : $", asked for {localRequestedDeviceBufferFrames}";
+
+            Logger.Verbose($"Device buffer: {deviceFrames} frames ({deviceBufferMs:F1} ms{granted})");
         }
         else
         {
@@ -385,26 +736,51 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     {
         var stopwatch = new Stopwatch();
 
+        // Starvation is derived from how long each iteration took rather than observed while it was
+        // happening, because the event worth measuring is one that stops this thread. See
+        // DeviceStarvationTracker.
+        //
+        // The interval runs from the top of one iteration to the top of the next, so that it *contains*
+        // the sleep and the mixing. Measuring from the bottom of one to the top of the next — which is
+        // what this did at first — times only the loop condition, reports a longest gap of 0.0 ms on a
+        // run containing second-long collections, and can never see a stall at all.
+        var interval = new Stopwatch();
+
+        double playableAtIntervalStart = 0;
+        double pushedDuringInterval = 0;
+        double blockMs = mix_block_frames / (double)SampleRate * 1000.0;
+
         while (!cancellation.IsCancellationRequested)
         {
+            if (interval.IsRunning)
+            {
+                // What the device had to play across the interval: what was already queued when it
+                // began, plus whatever this loop managed to push into it before the interval ended.
+                starvation.Observe(interval.Elapsed.TotalMilliseconds, playableAtIntervalStart + pushedDuringInterval,
+                    runningVoices() > 0);
+            }
+
+            interval.Restart();
+
             double queued = queuedMs();
             queuedMilliseconds = queued;
+
+            playableAtIntervalStart = queued;
+            pushedDuringInterval = 0;
 
             if (queued >= target_queue_ms)
             {
                 // Sleep well short of the queue depth, so scheduling jitter cannot drain it.
                 Thread.Sleep(1);
-                continue;
             }
+            else
+            {
+                stopwatch.Restart();
+                mixOneBlock();
+                mixMicroseconds = stopwatch.ElapsedTicks * 1_000_000 / Stopwatch.Frequency;
 
-            // Nothing queued while audio is playing means the device ran dry and the listener heard
-            // it. This is the number that says whether the design is holding up.
-            if (queued <= 0 && runningVoices() > 0)
-                Interlocked.Increment(ref underruns);
-
-            stopwatch.Restart();
-            mixOneBlock();
-            mixMicroseconds = stopwatch.ElapsedTicks * 1_000_000 / Stopwatch.Frequency;
+                pushedDuringInterval += blockMs;
+            }
         }
     }
 
@@ -496,7 +872,7 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
             return null;
         }
 
-        var channel = new SDLNativeAudioChannel(nativeEngine, node, lengthMs);
+        var channel = new SDLNativeAudioChannel(this, nativeEngine, node, lengthMs);
 
         register(channel, mixer, null);
 
@@ -537,7 +913,7 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
             throw;
         }
 
-        var channel = new SDLNativeAudioChannel(nativeEngine, node, feeder.LengthMs, feeder);
+        var channel = new SDLNativeAudioChannel(this, nativeEngine, node, feeder.LengthMs, feeder);
 
         register(channel, mixer, feeder);
 
@@ -610,6 +986,11 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
             }
         }
 
+        // Before PollEvents, because a channel that reads its position while handling an end or a
+        // loop should see this frame's figure rather than the last one's.
+        sampleOutputLatency();
+        checkForDeviceChange(frameTime);
+
         if (nativeEngine != null)
         {
             // The audio thread cannot raise a managed event, so anything a voice signalled — it ended,
@@ -626,15 +1007,33 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
             // "Callback", not "Mix Block": there is a real device callback to time now.
             GlobalStatistics.Get<long>("Audio", "SDL Callback (µs)").Value = stats.CallbackMicroseconds;
             GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value = stats.Starvations;
+
+            Interlocked.Exchange(ref lastPublishedUnderruns, stats.Starvations);
+            handleSustainedUnderruns(stats.Starvations, frameTime);
             GlobalStatistics.Get<long>("Audio", "SDL Put Failures").Value = stats.PutFailures;
             GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value = stats.ActiveVoices;
+            GlobalStatistics.Get<int>("Audio", "SDL Device Buffer (frames)").Value = deviceBufferFrames;
+            GlobalStatistics.Get<double>("Audio", "SDL Output Latency (ms)").Value = Math.Round(OutputLatencyMs, 2);
             return;
         }
 
-        GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value = Interlocked.Read(ref underruns);
+        // Counted in mix blocks of missing output, which is this mixer's natural unit — the native
+        // engine's count is per voice per block and the two are not comparable. Starved (ms) is, and is
+        // published by both for exactly that reason.
+        double blockMs = mix_block_frames / (double)SampleRate * 1000.0;
+        long managedUnderruns = starvation.CountIn(blockMs);
+
+        Interlocked.Exchange(ref lastPublishedUnderruns, managedUnderruns);
+        GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value = managedUnderruns;
+        GlobalStatistics.Get<double>("Audio", "SDL Starved (ms)").Value = Math.Round(starvation.StarvedMilliseconds, 1);
+        GlobalStatistics.Get<double>("Audio", "SDL Longest Mix Gap (ms)").Value = Math.Round(starvation.LongestGapMilliseconds, 1);
         GlobalStatistics.Get<long>("Audio", "SDL Mix Block (µs)").Value = mixMicroseconds;
+
+        handleSustainedUnderruns(managedUnderruns, frameTime);
         GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value = runningVoices();
         GlobalStatistics.Get<double>("Audio", "SDL Queued (ms)").Value = Math.Round(queuedMilliseconds, 1);
+        GlobalStatistics.Get<int>("Audio", "SDL Device Buffer (frames)").Value = deviceBufferFrames;
+        GlobalStatistics.Get<double>("Audio", "SDL Output Latency (ms)").Value = Math.Round(OutputLatencyMs, 2);
     }
 
     public void StopAll()

--- a/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioChannel.cs
@@ -75,6 +75,14 @@ internal class SDLNativeAudioChannel : ISDLChannel
     protected readonly SakuraAudioEngine Engine;
 
     /// <summary>
+    /// The manager, for the one thing a voice cannot know on its own: how far behind the mix the
+    /// device is.
+    /// </summary>
+    protected readonly ISDLAudioContext Context;
+
+    private readonly OutputLatencyCompensator latency = new OutputLatencyCompensator();
+
+    /// <summary>
     /// The native node this channel drives.
     /// </summary>
     internal uint Node { get; }
@@ -118,8 +126,9 @@ internal class SDLNativeAudioChannel : ISDLChannel
 
     public double Length { get; }
 
-    public SDLNativeAudioChannel(SakuraAudioEngine engine, uint node, double lengthMs, NativeStreamFeeder? feeder = null)
+    public SDLNativeAudioChannel(ISDLAudioContext context, SakuraAudioEngine engine, uint node, double lengthMs, NativeStreamFeeder? feeder = null)
     {
+        Context = context;
         Engine = engine;
         Node = node;
         Length = lengthMs;
@@ -259,6 +268,7 @@ internal class SDLNativeAudioChannel : ISDLChannel
     /// </summary>
     private void armSeekReport(double milliseconds)
     {
+        latency.Reset();
         baseMs = feeder != null ? Math.Max(0, milliseconds) : 0;
         seekTargetMs = Math.Max(0, milliseconds);
         seekPostedAtEpoch = Engine.TryGetState(Node, out var state) ? state.SeekEpoch : 0;
@@ -272,11 +282,15 @@ internal class SDLNativeAudioChannel : ISDLChannel
                 return 0;
 
             // Still waiting on the audio thread: the cursor it is reporting belongs to the position we
-            // are leaving, so answer with the one we are going to.
+            // are leaving, so answer with the one we are going to. Uncompensated on purpose — nothing
+            // of the new position has been mixed yet, let alone queued, so there is no latency to
+            // subtract and subtracting one would report a seek as landing short.
             if (state.SeekEpoch == seekPostedAtEpoch)
                 return seekTargetMs;
 
-            return baseMs + state.SourceFrames / (double)Engine.SampleRate * 1000.0;
+            double raw = baseMs + state.SourceFrames / (double)Engine.SampleRate * 1000.0;
+
+            return latency.Compensate(raw, Context.OutputLatencyMs, Frequency.Value);
         }
         set
         {
@@ -316,6 +330,10 @@ internal class SDLNativeAudioChannel : ISDLChannel
             return;
 
         lastEndEpoch = state.EndEpoch;
+
+        // A voice over a shared buffer wraps inside the engine without anything here seeking it, so
+        // this is the only notice the compensator gets that the position jumped.
+        latency.Reset();
 
         OnEnd?.Invoke();
 

--- a/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioChannel.cs
@@ -1,0 +1,367 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Sakura.Framework.Reactive;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// A handle onto one voice inside <c>libsakura-audio</c>, presented as an <see cref="IAudioChannel"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The counterpart to <see cref="SDLAudioChannel"/>, and deliberately the same public surface: the
+/// difference is where the audio is mixed. Nothing here touches a sample. Gain, pan and rate are
+/// single atomic stores the native mixer reads once per block; play, stop and seek are commands
+/// applied in order on the audio thread; and the audio itself is either PCM the native engine holds
+/// or a ring a <see cref="NativeStreamFeeder"/> fills from the decode thread.
+/// </para>
+/// <para>
+/// The one thing the native side cannot do is raise a managed event, so an ended or looped voice
+/// publishes a counter and <see cref="PollEvents"/> turns it into <see cref="OnEnd"/> on the update
+/// thread. That is the same place the managed mixer's queued events are raised, so the two behave
+/// alike from a caller's point of view.
+/// </para>
+/// </remarks>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal class SDLNativeAudioChannel : ISDLChannel
+{
+    public event Action OnStart = () => { };
+    public event Action OnStop = () => { };
+    public event Action OnEnd = () => { };
+
+    public event Action? Disposed;
+
+    public ReactiveBool IsRunning { get; } = new ReactiveBool();
+
+    public Reactive<double> Volume { get; } = new Reactive<double>(1.0);
+    public Reactive<double> Frequency { get; } = new Reactive<double>(1.0);
+    public Reactive<double> Balance { get; } = new Reactive<double>(0.0);
+
+    /// <summary>
+    /// Pitch-preserving speed. A no-op on this backend, as <see cref="IAudioChannel.Tempo"/> permits
+    /// for backends without a tempo DSP — a WSOLA implementation is a later item.
+    /// </summary>
+    public Reactive<double> Tempo { get; } = new Reactive<double>(1.0);
+
+    public bool AutoDispose { get; set; }
+
+    private bool looping;
+
+    public bool Looping
+    {
+        get => looping;
+        set
+        {
+            looping = value;
+            publishLoop();
+        }
+    }
+
+    private double restartPoint;
+
+    public double RestartPoint
+    {
+        get => restartPoint;
+        set
+        {
+            restartPoint = value;
+            publishLoop();
+        }
+    }
+
+    protected readonly SakuraAudioEngine Engine;
+
+    /// <summary>
+    /// The native node this channel drives.
+    /// </summary>
+    internal uint Node { get; }
+
+    /// <summary>
+    /// The decode side of a streaming voice, or null for one playing a shared PCM buffer.
+    /// </summary>
+    private readonly NativeStreamFeeder? feeder;
+
+    private readonly NativeAmplitudeReader amplitudes = new NativeAmplitudeReader();
+
+    private SDLLowPassFilter? filter;
+
+    private volatile bool isDisposed;
+
+    protected bool IsDisposed => isDisposed;
+
+    /// <summary>
+    /// Where a streaming voice's position is measured from. The native side counts frames since the
+    /// last seek, because a ring buffer has no idea where in the song it sits; a voice over a shared
+    /// buffer reports an absolute cursor and needs no base at all.
+    /// </summary>
+    private double baseMs;
+
+    /// <summary>
+    /// The position to report, and the seek epoch it is waiting on, while a posted seek has not been
+    /// applied yet. Without this a read in that window pairs the old cursor with the new base.
+    /// </summary>
+    private double seekTargetMs;
+
+    /// <summary>
+    /// The epoch a posted seek is waiting to see change, or -1 when none is outstanding.
+    /// </summary>
+    /// <remarks>
+    /// Not zero: a voice that has never been seeked reports epoch 0, so a zero here would read as a
+    /// seek to 0 that never lands, and the position would sit at zero for the whole track.
+    /// </remarks>
+    private long seekPostedAtEpoch = -1;
+
+    private long lastEndEpoch;
+
+    public double Length { get; }
+
+    public SDLNativeAudioChannel(SakuraAudioEngine engine, uint node, double lengthMs, NativeStreamFeeder? feeder = null)
+    {
+        Engine = engine;
+        Node = node;
+        Length = lengthMs;
+        this.feeder = feeder;
+
+        IsRunning.ValueChanged += e =>
+        {
+            if (e.NewValue) OnStart?.Invoke();
+            else OnStop?.Invoke();
+        };
+
+        Volume.ValueChanged += _ => publishGain();
+        Balance.ValueChanged += _ => publishGain();
+        Frequency.ValueChanged += e => Engine.SetRate(Node, e.NewValue);
+
+        publishGain();
+    }
+
+    private void publishGain()
+    {
+        // The pan law lives here rather than in the native engine, next to the BASS backend's, so the
+        // two can be compared: linear, full on one side at the extreme, both sides unity at centre.
+        double balance = Math.Clamp(Balance.Value, -1.0, 1.0);
+
+        float left = (float)(balance <= 0 ? 1.0 : 1.0 - balance);
+        float right = (float)(balance >= 0 ? 1.0 : 1.0 + balance);
+
+        Engine.SetGain(Node, (float)Math.Max(0, Volume.Value), left, right);
+    }
+
+    private void publishLoop()
+    {
+        // A streaming voice cannot wrap itself: only this side can seek its decoder. It is still told
+        // that it loops, so that it publishes the end and keeps running rather than stopping.
+        Engine.SetLoop(Node, looping, millisecondsToFrames(restartPoint));
+    }
+
+    private long millisecondsToFrames(double milliseconds) =>
+        (long)(Math.Max(0, milliseconds) / 1000.0 * Engine.SampleRate);
+
+    #region Filter
+
+    /// <summary>
+    /// The low-pass insert attached to this channel, if any.
+    /// </summary>
+    internal SDLLowPassFilter? Filter => filter;
+
+    /// <summary>
+    /// Attaches a low-pass filter, replacing any existing one.
+    /// </summary>
+    /// <remarks>
+    /// The filter object is the managed one, used purely as a coefficient calculator: it is where the
+    /// cutoff maths lives and where it is tested, and the native voice applies whatever it publishes.
+    /// </remarks>
+    internal SDLLowPassFilter AttachLowPassFilter()
+    {
+        filter?.Dispose();
+
+        var attached = new SDLLowPassFilter(Engine.SampleRate, Engine.Channels);
+
+        attached.CoefficientsChanged += publishFilter;
+
+        var (enabled, coefficients) = attached.CurrentCoefficients;
+        publishFilter(enabled, coefficients);
+
+        filter = attached;
+        return attached;
+    }
+
+    private void publishFilter(bool enabled, SDLLowPassFilter.Coefficients coefficients)
+    {
+        if (isDisposed)
+            return;
+
+        Engine.SetFilter(Node, enabled, coefficients.B0, coefficients.B1, coefficients.B2, coefficients.A1, coefficients.A2);
+    }
+
+    #endregion
+
+    #region Transport
+
+    public virtual void Play()
+    {
+        if (isDisposed)
+            return;
+
+        // Replaying something that already finished should start it over rather than sit at the end
+        // producing silence. A shared buffer rewinds itself inside the engine; a stream cannot, since
+        // rewinding it means rewinding a decoder.
+        if (feeder != null && Engine.TryGetState(Node, out var state) && state.Ended != 0)
+            seekInternal(Looping ? RestartPoint : 0);
+
+        Engine.Play(Node);
+        IsRunning.Value = true;
+    }
+
+    public virtual void Stop()
+    {
+        if (isDisposed)
+            return;
+
+        // Matches the BASS backend, where Stop rewinds and Pause does not.
+        Engine.Stop(Node);
+        armSeekReport(0);
+        IsRunning.Value = false;
+    }
+
+    public virtual void Pause()
+    {
+        if (isDisposed)
+            return;
+
+        Engine.Pause(Node);
+        IsRunning.Value = false;
+    }
+
+    /// <summary>
+    /// Moves both halves of the voice: the decoder, where there is one, and the engine's own cursor
+    /// and DSP state.
+    /// </summary>
+    private void seekInternal(double milliseconds)
+    {
+        // Order matters. The engine's seek resets the interpolation window, the filter's delay line
+        // and the metering, and zeroes its frame count; the feeder then discards what is buffered and
+        // decodes from the new position. Doing it the other way round would let the engine's reset
+        // land on audio the feeder had already written.
+        Engine.Seek(Node, millisecondsToFrames(milliseconds));
+        armSeekReport(milliseconds);
+
+        feeder?.Seek(milliseconds);
+        amplitudes.Reset();
+    }
+
+    /// <summary>
+    /// Records where the position is being moved to, and the seek epoch that was current when it was
+    /// asked for, so <see cref="CurrentTime"/> can report the target until the engine confirms it.
+    /// </summary>
+    private void armSeekReport(double milliseconds)
+    {
+        baseMs = feeder != null ? Math.Max(0, milliseconds) : 0;
+        seekTargetMs = Math.Max(0, milliseconds);
+        seekPostedAtEpoch = Engine.TryGetState(Node, out var state) ? state.SeekEpoch : 0;
+    }
+
+    public double CurrentTime
+    {
+        get
+        {
+            if (isDisposed || !Engine.TryGetState(Node, out var state))
+                return 0;
+
+            // Still waiting on the audio thread: the cursor it is reporting belongs to the position we
+            // are leaving, so answer with the one we are going to.
+            if (state.SeekEpoch == seekPostedAtEpoch)
+                return seekTargetMs;
+
+            return baseMs + state.SourceFrames / (double)Engine.SampleRate * 1000.0;
+        }
+        set
+        {
+            if (isDisposed)
+                return;
+
+            seekInternal(value);
+        }
+    }
+
+    #endregion
+
+    public float AmplitudeLeft => CurrentAmplitudes.AmplitudeLeft;
+
+    public float AmplitudeRight => CurrentAmplitudes.AmplitudeRight;
+
+    public virtual ChannelAmplitudes CurrentAmplitudes
+    {
+        get
+        {
+            if (isDisposed || !IsRunning.Value)
+                return ChannelAmplitudes.Empty;
+
+            return amplitudes.Read(Engine, Node);
+        }
+    }
+
+    /// <summary>
+    /// Turns anything the voice has signalled into events, on the update thread.
+    /// </summary>
+    public void PollEvents()
+    {
+        if (isDisposed || !Engine.TryGetState(Node, out var state))
+            return;
+
+        if (state.EndEpoch == lastEndEpoch)
+            return;
+
+        lastEndEpoch = state.EndEpoch;
+
+        OnEnd?.Invoke();
+
+        if (Looping)
+        {
+            // A voice over a shared buffer has already wrapped itself inside the engine and is still
+            // playing; a stream is sitting on an empty ring waiting to be told where to go.
+            if (feeder != null)
+                seekInternal(RestartPoint);
+
+            return;
+        }
+
+        IsRunning.Value = false;
+
+        if (AutoDispose)
+            Dispose();
+    }
+
+    public virtual void Dispose()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+
+        if (filter != null)
+        {
+            filter.CoefficientsChanged -= publishFilter;
+            filter.Dispose();
+            filter = null;
+        }
+
+        // The engine unlinks the voice from the graph on its own thread and only then marks the slot
+        // reclaimable, so nothing here has to wait for a callback to finish.
+        Engine.DestroyNode(Node);
+
+        feeder?.Dispose();
+
+        IsRunning.Value = false;
+        OnStart = null!;
+        OnStop = null!;
+        OnEnd = null!;
+
+        var disposed = Disposed;
+        Disposed = null;
+        disposed?.Invoke();
+    }
+}

--- a/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioMixer.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioMixer.cs
@@ -34,8 +34,8 @@ internal sealed class SDLNativeAudioMixer : SDLNativeAudioChannel, ISDLMixer
     /// </remarks>
     private volatile IAudioChannel[] snapshot = Array.Empty<IAudioChannel>();
 
-    public SDLNativeAudioMixer(SakuraAudioEngine engine, uint node)
-        : base(engine, node, 0)
+    public SDLNativeAudioMixer(ISDLAudioContext context, SakuraAudioEngine engine, uint node)
+        : base(context, engine, node, 0)
     {
     }
 

--- a/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioMixer.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioMixer.cs
@@ -9,10 +9,17 @@ using System.Threading;
 namespace Sakura.Framework.Audio.SdlEngine;
 
 /// <summary>
-/// SDL implementation of <see cref="IAudioMixer"/>
+/// A mixer node inside <c>libsakura-audio</c>, presented as an <see cref="IAudioMixer"/>.
 /// </summary>
+/// <remarks>
+/// A native mixer sums its children and then applies its own gain, filter and metering exactly as a
+/// voice does, which is what preserves <see cref="BassEngine.BassAudioMixer"/>'s semantics. SDL's own
+/// device mixing is flat, so routing everything straight at the device would have left
+/// <see cref="IAudioManager.TrackMixer"/> and <see cref="IAudioManager.SampleMixer"/> as bookkeeping
+/// with no per-mixer volume, filter or spectrum.
+/// </remarks>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-internal sealed class SDLAudioMixer : SDLAudioChannel, ISDLMixer
+internal sealed class SDLNativeAudioMixer : SDLNativeAudioChannel, ISDLMixer
 {
     private readonly Lock sync = new Lock();
     private readonly List<IAudioChannel> channels = new List<IAudioChannel>();
@@ -27,13 +34,8 @@ internal sealed class SDLAudioMixer : SDLAudioChannel, ISDLMixer
     /// </remarks>
     private volatile IAudioChannel[] snapshot = Array.Empty<IAudioChannel>();
 
-    /// <summary>
-    /// Sum of this mixer's children for the current block, before its own inserts.
-    /// </summary>
-    private float[] scratch = Array.Empty<float>();
-
-    public SDLAudioMixer(ISDLAudioContext context)
-        : base(context, null)
+    public SDLNativeAudioMixer(SakuraAudioEngine engine, uint node)
+        : base(engine, node, 0)
     {
     }
 
@@ -50,12 +52,17 @@ internal sealed class SDLAudioMixer : SDLAudioChannel, ISDLMixer
 
     public void AddChannel(IAudioChannel channel)
     {
-        if (channel is not SDLAudioChannel)
+        if (channel is not SDLNativeAudioChannel native)
             return;
 
         lock (sync)
         {
             if (channels.Contains(channel))
+                return;
+
+            // The graph edge is the engine's; this list exists only so the visualiser has something to
+            // enumerate, since the native graph is not walkable from here.
+            if (!Engine.AddChild(Node, native.Node))
                 return;
 
             channels.Add(channel);
@@ -69,6 +76,9 @@ internal sealed class SDLAudioMixer : SDLAudioChannel, ISDLMixer
         {
             if (!channels.Remove(channel))
                 return;
+
+            if (channel is SDLNativeAudioChannel native)
+                Engine.RemoveChild(Node, native.Node);
 
             snapshot = channels.ToArray();
         }
@@ -92,32 +102,6 @@ internal sealed class SDLAudioMixer : SDLAudioChannel, ISDLMixer
 
             return count;
         }
-    }
-
-    public override void Fill(Span<float> destination)
-    {
-        if (IsDisposed || !IsRunning.Value)
-            return;
-
-        var current = snapshot;
-
-        if (current.Length == 0)
-            return;
-
-        if (scratch.Length < destination.Length)
-            scratch = new float[destination.Length];
-
-        var block = scratch.AsSpan(0, destination.Length);
-        block.Clear();
-
-        foreach (var channel in current)
-        {
-            // Children add into the shared block; a stopped or starved one contributes nothing.
-            if (channel is SDLAudioChannel sdlChannel)
-                sdlChannel.Fill(block);
-        }
-
-        ApplyInsertsAndMix(block, destination);
     }
 
     public override void Dispose()

--- a/Sakura.Framework/Audio/SdlEngine/SDLSample.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLSample.cs
@@ -19,12 +19,23 @@ namespace Sakura.Framework.Audio.SdlEngine;
 internal sealed class SDLSample : ISample, IHasActiveChannels, IDisposable
 {
     private readonly SDLAudioManager manager;
+
+    /// <summary>
+    /// The decoded PCM, for the managed mixer. Null on the native path, where the engine holds its own
+    /// copy and this one would only be a second copy of the same audio.
+    /// </summary>
     private readonly PcmBuffer? buffer;
+
+    /// <summary>
+    /// The native engine's copy of the decoded PCM, shared by every voice playing this sample, or 0 on
+    /// the managed path.
+    /// </summary>
+    private uint nativeBuffer;
 
     private int activeChannelCount;
     private bool isDisposed;
 
-    public double Length => buffer?.LengthMs ?? 0;
+    public double Length { get; }
 
     public bool HasActiveChannels => Volatile.Read(ref activeChannelCount) > 0;
 
@@ -44,25 +55,60 @@ internal sealed class SDLSample : ISample, IHasActiveChannels, IDisposable
 
         try
         {
-            buffer = PcmBuffer.Decode(open(), manager.SampleRate, manager.Channels);
+            var decoded = PcmBuffer.Decode(open(), manager.SampleRate, manager.Channels);
+
+            Length = decoded.LengthMs;
+
+            if (manager.UsesNativeMixEngine)
+            {
+                // Handed over and then dropped: the engine copies the PCM into memory the audio thread
+                // can read without touching anything managed, so keeping the managed array as well
+                // would double the cost of every loaded sample for nothing.
+                nativeBuffer = manager.NativeEngine!.CreateBuffer(decoded.Samples);
+
+                if (nativeBuffer == 0)
+                    throw new InvalidOperationException("The native mix engine would not take the decoded sample.");
+            }
+            else
+            {
+                buffer = decoded;
+            }
 
             GlobalStatistics.Get<int>("Audio", "Loaded Samples").Value++;
-            Logger.Verbose($"🔈 Sample decoded to PCM ({buffer.Samples.Length * sizeof(float) / 1024} KB, {buffer.LengthMs:F0}ms)");
+            Logger.Verbose($"🔈 Sample decoded to PCM ({decoded.Samples.Length * sizeof(float) / 1024} KB, {decoded.LengthMs:F0}ms)");
         }
         catch (Exception e)
         {
             Logger.Error("Could not decode a sample.", e);
             buffer = null;
+            Length = 0;
         }
     }
 
     public IAudioChannel GetChannel()
     {
-        if (isDisposed || buffer == null)
+        if (isDisposed)
             return null!;
 
-        var source = new MemoryPcmSource(buffer);
-        var channel = manager.CreateChannel(source, manager.SampleMixer, streaming: false);
+        ISDLChannel? channel;
+
+        if (manager.UsesNativeMixEngine)
+        {
+            if (nativeBuffer == 0)
+                return null!;
+
+            channel = manager.CreateNativeBufferChannel(nativeBuffer, Length, manager.SampleMixer);
+        }
+        else
+        {
+            if (buffer == null)
+                return null!;
+
+            channel = manager.CreateChannel(new MemoryPcmSource(buffer), manager.SampleMixer, streaming: false);
+        }
+
+        if (channel == null)
+            return null!;
 
         Interlocked.Increment(ref activeChannelCount);
         channel.Disposed += () => Interlocked.Decrement(ref activeChannelCount);
@@ -90,10 +136,17 @@ internal sealed class SDLSample : ISample, IHasActiveChannels, IDisposable
 
         isDisposed = true;
 
-        if (buffer != null)
+        if (buffer != null || nativeBuffer != 0)
             GlobalStatistics.Get<int>("Audio", "Loaded Samples").Value--;
 
-        // Channels hold their own reference to the buffer through MemoryPcmSource, and the GC frees
-        // it once the last of them is gone — there is no unmanaged block to release here.
+        // On the managed path, channels hold their own reference to the buffer through
+        // MemoryPcmSource and the GC frees it once the last of them is gone. On the native path this
+        // drops only *this* object's claim on the engine's copy; every playing voice holds one of its
+        // own, so a sample disposed mid-hitsound does not cut it off.
+        if (nativeBuffer != 0)
+        {
+            manager.NativeEngine?.ReleaseBuffer(nativeBuffer);
+            nativeBuffer = 0;
+        }
     }
 }

--- a/Sakura.Framework/Audio/SdlEngine/SDLTrack.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLTrack.cs
@@ -133,8 +133,17 @@ internal sealed unsafe class SDLTrack : ITrack, IHasActiveChannels, IDisposable
                 return null!;
             }
 
-            var source = new StreamingPcmSource(stream, manager.SampleRate, manager.Channels);
-            var channel = manager.CreateChannel(source, manager.TrackMixer, streaming: true);
+            // Both engines stream a track: the difference is only whose ring buffer the decode thread
+            // fills. The native one is drained by the device callback with no managed code involved.
+            var channel = manager.UsesNativeMixEngine
+                ? manager.CreateNativeStreamingChannel(stream, manager.TrackMixer)
+                : manager.CreateChannel(new StreamingPcmSource(stream, manager.SampleRate, manager.Channels), manager.TrackMixer, streaming: true);
+
+            if (channel == null)
+            {
+                if (holdsReference) data!.Release();
+                return null!;
+            }
 
             Interlocked.Increment(ref activeChannelCount);
 

--- a/Sakura.Framework/Audio/SdlEngine/SakuraAudioNative.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SakuraAudioNative.cs
@@ -58,6 +58,17 @@ internal struct SakuraAudioNodeState
     /// </summary>
     public long EndEpoch;
 
+    /// <summary>
+    /// Bumped once per applied seek, so a caller can tell whether the seek it posted has landed.
+    /// </summary>
+    /// <remarks>
+    /// A seek is posted as a command and applied on the audio thread, so there is a window of one
+    /// device callback where <see cref="SourceFrames"/> is still the old cursor. Reporting a position
+    /// from it in that window pairs the old cursor with the new base, which reads as a jump backwards
+    /// and then forwards again — and a clock chain turns that into audible desync.
+    /// </remarks>
+    public long SeekEpoch;
+
     public int Running;
     public int Ended;
 
@@ -71,14 +82,18 @@ internal struct SakuraAudioNodeState
 /// </summary>
 internal static class SakuraAudioNative
 {
-    private const string lib_name = "libsakura-audio";
+    // Unprefixed on purpose: the runtime adds the "lib" prefix and the platform suffix on Unix, so
+    // this one name resolves libsakura-audio.dylib, libsakura-audio.so and sakura-audio.dll -- which
+    // is what CMake produces by default on each, and what every other native in runtimes/win-* looks
+    // like. iOS does not probe at all; see SetupLibraryResolvers.
+    private const string lib_name = "sakura-audio";
 
     /// <summary>
     /// The ABI this assembly was built against. Must match <c>SAKURA_AUDIO_ABI_VERSION</c> in
     /// <c>sakura_audio.h</c>, a shipped library that disagrees is refused rather than trusted to have
     /// the same struct layouts.
     /// </summary>
-    public const int ABI_VERSION = 1;
+    public const int ABI_VERSION = 2;
 
     /// <summary>
     /// Transform size and bin count of the native spectrum, fixed to line up with

--- a/Sakura.Framework/Audio/SdlEngine/StreamingPcmSource.cs
+++ b/Sakura.Framework/Audio/SdlEngine/StreamingPcmSource.cs
@@ -27,7 +27,7 @@ namespace Sakura.Framework.Audio.SdlEngine;
 /// under a superseded generation rather than letting a moment of pre-seek audio through.
 /// </para>
 /// </remarks>
-internal sealed class StreamingPcmSource : IPcmSource
+internal sealed class StreamingPcmSource : IPcmSource, IDecodeSource
 {
     /// <summary>
     /// How far ahead to decode. Large enough that a GC pause or a slow read cannot starve the mixer,

--- a/Sakura.Framework/Audio/SdlEngine/UnderrunWatchdog.cs
+++ b/Sakura.Framework/Audio/SdlEngine/UnderrunWatchdog.cs
@@ -1,0 +1,122 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Sakura.Framework.Audio.SdlEngine;
+
+/// <summary>
+/// Decides when the output device is starving badly enough that its buffer is the wrong size for this
+/// machine, and what to do about it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sakura set the default device buffer really aggressive (see <see cref="SDLAudioManager.DEFAULT_DEVICE_BUFFER_FRAMES"/> that's the default value)
+/// because measurement says the callback has an order of magnitude of headroom at that size and because a driver that cannot honor the
+/// request rounds it up rather than failing. What measurement cannot rule out is scheduling jitter on
+/// a machine nobody has tested, and the symptom of getting that wrong is crackling that a user has no
+/// way to connect to a setting they have never heard of.
+/// </para>
+/// <para>
+/// So the default is not a promise, it is a starting point that retreats under evidence. This type is
+/// the evidence half: it watches the underrun counter and reports the one transition worth acting on.
+/// Separated from the manager because the interesting cases — a burst that should be ignored, a
+/// sustained failure that should not, the guarantee of acting only once — are all about counting and
+/// timing, and none of them need an audio device to test.
+/// </para>
+/// </remarks>
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+internal sealed class UnderrunWatchdog
+{
+    /// <summary>
+    /// Window over which underruns are counted, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Five seconds since long enough that one stall on startup, during a device change, or from a hitch
+    /// elsewhere in the app cannot trip it, and short enough that a listener has not been putting up
+    /// with crackling for long before something says so.
+    /// </remarks>
+    public const double CHECK_INTERVAL_MS = 5000;
+
+    /// <summary>
+    /// How many underruns inside <see cref="CHECK_INTERVAL_MS"/> mean the buffer is genuinely too
+    /// small, rather than the machine having had a bad moment.
+    /// </summary>
+    public const long THRESHOLD = 10;
+
+    /// <summary>
+    /// The largest buffer this will grow to on its own.
+    /// </summary>
+    /// <remarks>
+    /// 1024 frames is roughly what SDL picks unprompted, so it is the point past which "the buffer is
+    /// too small" has stopped being a credible explanation. Something else is wrong — a device being
+    /// hammered by another app, a driver in a bad state, a machine that is simply overloaded — and
+    /// doubling again would trade latency for nothing.
+    /// </remarks>
+    public const int MAX_AUTO_BACKOFF_FRAMES = 1024;
+
+    private long underrunsAtLastCheck;
+    private double sinceCheckMs;
+
+    /// <summary>
+    /// Whether this run has already reported sustained starvation.
+    /// </summary>
+    /// <remarks>
+    /// Once per run, for two reasons. A device that is underrunning keeps underrunning, so a warning
+    /// every five seconds buries the log it exists to help someone read. And backing off repeatedly
+    /// inside one session would take a machine from 128 to 1024 frames in twenty seconds on the
+    /// strength of a single bad patch — one doubling per launch converges just as surely and cannot
+    /// overshoot on a transient.
+    /// </remarks>
+    private bool reported;
+
+    /// <summary>
+    /// Feeds the watchdog the running underrun total.
+    /// </summary>
+    /// <param name="totalUnderruns">Underruns since the device was opened.</param>
+    /// <param name="frameTime">Elapsed time since the last call, in milliseconds.</param>
+    /// <returns>
+    /// The number of underruns in the window that tripped it, or null — which is the answer almost
+    /// every frame, and the answer forever after it has fired once.
+    /// </returns>
+    public long? Poll(long totalUnderruns, double frameTime)
+    {
+        if (reported)
+            return null;
+
+        sinceCheckMs += frameTime;
+
+        if (sinceCheckMs < CHECK_INTERVAL_MS)
+            return null;
+
+        long since = totalUnderruns - underrunsAtLastCheck;
+
+        underrunsAtLastCheck = totalUnderruns;
+        sinceCheckMs = 0;
+
+        if (since < THRESHOLD)
+            return null;
+
+        reported = true;
+        return since;
+    }
+
+    /// <summary>
+    /// The buffer size to try next launch, or null where backing off is not the right answer.
+    /// </summary>
+    /// <param name="current">The buffer size currently configured, in frames.</param>
+    /// <remarks>
+    /// Null for two distinct cases, and the caller says something different about each. A
+    /// <paramref name="current"/> of zero means the buffer was never ours to choose — SDL picked it,
+    /// so it is already the driver's own preference and there is nothing for us to correct. At or past
+    /// <see cref="MAX_AUTO_BACKOFF_FRAMES"/>, doubling has stopped being a plausible fix.
+    /// </remarks>
+    public static int? NextBufferSize(int current)
+    {
+        if (current <= 0 || current >= MAX_AUTO_BACKOFF_FRAMES)
+            return null;
+
+        return Math.Min(current * 2, MAX_AUTO_BACKOFF_FRAMES);
+    }
+}

--- a/Sakura.Framework/Configurations/ConfigManager.cs
+++ b/Sakura.Framework/Configurations/ConfigManager.cs
@@ -98,6 +98,15 @@ public abstract class ConfigManager<TLookup> where TLookup : struct, Enum
     }
 
     /// <summary>
+    /// Whether <paramref name="lookup"/> has had a default registered via <see cref="Get{TValue}"/>.
+    /// </summary>
+    public bool IsRegistered(TLookup lookup)
+    {
+        lock (mutex)
+            return settings.ContainsKey(lookup);
+    }
+
+    /// <summary>
     /// Load settings from the backing file.
     /// </summary>
     public virtual void Load()
@@ -112,6 +121,8 @@ public abstract class ConfigManager<TLookup> where TLookup : struct, Enum
         }
 
         bool needsRewrite = false;
+
+        var present = new HashSet<TLookup>();
 
         lock (mutex)
         {
@@ -155,6 +166,8 @@ public abstract class ConfigManager<TLookup> where TLookup : struct, Enum
                         continue;
                     }
 
+                    present.Add(lookup);
+
                     if (settings.TryGetValue(lookup, out object? reactive))
                     {
                         if (!parseInto(lookup, reactive, value))
@@ -166,6 +179,9 @@ public abstract class ConfigManager<TLookup> where TLookup : struct, Enum
                         unclaimedValues[lookup] = value;
                     }
                 }
+
+                if (settings.Keys.Any(setting => !present.Contains(setting)))
+                    needsRewrite = true;
             }
             finally
             {

--- a/Sakura.Framework/Configurations/FrameworkConfigManager.cs
+++ b/Sakura.Framework/Configurations/FrameworkConfigManager.cs
@@ -24,7 +24,7 @@ public class FrameworkConfigManager : ConfigManager<FrameworkSetting>
         Get(FrameworkSetting.MasterVolume, 1.0);
         Get(FrameworkSetting.TrackVolume, 1.0);
         Get(FrameworkSetting.SampleVolume, 1.0);
-        Get(FrameworkSetting.AudioBackend, AudioBackend.BASS);
+        Get(FrameworkSetting.AudioBackend, AudioBackend.Automatic);
         Get(FrameworkSetting.AudioDeviceBufferFrames, SDLAudioManager.DEFAULT_DEVICE_BUFFER_FRAMES);
         Get(FrameworkSetting.WindowMode, WindowMode.Windowed);
         Get(FrameworkSetting.HardwareAcceleration, true);

--- a/Sakura.Framework/Configurations/FrameworkConfigManager.cs
+++ b/Sakura.Framework/Configurations/FrameworkConfigManager.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file for full license text.
 
 using Sakura.Framework.Audio;
+using Sakura.Framework.Audio.SdlEngine;
 using Sakura.Framework.Graphics.Performance;
 using Sakura.Framework.Platform;
 using Sakura.Framework.Threading;
@@ -24,6 +25,7 @@ public class FrameworkConfigManager : ConfigManager<FrameworkSetting>
         Get(FrameworkSetting.TrackVolume, 1.0);
         Get(FrameworkSetting.SampleVolume, 1.0);
         Get(FrameworkSetting.AudioBackend, AudioBackend.BASS);
+        Get(FrameworkSetting.AudioDeviceBufferFrames, SDLAudioManager.DEFAULT_DEVICE_BUFFER_FRAMES);
         Get(FrameworkSetting.WindowMode, WindowMode.Windowed);
         Get(FrameworkSetting.HardwareAcceleration, true);
         Get(FrameworkSetting.RendererType, RendererType.Automatic);

--- a/Sakura.Framework/Configurations/FrameworkSetting.cs
+++ b/Sakura.Framework/Configurations/FrameworkSetting.cs
@@ -3,6 +3,9 @@
 
 namespace Sakura.Framework.Configurations;
 
+/// <summary>
+/// Every setting the framework persists to <c>framework.ini</c>.
+/// </summary>
 [SettingSource("framework.ini")]
 public enum FrameworkSetting
 {
@@ -21,5 +24,6 @@ public enum FrameworkSetting
     WindowWidth,
     WindowHeight,
     RelativeMouseMode,
-    CursorSensitivity
+    CursorSensitivity,
+    AudioDeviceBufferFrames
 }

--- a/Sakura.Framework/Graphics/Performance/FpsGraph.cs
+++ b/Sakura.Framework/Graphics/Performance/FpsGraph.cs
@@ -4,6 +4,7 @@
 using System;
 using Sakura.Framework.Allocation;
 using Sakura.Framework.Audio;
+using Sakura.Framework.Audio.SdlEngine;
 using Sakura.Framework.Configurations;
 using Sakura.Framework.Extensions.ColorExtensions;
 using Sakura.Framework.Extensions.DrawableExtensions;
@@ -304,6 +305,25 @@ public partial class FpsGraph : Container, IRemoveFromDrawVisualiser
 
         if (actual.EndsWith("AudioManager"))
             actual = actual[..^"AudioManager".Length];
+
+        if (host.AudioManager is SDLAudioManager sdl)
+        {
+            if (sdl.UsesNativeMixEngine)
+            {
+                actual += " (native)";
+            }
+            else if (configured == AudioBackend.SDLManaged)
+            {
+                actual += " (managed)";
+            }
+            else
+            {
+                // The native mixer was asked for and did not happen, so this is a degraded backend
+                // rather than a chosen one. Called out, and coloured, because everything still works
+                // and nothing else on screen would say so.
+                actual += " (managed fallback)";
+            }
+        }
 
         return configured == AudioBackend.Automatic ? $"Automatic ({actual})" : actual;
     }

--- a/native/sakura-audio/CMakeLists.txt
+++ b/native/sakura-audio/CMakeLists.txt
@@ -52,6 +52,19 @@ check_symbol_exists(timespec_get "time.h" SAKURA_AUDIO_HAVE_TIMESPEC_GET)
 
 add_library(sakura-audio SHARED sakura_audio.c)
 
+# PE exports nothing unless asked, where ELF and Mach-O export everything unless asked not to. Without
+# this the Windows legs build, link and package a DLL with no export directory at all, so the managed
+# side loads it and then throws EntryPointNotFoundException on the very first call -- which
+# SakuraAudioNative.IsAvailable catches and reports as "not available", falling back to the managed
+# mixer. It looks exactly like a platform where the library was never shipped, on all three Windows
+# RIDs, silently. See AUDIO_SDL.md.
+#
+# Exporting everything is safe here rather than lazy: every function in sakura_audio.c that is not part
+# of the header's ABI is static, so "all symbols" and "the public API" are already the same set. A
+# __declspec(dllexport) macro on each of the header's declarations would be the more precise spelling
+# and is a fine later change; it is not a different outcome.
+set_target_properties(sakura-audio PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 target_include_directories(sakura-audio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(SAKURA_AUDIO_HAVE_TIMESPEC_GET)


### PR DESCRIPTION
So really confident to use SDL as default backend so... 🙏

This PR (sorry for not seperate PR but can see commit by commit) just fix some minor thing  (latency) and make the thing easier and should be tunable but also overridable (if you confident that it will be better e.g. SDL buffer that use more compute power but less latency) all SDL number and settings are based on my measurement and benchmark run. So for example SDL buffer we set at 128 that's really low but also have `UnderrunWatchdog` to auto-scaling it if the sound got stutter to 512, or 1024 that's most allow and should be able to run on all device without problem). For some application that use sound capability but not want low latency you can really set the buffer in `FrameworkConfigManager` on app start yourself. And as always, if don't use the sound capability just override `CreateAudioManager` to `HeadlessAudioManager`

Also fix libsakura-audio is not able to find on windows due to not set default location on build