### PR TITLE
Fix wrong aggressively underrun SDL audio watchdog

### DIFF
--- a/Sakura.Framework.Tests/Audio/AudioDecodeSchedulerTest.cs
+++ b/Sakura.Framework.Tests/Audio/AudioDecodeSchedulerTest.cs
@@ -1,0 +1,110 @@
+// This code is part of the Sakura framework project. Licensed under the MIT License.
+// See the LICENSE file for full license text.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using NUnit.Framework;
+using Sakura.Framework.Audio.SdlEngine;
+
+namespace Sakura.Framework.Tests.Audio;
+
+/// <summary>
+/// How promptly the decoded thread comes back to a source, which is the difference between a seek
+/// costing a millisecond of silence and costing several.
+/// </summary>
+[TestFixture]
+public class AudioDecodeSchedulerTest
+{
+    private static readonly TimeSpan measure_over = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// A source that counts how often it is asked and never manages any work.
+    /// </summary>
+    /// <param name="wantsDecode">
+    /// Whether it wants decoding. True, with a failing pump is the post-seek state: the ring is spoken
+    /// for until the audio thread applies the discard, so there is work, and it cannot be done yet.
+    /// </param>
+    private sealed class StubSource(bool wantsDecode) : IDecodeSource
+    {
+        private int pumps;
+        private int asked;
+
+        /// <summary>
+        /// Times <see cref="PumpDecode"/> was called once per scheduler round.
+        /// </summary>
+        public int Pumps => Volatile.Read(ref pumps);
+
+        /// <summary>
+        /// Times the scheduler looked at this source completely.
+        /// </summary>
+        public int Asked => Volatile.Read(ref asked);
+
+        public bool WantsDecode
+        {
+            get
+            {
+                Interlocked.Increment(ref asked);
+                return wantsDecode;
+            }
+        }
+
+        public bool PumpDecode()
+        {
+            Interlocked.Increment(ref pumps);
+            return false;
+        }
+    }
+
+    private static StubSource run(bool wantsDecode)
+    {
+        var source = new StubSource(wantsDecode);
+
+        using var scheduler = new AudioDecodeScheduler();
+        scheduler.Register(source);
+
+        var elapsed = Stopwatch.StartNew();
+
+        while (elapsed.Elapsed < measure_over)
+            Thread.Sleep(1);
+
+        scheduler.Unregister(source);
+
+        return source;
+    }
+
+    [Test]
+    public void ComesBackPromptlyForASourceWaitingOnTheAudioThread()
+    {
+        int pumps = run(true).Pumps;
+
+        // One pump per round, so this is the round rate. The blocked wait is 1 ms, giving ~200 rounds
+        // over the measured window; the idle wait of 5 ms would give ~40. Asserting well above 40 and
+        // well below 200 leaves room for a loaded machine and for timer granularity, while still
+        // failing outright if the blocked path ever reverts to idling.
+        Assert.That(pumps, Is.GreaterThan(60),
+            $"A source blocked on the audio thread was polled only {pumps} times in {measure_over.TotalMilliseconds:F0} ms, "
+            + "which is the idle rate. A seek's discard is applied at the top of the next device callback, 2.9 ms away "
+            + "at the default buffer, so idling the full delay there is silence out of a voice that is already running.");
+    }
+
+    [Test]
+    public void DoesNotSpinOnASourceThatIsBlocked()
+    {
+        int pumps = run(true).Pumps;
+
+        // The wait is short, not absent. Busy-polling would run into the tens of thousands, on a
+        // thread that is deliberately above normal priority.
+        Assert.That(pumps, Is.LessThan(2000),
+            "The blocked path should wait, not spin: this thread outranks everything but the mixer.");
+    }
+
+    [Test]
+    public void DoesNotDecodeForASourceThatWantsNothing()
+    {
+        var source = run(false);
+
+        Assert.That(source.Pumps, Is.Zero, "A source that wants no decoding must never be pumped.");
+        Assert.That(source.Asked, Is.GreaterThan(0), "The scheduler should still be looking at it each round.");
+    }
+}

--- a/Sakura.Framework.Tests/Audio/UnderrunWatchdogTest.cs
+++ b/Sakura.Framework.Tests/Audio/UnderrunWatchdogTest.cs
@@ -11,7 +11,7 @@ namespace Sakura.Framework.Tests.Audio;
 /// </summary>
 /// <remarks>
 /// The policy that lets the framework ship an aggressive device buffer. It is tested apart from the
-/// manager because provoking real underruns on demand is not something a test can do, while the
+/// manager. Provoking real underruns on demand is not something a test can do, while the
 /// decisions — ignore a burst, act on sustained starvation, act only once, know when doubling is not
 /// the answer — are pure counting and timing.
 /// </remarks>
@@ -20,13 +20,37 @@ public class UnderrunWatchdogTest
 {
     private const double interval = UnderrunWatchdog.CHECK_INTERVAL_MS;
 
+    private static readonly int window = UnderrunWatchdog.MINIMUM_OBSERVATIONS * 4;
+
+    /// <summary>
+    /// Runs one full window of <paramref name="misses"/> misses, <paramref name="met"/> deadlines met
+    /// and <paramref name="idle"/> silent frames, and returns whatever the window decided.
+    /// </summary>
+    private static UnderrunWatchdog.Verdict? runWindow(UnderrunWatchdog watchdog, int misses, int met, int idle = 0)
+    {
+        UnderrunWatchdog.Verdict? last = null;
+
+        for (int i = 0; i < misses + met + idle; i++)
+        {
+            var observation = i < misses ? UnderrunWatchdog.Observation.Missed
+                : i < misses + met ? UnderrunWatchdog.Observation.Met
+                : UnderrunWatchdog.Observation.Idle;
+
+            bool isLast = i == misses + met + idle - 1;
+
+            last = watchdog.Poll(observation, isLast ? interval : 0);
+        }
+
+        return last;
+    }
+
     [Test]
     public void SaysNothingOnAHealthyDevice()
     {
         var watchdog = new UnderrunWatchdog();
 
         for (int i = 0; i < 10; i++)
-            Assert.That(watchdog.Poll(0, interval), Is.Null);
+            Assert.That(runWindow(watchdog, 0, window), Is.Null);
     }
 
     [Test]
@@ -34,19 +58,24 @@ public class UnderrunWatchdogTest
     {
         var watchdog = new UnderrunWatchdog();
 
-        Assert.That(watchdog.Poll(1000, interval - 1), Is.Null,
-            "A thousand underruns is plainly wrong, but reporting it before a full window means reporting a rate "
-            + "measured over an unknown amount of time.");
+        for (int i = 0; i < window; i++)
+        {
+            Assert.That(watchdog.Poll(UnderrunWatchdog.Observation.Missed, 0), Is.Null,
+                "A device missing every deadline is plainly wrong, but reporting it before a full window means "
+                + "reporting a rate measured over an unknown amount of time.");
+        }
     }
 
     [Test]
-    public void IgnoresABurstBelowTheThreshold()
+    public void IgnoresABurstBelowTheFraction()
     {
         var watchdog = new UnderrunWatchdog();
 
-        Assert.That(watchdog.Poll(UnderrunWatchdog.THRESHOLD - 1, interval), Is.Null,
-            "Startup, a device change and a hitch elsewhere in the app all produce a few underruns and all recover "
-            + "on their own. Acting on those would make the warning meaningless.");
+        int misses = (int)(window * UnderrunWatchdog.TRIP_FRACTION) - 1;
+
+        Assert.That(runWindow(watchdog, misses, window - misses), Is.Null,
+            "Startup, a device change and a hitch elsewhere in the app all make the callback late for a moment and "
+            + "all recover on their own. Acting on those would make the warning meaningless.");
     }
 
     [Test]
@@ -54,7 +83,14 @@ public class UnderrunWatchdogTest
     {
         var watchdog = new UnderrunWatchdog();
 
-        Assert.That(watchdog.Poll(UnderrunWatchdog.THRESHOLD, interval), Is.EqualTo(UnderrunWatchdog.THRESHOLD));
+        int misses = (int)(window * UnderrunWatchdog.TRIP_FRACTION) + 1;
+
+        var verdict = runWindow(watchdog, misses, window - misses);
+
+        Assert.That(verdict, Is.Not.Null);
+        Assert.That(verdict!.Value.Misses, Is.EqualTo(misses));
+        Assert.That(verdict.Value.Observations, Is.EqualTo(window));
+        Assert.That(verdict.Value.Fraction, Is.GreaterThan(UnderrunWatchdog.TRIP_FRACTION));
     }
 
     [Test]
@@ -62,33 +98,67 @@ public class UnderrunWatchdogTest
     {
         var watchdog = new UnderrunWatchdog();
 
-        Assert.That(watchdog.Poll(100, interval), Is.Not.Null);
+        Assert.That(runWindow(watchdog, window, 0), Is.Not.Null);
 
         for (int i = 0; i < 10; i++)
         {
-            Assert.That(watchdog.Poll(100 + (i + 1) * 100, interval), Is.Null,
+            Assert.That(runWindow(watchdog, window, 0), Is.Null,
                 "A device that is underrunning keeps underrunning. Reporting every window buries the log, and backing "
                 + "off every window would take a machine from 128 frames to 1024 in twenty seconds on one bad patch.");
         }
     }
 
     [Test]
-    public void MeasuresARateRatherThanATotal()
+    public void MeasuresAShareRatherThanACount()
     {
         var watchdog = new UnderrunWatchdog();
 
-        // A long-running session that accumulated underruns slowly: well past the threshold in total,
-        // never near it in any one window.
-        long total = 0;
-
+        // The regression of this whole type was rewritten for. A handful of misses per window is what a
+        // seek, a loop point or a track starting produces, and a session does that all day. Counted,
+        // it walks the buffer to the cap; as a share of a busy window it is nothing.
         for (int i = 0; i < 50; i++)
         {
-            total += UnderrunWatchdog.THRESHOLD - 1;
-
-            Assert.That(watchdog.Poll(total, interval), Is.Null,
-                "Occasional underruns over an hour are not the same failure as steady crackling, and only the second "
-                + "one means the buffer is the wrong size.");
+            Assert.That(runWindow(watchdog, 5, window - 5), Is.Null,
+                "A few late callbacks in a window full of prompt ones is not steady crackling, and only steady "
+                + "crackling means the buffer is the wrong size.");
         }
+    }
+
+    [Test]
+    public void DoesNotTripOnAWindowWithTooLittleToGoOn()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        Assert.That(runWindow(watchdog, UnderrunWatchdog.MINIMUM_OBSERVATIONS - 1, 0), Is.Null,
+            "A window in which audio played for a handful of frames reads 100% on no evidence at all, and startup is "
+            + "full of windows like that.");
+    }
+
+    [Test]
+    public void IdleFramesAreNotEvidenceOfHealth()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        // A device that missed every deadline it was actually asked to meet, in a session that was
+        // mostly silent. Counting the silence as healthy would dilute this below the trip fraction.
+        Assert.That(runWindow(watchdog, UnderrunWatchdog.MINIMUM_OBSERVATIONS, 0, idle: window), Is.Not.Null);
+    }
+
+    [Test]
+    public void WindowsDoNotCarryOver()
+    {
+        var watchdog = new UnderrunWatchdog();
+
+        Assert.That(runWindow(watchdog, window, 0, idle: 0), Is.Not.Null);
+
+        var fresh = new UnderrunWatchdog();
+
+        // A bad window followed by good ones must not leave a residue that trips a later one.
+        Assert.That(runWindow(fresh, (int)(window * UnderrunWatchdog.TRIP_FRACTION) - 1, window), Is.Null);
+        Assert.That(runWindow(fresh, 0, window), Is.Null);
+        Assert.That(runWindow(fresh, (int)(window * UnderrunWatchdog.TRIP_FRACTION) - 1, window), Is.Null,
+            "Misses carried between windows would turn a session that misbehaved once an hour ago into a session "
+            + "that is misbehaving now.");
     }
 
     [Test]
@@ -98,9 +168,10 @@ public class UnderrunWatchdogTest
 
         // A realistic frame time rather than one poll per window.
         for (double elapsed = 0; elapsed < interval - 16; elapsed += 16)
-            Assert.That(watchdog.Poll(100, 16), Is.Null);
+            Assert.That(watchdog.Poll(UnderrunWatchdog.Observation.Missed, 16), Is.Null);
 
-        Assert.That(watchdog.Poll(100, 16), Is.Not.Null, "The window should close on accumulated frame time.");
+        Assert.That(watchdog.Poll(UnderrunWatchdog.Observation.Missed, 16), Is.Not.Null,
+            "The window should close on accumulated frame time.");
     }
 
     [TestCase(128, 256)]

--- a/Sakura.Framework/Audio/SdlEngine/AudioDecodeScheduler.cs
+++ b/Sakura.Framework/Audio/SdlEngine/AudioDecodeScheduler.cs
@@ -20,6 +20,14 @@ internal sealed class AudioDecodeScheduler : IDisposable
     private static readonly TimeSpan idle_delay = TimeSpan.FromMilliseconds(5);
 
     /// <summary>
+    /// How long to wait when a source wanted work but could not do it yet.
+    /// </summary>
+    /// <remarks>
+    /// A source in that state is not idle, it is blocked on the audio thread
+    /// </remarks>
+    private static readonly TimeSpan blocked_delay = TimeSpan.FromMilliseconds(1);
+
+    /// <summary>
     /// Maximum consecutive pumps for one source before moving on.
     /// </summary>
     private const int max_pumps_per_source = 8;
@@ -79,6 +87,7 @@ internal sealed class AudioDecodeScheduler : IDisposable
         while (!cancellation.IsCancellationRequested)
         {
             bool didWork = false;
+            bool blocked = false;
 
             // registration during a pass is picked up next time
             // around, which is soon enough and keeps the lock off the decode path.
@@ -94,14 +103,22 @@ internal sealed class AudioDecodeScheduler : IDisposable
                     for (int i = 0; i < max_pumps_per_source && source.WantsDecode; i++)
                     {
                         if (!source.PumpDecode())
+                        {
+                            // A pass that did nothing but still wants to decode is waiting on something
+                            // other than this thread, which in practice is the audio thread applying a
+                            // seek's discard. Asked again after a short wait rather than a full idle
+                            // one, a source that has simply finished stops wanting decoding and does
+                            // not land here.
+                            blocked |= source.WantsDecode;
                             break;
+                        }
 
                         didWork = true;
                     }
                 }
                 catch (Exception e)
                 {
-                    // One bad file must not take the decode thread down with it and silence
+                    // One bad file must not take the decoded thread down with it and silence
                     // everything else that is playing.
                     Logger.Error($"[AudioDecodeScheduler] Decoding failed for a source; dropping it.", e);
                     Unregister(source);
@@ -109,7 +126,7 @@ internal sealed class AudioDecodeScheduler : IDisposable
             }
 
             if (!didWork)
-                wakeup.WaitOne(idle_delay);
+                wakeup.WaitOne(blocked ? blocked_delay : idle_delay);
         }
     }
 

--- a/Sakura.Framework/Audio/SdlEngine/NativeStreamFeeder.cs
+++ b/Sakura.Framework/Audio/SdlEngine/NativeStreamFeeder.cs
@@ -67,6 +67,11 @@ internal sealed class NativeStreamFeeder : IDecodeSource, IDisposable
     private double? pendingSeekMs;
 
     /// <summary>
+    /// Floats sitting in <see cref="convertScratch"/> that are decoded but not yet written, or 0.
+    /// </summary>
+    private int staged;
+
+    /// <summary>
     /// Set once the decoder has no more audio, and mirrored into the native voice, which is only
     /// ended once it is drained <em>and</em> its ring is empty.
     /// </summary>
@@ -217,6 +222,9 @@ internal sealed class NativeStreamFeeder : IDecodeSource, IDisposable
                 decoder.Seek(seek.Value);
                 converter.Clear();
 
+                // Whatever was held back belongs to the position we are leaving.
+                staged = 0;
+
                 lock (sync)
                     decoderDrained = false;
 
@@ -225,15 +233,43 @@ internal sealed class NativeStreamFeeder : IDecodeSource, IDisposable
                 engine.StreamFlushBegin(voice);
             }
 
-            // Nothing may be written while a discard is outstanding: it would be thrown away with the
-            // audio it is replacing. Come back on the next pass, by which point a running device has
-            // acknowledged it.
-            if (engine.StreamFlushPending(voice))
-                return false;
+            // Nothing may be written while a discard is outstanding: the ring still holds the audio it
+            // is replacing, so its free space is not ours yet, and ring_write refuses outright.
+            bool flushPending = engine.StreamFlushPending(voice);
+
+            // A block held back from an earlier pass goes first, or the stream plays out of order.
+            // This is the pass right after a seek: the wait is over and the ring is filled with a copy
+            // rather than a decoding.
+            if (!flushPending && staged > 0)
+            {
+                if (engine.StreamSpace(voice) * deviceChannels < staged)
+                    return false;
+
+                lock (sync)
+                {
+                    if (isDisposed)
+                        return false;
+
+                    engine.StreamWrite(voice, convertScratch.AsSpan(0, staged));
+                    staged = 0;
+                }
+
+                return true;
+            }
 
             lock (sync)
             {
-                if (decoderDrained || engine.StreamSpace(voice) * deviceChannels < convertScratch.Length)
+                if (decoderDrained)
+                    return false;
+
+                // While the discard is outstanding, the ring's free space says nothing, so decode
+                // anyway and hold the result — the thread would otherwise spend the wait asleep and
+                // then still owe a decoding once it woke, and every millisecond of that is a running
+                // voice playing silence. convertScratch is where it is held.
+                if (!flushPending && engine.StreamSpace(voice) * deviceChannels < convertScratch.Length)
+                    return false;
+
+                if (staged > 0)
                     return false;
             }
 
@@ -265,7 +301,12 @@ internal sealed class NativeStreamFeeder : IDecodeSource, IDisposable
                     return true;
 
                 if (converted > 0)
-                    engine.StreamWrite(voice, convertScratch.AsSpan(0, converted));
+                {
+                    if (flushPending)
+                        staged = converted;
+                    else
+                        engine.StreamWrite(voice, convertScratch.AsSpan(0, converted));
+                }
 
                 if (read == 0 && converted == 0)
                 {
@@ -275,7 +316,9 @@ internal sealed class NativeStreamFeeder : IDecodeSource, IDisposable
                 }
             }
 
-            return true;
+            // A pass that only staged has nothing further to do until the audio thread releases the
+            // ring and says so rather than being asked seven more times.
+            return !flushPending;
         }
     }
 

--- a/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLAudioManager.cs
@@ -191,12 +191,29 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     private readonly UnderrunWatchdog underrunWatchdog = new UnderrunWatchdog();
 
     /// <summary>
+    /// Device callbacks the native engine had served as of the previous <see cref="Update"/>.
+    /// </summary>
+    /// <remarks>
+    /// The engine publishes the duration of the "most recent" callback, so a frame that saw no
+    /// new callback would otherwise re-read the last one's figure and count it again. Comparing the
+    /// count is what makes each frame's reading a fresh observation, and what tells an idle or stopped
+    /// device apart from a device being served promptly.
+    /// </remarks>
+    private long lastObservedCallbacks;
+
+    /// <summary>
+    /// Milliseconds the device queue had spent dry as of the previous <see cref="Update"/>. The
+    /// managed mixer's half of the same question.
+    /// </summary>
+    private double lastObservedStarvedMs;
+
+    /// <summary>
     /// This manager's own underrun count, as of the last <see cref="Update"/>.
     /// </summary>
     /// <remarks>
-    /// The <c>SDL Underruns</c> statistic is process-global and is overwritten by whichever manager
-    /// updated most recently, which makes it useless for asking "did <em>this</em> device starve" —
-    /// a question both the watchdog and the tests need answered. This is the per-manager figure.
+    /// The published statistics are process-global and are overwritten by whichever manager updated
+    /// most recently, which makes them useless for asking "did this device starve" See <see cref="UnderrunWatchdog"/>
+    /// for more measurement info.
     /// </remarks>
     private long lastPublishedUnderruns;
 
@@ -437,6 +454,65 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
         deviceBufferMicroseconds = rate > 0 ? (int)Math.Round(frames / (double)rate * 1_000_000.0) : 0;
 
     /// <summary>
+    /// This frame's answer, on the native engine, to whether the device is being served in time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The callback mixes on demand into the device's own buffer, so the deadline it is racing is that
+    /// buffer's duration: take longer than <see cref="deviceBufferMicroseconds"/> to produce
+    /// <see cref="deviceBufferFrames"/> and the device has run out before the audio arrived. That is
+    /// the failure a larger buffer actually fixes, and the only one; it doubles the deadline while
+    /// the per-callback fixed cost (draining the command queue, the stream sync, both of which walk
+    /// every node whatever the block size) stays where it was.
+    /// </para>
+    /// <para>
+    /// Sampled a frame once out of the several hundred callbacks a second rather than counted on the
+    /// audio thread, which would mean a new native stat and a library round-trip. The phase is
+    /// arbitrary, so it is a fair sample of callbacks, and the watchdog reads a share rather than a
+    /// total precisely so a sampled figure is enough to act on.
+    /// </para>
+    /// <para>
+    /// A callback duration of zero means the platform has no <c>timespec_get</c> (Android below API
+    /// 29) and the engine could not time itself, so there is nothing to judge and every frame reads as
+    /// idle. The backoff simply never fires there, which is the right way round.
+    /// </para>
+    /// </remarks>
+    private UnderrunWatchdog.Observation observeNativeCallback(SakuraAudioStats stats)
+    {
+        if (stats.Callbacks == lastObservedCallbacks || stats.CallbackMicroseconds <= 0 || deviceBufferMicroseconds <= 0)
+            return UnderrunWatchdog.Observation.Idle;
+
+        lastObservedCallbacks = stats.Callbacks;
+
+        return stats.CallbackMicroseconds > deviceBufferMicroseconds
+            ? UnderrunWatchdog.Observation.Missed
+            : UnderrunWatchdog.Observation.Met;
+    }
+
+    /// <summary>
+    /// The same answer on the managed mixer, where the device is pushed to rather than pulled from.
+    /// </summary>
+    /// <remarks>
+    /// There is no callback to time, so the failure is measured after the fact: the queue this mixer
+    /// keeps ahead of the device ran dry, which <see cref="DeviceStarvationTracker"/> already records
+    /// in milliseconds. Any increase since the last frame is a miss. Unlike the native engine's voice
+    /// starvation this is genuinely device-level — a decoder falling behind pushes silence into a
+    /// queue that stays full and does not show up here.
+    /// </remarks>
+    private UnderrunWatchdog.Observation observeManagedQueue()
+    {
+        double starved = starvation.StarvedMilliseconds;
+
+        if (starved > lastObservedStarvedMs)
+        {
+            lastObservedStarvedMs = starved;
+            return UnderrunWatchdog.Observation.Missed;
+        }
+
+        return runningVoices() > 0 ? UnderrunWatchdog.Observation.Met : UnderrunWatchdog.Observation.Idle;
+    }
+
+    /// <summary>
     /// Acts, once, when the device is starving steadily rather than occasionally.
     /// </summary>
     /// <remarks>
@@ -450,28 +526,38 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
     /// The retreat is persisted and takes effect next launch rather than being applied here. Growing
     /// the buffer live would mean tearing down and reopening the device underneath a callback that is
     /// very likely running, for an audible gap, on a code path that exists for nothing else — and the
-    /// session it would rescue is one the listener has already heard crackle. Writing the number down
-    /// costs one line of config and fixes the machine permanently.
+    /// session it would rescue is one that has already been missing its deadlines for five seconds.
+    /// Writing the number down costs one line of config and fixes the machine permanently.
     /// </para>
     /// </remarks>
-    private void handleSustainedUnderruns(long total, double frameTime)
+    private void handleSustainedUnderruns(UnderrunWatchdog.Observation observation, double frameTime)
     {
-        long? since = underrunWatchdog.Poll(total, frameTime);
+        var verdict = underrunWatchdog.Poll(observation, frameTime);
 
-        if (since == null)
+        if (verdict == null)
             return;
 
-        string observed = $"The audio device underran {since} times in the last {UnderrunWatchdog.CHECK_INTERVAL_MS / 1000:F0} seconds, "
-                          + $"which is audible as crackling. The device buffer is {deviceBufferFrames} frames "
-                          + $"({deviceBufferMicroseconds / 1000.0:F1} ms).";
+        // Says what was measured, and stops there. Telling someone they heard crackling when they did
+        // not is how a warning gets learned as noise — and a miss is a deadline the output path did not
+        // make, which a driver with slack in its own buffering can still absorb without a click.
+        string observed = $"The audio device went unfed on {verdict.Value.Misses} of the {verdict.Value.Observations} frames "
+                          + $"sampled in the last {UnderrunWatchdog.CHECK_INTERVAL_MS / 1000:F0} seconds "
+                          + $"({verdict.Value.Fraction:P0}). The device buffer is {deviceBufferFrames} frames "
+                          + $"({deviceBufferMicroseconds / 1000.0:F1} ms). This is measured, not heard: at this rate it "
+                          + "usually clicks, but not hearing anything does not mean nothing was missed.";
 
-        int? next = UnderrunWatchdog.NextBufferSize(requestedDeviceBufferFrames);
+        // Only the native engine's latency is the device buffer; the managed mixer's is its own queue
+        // and applyDeviceBufferHint does not even set the hint for it. Doubling a number that is never
+        // read would be a silent no-op dressed up as a fix, so that path gets the warning and nothing
+        // else.
+        int? next = nativeEngine == null ? null : UnderrunWatchdog.NextBufferSize(requestedDeviceBufferFrames);
 
         if (next == null || persistDeviceBufferFrames == null)
         {
             // Nothing to do but say so. Either the buffer was SDL's own choice and is already the
             // driver's preference, or it is large enough that "too small" has stopped explaining
-            // anything, or nobody gave this manager somewhere to write the answer down.
+            // anything, or this is the managed mixer whose latency the buffer does not set, or nobody
+            // gave this manager somewhere to write the answer down.
             Logger.Warning($"{observed} Raising AudioDeviceBufferFrames in framework.ini may help, but this buffer is "
                            + "already at or past the point where a larger one is the likely fix — something else is "
                            + "competing for the audio device. Reported once per run.");
@@ -1006,10 +1092,14 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
 
             // "Callback", not "Mix Block": there is a real device callback to time now.
             GlobalStatistics.Get<long>("Audio", "SDL Callback (µs)").Value = stats.CallbackMicroseconds;
-            GlobalStatistics.Get<long>("Audio", "SDL Underruns").Value = stats.Starvations;
+
+            // Named for what it is. This counts blocks in which a voice had less audio than the mixer
+            // asked for — a decoder that fell behind, most often a seek — and not the device failing
+            // to be served, which is what "underrun" reads as and what the watchdog acts on.
+            GlobalStatistics.Get<long>("Audio", "SDL Voice Starvations").Value = stats.Starvations;
 
             Interlocked.Exchange(ref lastPublishedUnderruns, stats.Starvations);
-            handleSustainedUnderruns(stats.Starvations, frameTime);
+            handleSustainedUnderruns(observeNativeCallback(stats), frameTime);
             GlobalStatistics.Get<long>("Audio", "SDL Put Failures").Value = stats.PutFailures;
             GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value = stats.ActiveVoices;
             GlobalStatistics.Get<int>("Audio", "SDL Device Buffer (frames)").Value = deviceBufferFrames;
@@ -1029,7 +1119,7 @@ internal sealed unsafe class SDLAudioManager : IAudioManager, ISDLAudioContext, 
         GlobalStatistics.Get<double>("Audio", "SDL Longest Mix Gap (ms)").Value = Math.Round(starvation.LongestGapMilliseconds, 1);
         GlobalStatistics.Get<long>("Audio", "SDL Mix Block (µs)").Value = mixMicroseconds;
 
-        handleSustainedUnderruns(managedUnderruns, frameTime);
+        handleSustainedUnderruns(observeManagedQueue(), frameTime);
         GlobalStatistics.Get<int>("Audio", "SDL Active Voices").Value = runningVoices();
         GlobalStatistics.Get<double>("Audio", "SDL Queued (ms)").Value = Math.Round(queuedMilliseconds, 1);
         GlobalStatistics.Get<int>("Audio", "SDL Device Buffer (frames)").Value = deviceBufferFrames;

--- a/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioChannel.cs
+++ b/Sakura.Framework/Audio/SdlEngine/SDLNativeAudioChannel.cs
@@ -223,6 +223,8 @@ internal class SDLNativeAudioChannel : ISDLChannel
 
         Engine.Play(Node);
         IsRunning.Value = true;
+
+        Context.WakeDecoder();
     }
 
     public virtual void Stop()
@@ -260,6 +262,11 @@ internal class SDLNativeAudioChannel : ISDLChannel
 
         feeder?.Seek(milliseconds);
         amplitudes.Reset();
+
+        // A seek empties the ring, so every block until the decode thread refills it is silence out
+        // of a running voice. Without this the seek waits out the scheduler's idle delay before it is
+        // even noticed, and a second one before the flush the first pass posted has been acknowledged.
+        Context.WakeDecoder();
     }
 
     /// <summary>

--- a/Sakura.Framework/Audio/SdlEngine/UnderrunWatchdog.cs
+++ b/Sakura.Framework/Audio/SdlEngine/UnderrunWatchdog.cs
@@ -11,26 +11,56 @@ namespace Sakura.Framework.Audio.SdlEngine;
 /// machine, and what to do about it.
 /// </summary>
 /// <remarks>
-/// <para>
 /// Sakura set the default device buffer really aggressive (see <see cref="SDLAudioManager.DEFAULT_DEVICE_BUFFER_FRAMES"/> that's the default value)
 /// because measurement says the callback has an order of magnitude of headroom at that size and because a driver that cannot honor the
 /// request rounds it up rather than failing. What measurement cannot rule out is scheduling jitter on
 /// a machine nobody has tested, and the symptom of getting that wrong is crackling that a user has no
 /// way to connect to a setting they have never heard of.
-/// </para>
-/// <para>
-/// So the default is not a promise, it is a starting point that retreats under evidence. This type is
-/// the evidence half: it watches the underrun counter and reports the one transition worth acting on.
-/// Separated from the manager because the interesting cases — a burst that should be ignored, a
-/// sustained failure that should not, the guarantee of acting only once — are all about counting and
-/// timing, and none of them need an audio device to test.
-/// </para>
 /// </remarks>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
 internal sealed class UnderrunWatchdog
 {
     /// <summary>
-    /// Window over which underruns are counted, in milliseconds.
+    /// One frame's answer to "is the output path keeping the device fed".
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a judgment the caller makes rather than a number it hands over, because the two
+    /// engines fail in different places and only the manager knows which it is running. On the native
+    /// engine the device callback mixes on demand and the failure is the callback overrunning the
+    /// deadline its own buffer sets; on the managed one a push loop keeps a queue ahead of the device
+    /// and the failure is that queue running dry. Both are the device going unfed, which is what a
+    /// bigger buffer buys time against.
+    /// </remarks>
+    public enum Observation
+    {
+        /// <summary>
+        /// Nothing was being served, so this frame says nothing either way and is not counted.
+        /// </summary>
+        /// <remarks>
+        /// An idle device is not healthy, counting silence as evidence of health would let a
+        /// mostly quiet session dilute a real failure below <see cref="TRIP_FRACTION"/>.
+        /// </remarks>
+        Idle,
+
+        /// <summary>
+        /// The device was served in time.
+        /// </summary>
+        Met,
+
+        /// <summary>
+        /// The device was not served in time.
+        /// </summary>
+        /// <remarks>
+        /// A missed deadline, not a heard one. Whether any single miss clicks depends on slack the
+        /// driver has and this side cannot see, which is why the trip is a share of many observations
+        /// rather than a reaction to one — and why nothing that reports this should tell a listener
+        /// what they heard.
+        /// </remarks>
+        Missed,
+    }
+
+    /// <summary>
+    /// Window over which observations are counted, in milliseconds.
     /// </summary>
     /// <remarks>
     /// Five seconds since long enough that one stall on startup, during a device change, or from a hitch
@@ -40,10 +70,27 @@ internal sealed class UnderrunWatchdog
     public const double CHECK_INTERVAL_MS = 5000;
 
     /// <summary>
-    /// How many underruns inside <see cref="CHECK_INTERVAL_MS"/> mean the buffer is genuinely too
-    /// small, rather than the machine having had a bad moment.
+    /// What share of the window's observations have to have missed before the buffer, rather than the
+    /// machine having had a bad moment, is the explanation.
     /// </summary>
-    public const long THRESHOLD = 10;
+    /// <remarks>
+    /// A fraction and not a count, because a count is only meaningful next to the rate it was sampled
+    /// at, and that rate moves with the frame rate. A buffer that is genuinely too small for a machine
+    /// misses more or less continuously. The callback is racing the same deadline every time it is
+    /// called, so a fifth is far above anything a GC pause, a device change, or a shader compiler
+    /// produces and far below what a real misfit does.
+    /// </remarks>
+    public const double TRIP_FRACTION = 0.2;
+
+    /// <summary>
+    /// Observations a window needs before its fraction means anything.
+    /// </summary>
+    /// <remarks>
+    /// A window in which audio played for three frames can trivially read 100%, and startup is full of
+    /// windows like that. At a normal frame rate a full window is several hundred observations, so
+    /// this only excludes the ones that were mostly silent or mostly stalled.
+    /// </remarks>
+    public const int MINIMUM_OBSERVATIONS = 100;
 
     /// <summary>
     /// The largest buffer this will grow to on its own.
@@ -56,7 +103,21 @@ internal sealed class UnderrunWatchdog
     /// </remarks>
     public const int MAX_AUTO_BACKOFF_FRAMES = 1024;
 
-    private long underrunsAtLastCheck;
+    /// <summary>
+    /// What one tripped window looked like, for the log to quote.
+    /// </summary>
+    /// <param name="Observations">Frames in the window that had something to say.</param>
+    /// <param name="Misses">How many of those found the device unfed.</param>
+    public readonly record struct Verdict(int Observations, int Misses)
+    {
+        /// <summary>
+        /// The share of observations that missed, which is the figure the trip is made on.
+        /// </summary>
+        public double Fraction => Observations == 0 ? 0 : Misses / (double)Observations;
+    }
+
+    private int observations;
+    private int misses;
     private double sinceCheckMs;
 
     /// <summary>
@@ -72,34 +133,49 @@ internal sealed class UnderrunWatchdog
     private bool reported;
 
     /// <summary>
-    /// Feeds the watchdog the running underrun total.
+    /// Feeds the watchdog one frame's view of the device.
     /// </summary>
-    /// <param name="totalUnderruns">Underruns since the device was opened.</param>
+    /// <param name="observation">What this frame saw — see <see cref="Observation"/>.</param>
     /// <param name="frameTime">Elapsed time since the last call, in milliseconds.</param>
     /// <returns>
-    /// The number of underruns in the window that tripped it, or null — which is the answer almost
-    /// every frame, and the answer forever after it has fired once.
+    /// The window that tripped it or null which is the answer almost every frame, and the answer
+    /// forever after it has fired once.
     /// </returns>
-    public long? Poll(long totalUnderruns, double frameTime)
+    public Verdict? Poll(Observation observation, double frameTime)
     {
         if (reported)
             return null;
 
         sinceCheckMs += frameTime;
 
+        switch (observation)
+        {
+            case Observation.Met:
+                observations++;
+                break;
+
+            case Observation.Missed:
+                observations++;
+                misses++;
+                break;
+        }
+
         if (sinceCheckMs < CHECK_INTERVAL_MS)
             return null;
 
-        long since = totalUnderruns - underrunsAtLastCheck;
+        var verdict = new Verdict(observations, misses);
 
-        underrunsAtLastCheck = totalUnderruns;
+        // Each window stands on its own. Carrying counts across them would turn a session that
+        // misbehaved once an hour ago into a session that is misbehaving now.
+        observations = 0;
+        misses = 0;
         sinceCheckMs = 0;
 
-        if (since < THRESHOLD)
+        if (verdict.Observations < MINIMUM_OBSERVATIONS || verdict.Fraction < TRIP_FRACTION)
             return null;
 
         reported = true;
-        return since;
+        return verdict;
     }
 
     /// <summary>

--- a/Sakura.Framework/Graphics/Video/VideoDecoder.cs
+++ b/Sakura.Framework/Graphics/Video/VideoDecoder.cs
@@ -480,17 +480,25 @@ public unsafe class VideoDecoder : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// Decode threads to give the software codec.
+    /// </summary>
+    private static int softwareDecodeThreads() => Math.Clamp(Environment.ProcessorCount / 2, 1, 4);
+
     private void openCodecSoftware(AVCodec* codec)
     {
         codecContext = ffmpeg.avcodec_alloc_context3(codec);
         codecContext->pkt_timebase = avStream->time_base;
         ffmpeg.avcodec_parameters_to_context(codecContext, avStream->codecpar);
+        
+        int threads = softwareDecodeThreads();
+        codecContext->thread_count = threads;
 
         if (ffmpeg.avcodec_open2(codecContext, codec, null) < 0)
             throw new Exception("Could not open software codec.");
 
         ActiveHardwareDevice = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
-        Logger.Verbose("[VideoDecoder] Software decoding active.");
+        Logger.Verbose($"[VideoDecoder] Software decoding active, {threads} decode threads.");
         GlobalStatistics.Get<string>("Video", "HW Decoder").Value = "Software";
     }
 


### PR DESCRIPTION
During long run I notice that the `UnderrunWatchdog` mostly push the SDL buffer from default 128 even not hearing stutter. So investigated an watchdong is wrong on some circumstances so make watchdog better, it should not aggressive now. Also there are problem that if some hardware is not support FFmpeg hardware decoder (really rare chances, on some video format maybe always use fallback). So just limited the thread allocation of software decoder too.